### PR TITLE
Update to CodeQL 2.9.4

### DIFF
--- a/c/cert/src/codeql-pack.lock.yml
+++ b/c/cert/src/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.0.13
+    version: 0.2.3
 compiled: false
 lockVersion: 1.0.0

--- a/c/cert/src/qlpack.yml
+++ b/c/cert/src/qlpack.yml
@@ -3,4 +3,4 @@ version: 2.6.0-dev
 suites: codeql-suites
 dependencies:
   codeql/common-c-coding-standards: '*'
-  codeql/cpp-all: 0.0.13
+  codeql/cpp-all: 0.2.3

--- a/c/cert/test/codeql-pack.lock.yml
+++ b/c/cert/test/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.0.13
+    version: 0.2.3
 compiled: false
 lockVersion: 1.0.0

--- a/c/common/src/codeql-pack.lock.yml
+++ b/c/common/src/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.0.13
+    version: 0.2.3
 compiled: false
 lockVersion: 1.0.0

--- a/c/common/src/qlpack.yml
+++ b/c/common/src/qlpack.yml
@@ -2,4 +2,4 @@ name: codeql/common-c-coding-standards
 version: 2.6.0-dev
 dependencies:
   codeql/common-cpp-coding-standards: '*'
-  codeql/cpp-all: 0.0.13
+  codeql/cpp-all: 0.2.3

--- a/c/common/test/codeql-pack.lock.yml
+++ b/c/common/test/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.0.13
+    version: 0.2.3
 compiled: false
 lockVersion: 1.0.0

--- a/c/misra/src/codeql-pack.lock.yml
+++ b/c/misra/src/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.0.13
+    version: 0.2.3
 compiled: false
 lockVersion: 1.0.0

--- a/c/misra/src/qlpack.yml
+++ b/c/misra/src/qlpack.yml
@@ -3,4 +3,4 @@ version: 2.6.0-dev
 suites: codeql-suites
 dependencies:
   codeql/common-c-coding-standards: '*'
-  codeql/cpp-all: 0.0.13
+  codeql/cpp-all: 0.2.3

--- a/c/misra/test/codeql-pack.lock.yml
+++ b/c/misra/test/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.0.13
+    version: 0.2.3
 compiled: false
 lockVersion: 1.0.0

--- a/change_notes/2022-05-04-compiler-generated-fp-M0-1-4.md
+++ b/change_notes/2022-05-04-compiler-generated-fp-M0-1-4.md
@@ -1,0 +1,3 @@
+ - `M0-1-4` - `SingleUsePODVariable.ql`
+   - This rule no longer considers compiler-generated access to a variable when determining if the
+     variable has a single use.

--- a/change_notes/2022-06-01-fix-A8-5-3-braced-initialization-detection.md
+++ b/change_notes/2022-06-01-fix-A8-5-3-braced-initialization-detection.md
@@ -1,0 +1,3 @@
+- `A8-5-3` - `AvoidAutoWithBracedInitialization.ql`:
+  - Fix regression where `auto x{0}` was no longer detected as a braced initialization with type `auto` with the latest CodeQL versions.
+  - No longer falsely detect cases where braced initialization was not used, but where the inferred type would be `std::initializer_list`.

--- a/change_notes/2022-07-15-fix-A7-3-1-location-reporting.md
+++ b/change_notes/2022-07-15-fix-A7-3-1-location-reporting.md
@@ -1,0 +1,2 @@
+- `A7-3-1` - `DefinitionNotConsideredForUnqualifiedLookup.ql`
+  - The locations reported for names occurring in using-declarations has improved in the latest CodeQL versions.

--- a/cpp/autosar/src/codeql-pack.lock.yml
+++ b/cpp/autosar/src/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.0.13
+    version: 0.2.3
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/autosar/src/qlpack.yml
+++ b/cpp/autosar/src/qlpack.yml
@@ -3,4 +3,4 @@ version: 2.6.0-dev
 suites: codeql-suites
 dependencies:
   codeql/common-cpp-coding-standards: '*'
