### PR TITLE
Update to CodeQL 2.10.1

### DIFF
--- a/c/cert/src/codeql-pack.lock.yml
+++ b/c/cert/src/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.2.3
+    version: 0.3.1
 compiled: false
 lockVersion: 1.0.0

--- a/c/cert/src/qlpack.yml
+++ b/c/cert/src/qlpack.yml
@@ -3,4 +3,4 @@ version: 2.6.0-dev
 suites: codeql-suites
 dependencies:
   codeql/common-c-coding-standards: '*'
-  codeql/cpp-all: 0.2.3
+  codeql/cpp-all: 0.3.1

--- a/c/cert/test/codeql-pack.lock.yml
+++ b/c/cert/test/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.2.3
+    version: 0.3.1
 compiled: false
 lockVersion: 1.0.0

--- a/c/common/src/codeql-pack.lock.yml
+++ b/c/common/src/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.2.3
+    version: 0.3.1
 compiled: false
 lockVersion: 1.0.0

--- a/c/common/src/qlpack.yml
+++ b/c/common/src/qlpack.yml
@@ -2,4 +2,4 @@ name: codeql/common-c-coding-standards
 version: 2.6.0-dev
 dependencies:
   codeql/common-cpp-coding-standards: '*'
-  codeql/cpp-all: 0.2.3
+  codeql/cpp-all: 0.3.1

--- a/c/common/test/codeql-pack.lock.yml
+++ b/c/common/test/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.2.3
+    version: 0.3.1
 compiled: false
 lockVersion: 1.0.0

--- a/c/misra/src/codeql-pack.lock.yml
+++ b/c/misra/src/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.2.3
+    version: 0.3.1
 compiled: false
 lockVersion: 1.0.0

--- a/c/misra/src/qlpack.yml
+++ b/c/misra/src/qlpack.yml
@@ -3,4 +3,4 @@ version: 2.6.0-dev
 suites: codeql-suites
 dependencies:
   codeql/common-c-coding-standards: '*'
-  codeql/cpp-all: 0.2.3
+  codeql/cpp-all: 0.3.1

--- a/c/misra/test/codeql-pack.lock.yml
+++ b/c/misra/test/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.2.3
+    version: 0.3.1
 compiled: false
 lockVersion: 1.0.0

--- a/change_notes/2022-06-28-detect-static-namespace-members.md
+++ b/change_notes/2022-06-28-detect-static-namespace-members.md
@@ -1,0 +1,6 @@
+- `A2-10-4` - `IdentifierNameOfStaticFunctionReusedInNamespace.ql`:
+  - Reuse of an identifier name of a static function in a namespace is now detected.
+- `A2-10-4` - `IdentifierNameOfStaticNonMemberObjectReusedInNamespace.ql`:
+  - Reuse of an identifier name of a static non-member object in a namespace is now detected.
+- `A2-10-5` - `IdentifierNameOfStaticNonMemberObjectWithExternalOrInternalLinkageIsReused.ql`:
+  - Reuse of an identifier name of a static non-member object with internal linkage in a namespace is now detected.

--- a/cpp/autosar/src/codeql-pack.lock.yml
+++ b/cpp/autosar/src/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.2.3
+    version: 0.3.1
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/autosar/src/qlpack.yml
+++ b/cpp/autosar/src/qlpack.yml
@@ -3,4 +3,4 @@ version: 2.6.0-dev
 suites: codeql-suites
 dependencies:
   codeql/common-cpp-coding-standards: '*'
-  codeql/cpp-all: 0.2.3
+  codeql/cpp-all: 0.3.1

--- a/cpp/autosar/test/codeql-pack.lock.yml
+++ b/cpp/autosar/test/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.2.3
+    version: 0.3.1
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/autosar/test/rules/A2-10-4/IdentifierNameOfStaticFunctionReusedInNamespace.expected
+++ b/cpp/autosar/test/rules/A2-10-4/IdentifierNameOfStaticFunctionReusedInNamespace.expected
@@ -1,0 +1,2 @@
+| test1a.cpp:13:13:13:14 | f1 | Static function $@ reuses identifier of $@ | test1a.cpp:13:13:13:14 | f1 | f1 | test1b.cpp:6:13:6:14 | f1 | f1 |
+| test1b.cpp:6:13:6:14 | f1 | Static function $@ reuses identifier of $@ | test1b.cpp:6:13:6:14 | f1 | f1 | test1a.cpp:13:13:13:14 | f1 | f1 |