-  codeql/cpp-all: 0.0.13
+  codeql/cpp-all: 0.2.3

--- a/cpp/autosar/src/rules/A8-5-3/AvoidAutoWithBracedInitialization.ql
+++ b/cpp/autosar/src/rules/A8-5-3/AvoidAutoWithBracedInitialization.ql
@@ -21,5 +21,5 @@ from Variable v
 where
   not isExcluded(v, InitializationPackage::avoidAutoWithBracedInitializationQuery()) and
   v.getTypeWithAuto().getUnspecifiedType() instanceof AutoType and
-  v.getType().getUnspecifiedType().(Class).hasQualifiedName("std", "initializer_list")
+  v.getInitializer().isBraced()
 select v, "Variable " + v.getName() + " of type auto uses braced initialization."

--- a/cpp/autosar/src/rules/M0-1-4/SingleUsePODVariable.qll
+++ b/cpp/autosar/src/rules/M0-1-4/SingleUsePODVariable.qll
@@ -10,8 +10,9 @@ int getUseCount(Variable v) {
     // We enforce that it's a POD type variable, so if it has an initializer it is explicit
     (if v.hasInitializer() then initializers = 1 else initializers = 0) and
     result =
-      initializers + count(v.getAnAccess()) +
-        count(UserProvidedConstructorFieldInit cfi | cfi.getTarget() = v)
+      initializers +
+        count(VariableAccess access | access = v.getAnAccess() and not access.isCompilerGenerated())
+        + count(UserProvidedConstructorFieldInit cfi | cfi.getTarget() = v)
   )
 }
 
@@ -23,7 +24,9 @@ Element getSingleUse(Variable v) {
     or
     result = any(UserProvidedConstructorFieldInit cfi | cfi.getTarget() = v)
     or
-    result = v.getAnAccess()
+    exists(VariableAccess access |
+      access = v.getAnAccess() and not access.isCompilerGenerated() and result = access
+    )
   )
 }
 

--- a/cpp/autosar/test/codeql-pack.lock.yml
+++ b/cpp/autosar/test/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.0.13
+    version: 0.2.3
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/autosar/test/rules/A7-3-1/DefinitionNotConsideredForUnqualifiedLookup.expected
+++ b/cpp/autosar/test/rules/A7-3-1/DefinitionNotConsideredForUnqualifiedLookup.expected
@@ -1,1 +1,1 @@
-| test.cpp:42:6:42:7 | declaration of f1 | Definition for 'f1' is not available for unqualified lookup because it is declared after $@ | test.cpp:39:1:39:13 | using f1 | using-declaration |
+| test.cpp:42:6:42:7 | declaration of f1 | Definition for 'f1' is not available for unqualified lookup because it is declared after $@ | test.cpp:39:12:39:13 | using f1 | using-declaration |

--- a/cpp/autosar/test/rules/A8-5-3/test.cpp
+++ b/cpp/autosar/test/rules/A8-5-3/test.cpp
@@ -1,11 +1,12 @@
 #include <initializer_list>
 
 void test() {
-  auto a1(1);       // COMPLIANT
-  auto a2{1};       // NON_COMPLIANT
-  auto a3 = 1;      // COMPLIANT
-  auto a4 = {1};    // NON_COMPLIANT
-  int a5 = {1};     // COMPLIANT
-  const auto a6(1); // COMPLIANT
-  const auto a7{1}; // NON_COMPLIANT
+  auto a1(1);                             // COMPLIANT
+  auto a2{1};                             // NON_COMPLIANT
+  auto a3 = 1;                            // COMPLIANT
+  auto a4 = {1};                          // NON_COMPLIANT
+  int a5 = {1};                           // COMPLIANT
+  const auto a6(1);                       // COMPLIANT
+  const auto a7{1};                       // NON_COMPLIANT
+  auto a8 = std::initializer_list<int>(); // COMPLIANT
 }

--- a/cpp/cert/src/codeql-pack.lock.yml
+++ b/cpp/cert/src/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.0.13
+    version: 0.2.3
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/cert/src/qlpack.yml
+++ b/cpp/cert/src/qlpack.yml
@@ -2,5 +2,5 @@ name: codeql/cert-cpp-coding-standards
 version: 2.6.0-dev
 suites: codeql-suites
 dependencies:
-  codeql/cpp-all: 0.0.13
+  codeql/cpp-all: 0.2.3
   codeql/common-cpp-coding-standards: '*'

--- a/cpp/cert/test/codeql-pack.lock.yml
+++ b/cpp/cert/test/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.0.13
+    version: 0.2.3
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/common/src/codeql-pack.lock.yml
+++ b/cpp/common/src/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.0.13
+    version: 0.2.3
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/common/src/qlpack.yml
+++ b/cpp/common/src/qlpack.yml
@@ -1,4 +1,4 @@
 name: codeql/common-cpp-coding-standards
 version: 2.6.0-dev
 dependencies:
-  codeql/cpp-all: 0.0.13
+  codeql/cpp-all: 0.2.3

--- a/cpp/common/test/codeql-pack.lock.yml
+++ b/cpp/common/test/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.0.13
+    version: 0.2.3
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/misra/src/codeql-pack.lock.yml
+++ b/cpp/misra/src/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.0.13
+    version: 0.2.3
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/misra/src/qlpack.yml
+++ b/cpp/misra/src/qlpack.yml
@@ -2,4 +2,4 @@ name: codeql/misra-cpp-coding-standards
 version: 2.6.0-dev
 dependencies:
   codeql/common-cpp-coding-standards: '*'
-  codeql/cpp-all: 0.0.13
+  codeql/cpp-all: 0.2.3

--- a/cpp/misra/test/codeql-pack.lock.yml
+++ b/cpp/misra/test/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.0.13
+    version: 0.2.3
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/report/src/codeql-pack.lock.yml
+++ b/cpp/report/src/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.0.13
+    version: 0.2.3
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/report/src/qlpack.yml
+++ b/cpp/report/src/qlpack.yml
@@ -1,4 +1,4 @@
 name: codeql/report-cpp-coding-standards
 version: 2.6.0-dev
 dependencies:
-  codeql/cpp-all: 0.0.13
+  codeql/cpp-all: 0.2.3

--- a/supported_codeql_configs.json
+++ b/supported_codeql_configs.json
@@ -1,9 +1,9 @@
 {
   "supported_environment": [
     {
-      "codeql_cli": "2.8.5",
-      "codeql_standard_library": "codeql-cli/v2.8.5",
-      "codeql_cli_bundle": "codeql-bundle-20220401"
+      "codeql_cli": "2.9.4",
+      "codeql_standard_library": "codeql-cli/v2.9.4",
+      "codeql_cli_bundle": "codeql-bundle-20220615"
     }
   ], 
   "supported_language" : [


### PR DESCRIPTION
## Description

(Note that this PR targets the next branch, which is used by the CI for CodeQL to detect changes that break `github/codeql-coding-standards`. These changes should eventually be merged to `main`, but that should not happen until we are ready to update to the required toolset.)

Update to the latest CodeQL version in the 2.9.x series. Note that earlier versions in the series do not have the `isBraced` predicate mentioned below. Hence, targeting those versions would result in regressions.

In A7-3-1, more accurate locations for names in using-declarations are now reported.

In A8-5-3, after the CodeQL update, `int` was emitted as the type for `x` in `auto x{1}`, and not `std::initializer_list`. To address this, an `isBraced` predicate was added to the `Initialization` class of the CodeQL C++ library. This PR switches A8-5-3 over to use that predicate. This also addresses a false positive that could occur, where no braced initialization was used, but where the inferred type for `auto` was `std::initializer_list`.

In M0-1-4, `SingleUsePODVariable.ql`, we were including compiler-generated accesses to the variable when computing the number of uses. This caused new false negatives with the latest C++ extractor, because more compiler-generated constructors, assignment operators, etc. are now present in the database. The intent of the rule is clearly to count user-written uses, so the rule has been updated to ignore compiler-generated uses.

## Change request type

 - [x] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - A8-5-3
     - M0-1-4

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)