--- a/cpp/autosar/test/rules/A2-10-4/IdentifierNameOfStaticNonMemberObjectReusedInNamespace.expected
+++ b/cpp/autosar/test/rules/A2-10-4/IdentifierNameOfStaticNonMemberObjectReusedInNamespace.expected
@@ -1,0 +1,2 @@
+| test1a.cpp:2:12:2:13 | v1 | Non-member static object $@ reuses identifier name of non-member static object $@ | test1a.cpp:2:12:2:13 | v1 | v1 | test1b.cpp:2:12:2:13 | v1 | v1 |
+| test1b.cpp:2:12:2:13 | v1 | Non-member static object $@ reuses identifier name of non-member static object $@ | test1b.cpp:2:12:2:13 | v1 | v1 | test1a.cpp:2:12:2:13 | v1 | v1 |

--- a/cpp/autosar/test/rules/A2-10-4/test1b.cpp
+++ b/cpp/autosar/test/rules/A2-10-4/test1b.cpp
@@ -3,7 +3,6 @@ static int v1 = 3; // NON_COMPLIANT
 } // namespace ns1
 
 namespace ns3 {
-static void f1() {} // NON_COMPLIANT - Not accepted by Clang linker and
-                    // therefore not alerted upon.
+static void f1() {} // NON_COMPLIANT - Not accepted by Clang linker
 void f2() {}        // COMPLIANT - Not accepted by Clang linker
 } // namespace ns3

--- a/cpp/autosar/test/rules/A2-10-5/IdentifierNameOfANonMemberObjectWithExternalOrInternalLinkageIsReused.expected
+++ b/cpp/autosar/test/rules/A2-10-5/IdentifierNameOfANonMemberObjectWithExternalOrInternalLinkageIsReused.expected
@@ -1,2 +1,4 @@
-| test1a.cpp:6:12:6:13 | g3 | Identifier name of non-member object $@ reuses the identifier name of non-member object $@. | test1a.cpp:6:12:6:13 | g3 | g3 | test1b.cpp:7:12:7:13 | g3 | g3 |
-| test1b.cpp:7:12:7:13 | g3 | Identifier name of non-member object $@ reuses the identifier name of non-member object $@. | test1b.cpp:7:12:7:13 | g3 | g3 | test1a.cpp:6:12:6:13 | g3 | g3 |
+| test1a.cpp:2:12:2:13 | g1 | Identifier name of non-member object $@ reuses the identifier name of non-member object $@. | test1a.cpp:2:12:2:13 | g1 | g1 | test1b.cpp:2:12:2:13 | g1 | g1 |
+| test1a.cpp:6:12:6:13 | g3 | Identifier name of non-member object $@ reuses the identifier name of non-member object $@. | test1a.cpp:6:12:6:13 | g3 | g3 | test1b.cpp:6:12:6:13 | g3 | g3 |
+| test1b.cpp:2:12:2:13 | g1 | Identifier name of non-member object $@ reuses the identifier name of non-member object $@. | test1b.cpp:2:12:2:13 | g1 | g1 | test1a.cpp:2:12:2:13 | g1 | g1 |
+| test1b.cpp:6:12:6:13 | g3 | Identifier name of non-member object $@ reuses the identifier name of non-member object $@. | test1b.cpp:6:12:6:13 | g3 | g3 | test1a.cpp:6:12:6:13 | g3 | g3 |

--- a/cpp/autosar/test/rules/A2-10-5/IdentifierNameOfAStaticFunctionIsReused.expected
+++ b/cpp/autosar/test/rules/A2-10-5/IdentifierNameOfAStaticFunctionIsReused.expected
@@ -1,2 +1,2 @@
-| test1a.cpp:7:13:7:14 | f1 | Identifier name of static function $@ reuses identifier name of static function $@ | test1a.cpp:7:13:7:14 | f1 | f1 | test1b.cpp:10:13:10:14 | f1 | f1 |
-| test1b.cpp:10:13:10:14 | f1 | Identifier name of static function $@ reuses identifier name of static function $@ | test1b.cpp:10:13:10:14 | f1 | f1 | test1a.cpp:7:13:7:14 | f1 | f1 |
+| test1a.cpp:7:13:7:14 | f1 | Identifier name of static function $@ reuses identifier name of static function $@ | test1a.cpp:7:13:7:14 | f1 | f1 | test1b.cpp:9:13:9:14 | f1 | f1 |
+| test1b.cpp:9:13:9:14 | f1 | Identifier name of static function $@ reuses identifier name of static function $@ | test1b.cpp:9:13:9:14 | f1 | f1 | test1a.cpp:7:13:7:14 | f1 | f1 |

--- a/cpp/autosar/test/rules/A2-10-5/test1b.cpp
+++ b/cpp/autosar/test/rules/A2-10-5/test1b.cpp
@@ -1,6 +1,5 @@
 namespace n1 {
-static int g1 = 1; // NON_COMPLIANT[FALSE_NEGATIVE], considered the same as
-                   // n1::g1 in test1a.cpp.
+static int g1 = 1; // NON_COMPLIANT
 }
 
 namespace n2 {

--- a/cpp/cert/src/codeql-pack.lock.yml
+++ b/cpp/cert/src/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.2.3
+    version: 0.3.1
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/cert/src/qlpack.yml
+++ b/cpp/cert/src/qlpack.yml
@@ -2,5 +2,5 @@ name: codeql/cert-cpp-coding-standards
 version: 2.6.0-dev
 suites: codeql-suites
 dependencies:
-  codeql/cpp-all: 0.2.3
+  codeql/cpp-all: 0.3.1
   codeql/common-cpp-coding-standards: '*'

--- a/cpp/cert/test/codeql-pack.lock.yml
+++ b/cpp/cert/test/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.2.3
+    version: 0.3.1
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/common/src/codeql-pack.lock.yml
+++ b/cpp/common/src/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.2.3
+    version: 0.3.1
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/common/src/qlpack.yml
+++ b/cpp/common/src/qlpack.yml
@@ -1,4 +1,4 @@
 name: codeql/common-cpp-coding-standards
 version: 2.6.0-dev
 dependencies:
-  codeql/cpp-all: 0.2.3
+  codeql/cpp-all: 0.3.1

--- a/cpp/common/test/codeql-pack.lock.yml
+++ b/cpp/common/test/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.2.3
+    version: 0.3.1
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/misra/src/codeql-pack.lock.yml
+++ b/cpp/misra/src/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.2.3
+    version: 0.3.1
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/misra/src/qlpack.yml
+++ b/cpp/misra/src/qlpack.yml
@@ -2,4 +2,4 @@ name: codeql/misra-cpp-coding-standards
 version: 2.6.0-dev
 dependencies:
   codeql/common-cpp-coding-standards: '*'
-  codeql/cpp-all: 0.2.3
+  codeql/cpp-all: 0.3.1

--- a/cpp/misra/test/codeql-pack.lock.yml
+++ b/cpp/misra/test/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.2.3
+    version: 0.3.1
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/report/src/codeql-pack.lock.yml
+++ b/cpp/report/src/codeql-pack.lock.yml
@@ -1,6 +1,6 @@
 ---
 dependencies:
   codeql/cpp-all:
-    version: 0.2.3
+    version: 0.3.1
 compiled: false
 lockVersion: 1.0.0

--- a/cpp/report/src/qlpack.yml
+++ b/cpp/report/src/qlpack.yml
@@ -1,4 +1,4 @@
 name: codeql/report-cpp-coding-standards
 version: 2.6.0-dev
 dependencies:
-  codeql/cpp-all: 0.2.3
+  codeql/cpp-all: 0.3.1

--- a/supported_codeql_configs.json
+++ b/supported_codeql_configs.json
@@ -1,9 +1,9 @@
 {
   "supported_environment": [
     {
-      "codeql_cli": "2.9.4",
-      "codeql_standard_library": "codeql-cli/v2.9.4",
-      "codeql_cli_bundle": "codeql-bundle-20220615"
+      "codeql_cli": "2.10.1",
+      "codeql_standard_library": "codeql-cli/v2.10.1",
+      "codeql_cli_bundle": "codeql-bundle-20220714"
     }
   ], 
   "supported_language" : [


### PR DESCRIPTION
## Description

(Note that this PR targets the `next` branch, which is used by the CI for CodeQL to detect changes that break `github/codeql-coding-standards`. These changes should eventually be merged to `main`, but that should not happen until we are ready to update to the required toolset.)

Update to CodeQL 2.10.1. This version of CodeQL respects that static declarations within namespaces have internal linkage, affecting A2-10-4 and A2-20-5.

Update the expected test results of A2-10-4 and A2-20-5, as the relevant non-compliant cases are now flagged up during testing.

## Change request type

 - [x] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)