### PR TITLE
2.6 Version Bump

### DIFF
--- a/c/cert/src/qlpack.yml
+++ b/c/cert/src/qlpack.yml
@@ -1,4 +1,4 @@
 name: cert-c-coding-standards
-version: 2.6.0-dev
+version: 2.6.0
 suites: codeql-suites
 libraryPathDependencies: common-c-coding-standards

--- a/c/cert/test/qlpack.yml
+++ b/c/cert/test/qlpack.yml
@@ -1,4 +1,4 @@
 name: cert-c-coding-standards-tests
-version: 2.6.0-dev
+version: 2.6.0
 libraryPathDependencies: cert-c-coding-standards
 extractor: cpp

--- a/c/common/src/qlpack.yml
+++ b/c/common/src/qlpack.yml
@@ -1,3 +1,3 @@
 name: common-c-coding-standards
-version: 2.6.0-dev
+version: 2.6.0
 libraryPathDependencies: common-cpp-coding-standards

--- a/c/common/test/qlpack.yml
+++ b/c/common/test/qlpack.yml
@@ -1,4 +1,4 @@
 name: common-c-coding-standards-tests
-version: 2.6.0-dev
+version: 2.6.0
 libraryPathDependencies: common-c-coding-standards
 extractor: cpp

--- a/c/misra/src/qlpack.yml
+++ b/c/misra/src/qlpack.yml
@@ -1,4 +1,4 @@
 name: misra-c-coding-standards
-version: 2.6.0-dev
+version: 2.6.0
 suites: codeql-suites
 libraryPathDependencies: common-c-coding-standards

--- a/c/misra/test/qlpack.yml
+++ b/c/misra/test/qlpack.yml
@@ -1,4 +1,4 @@
 name: misra-c-coding-standards-tests
-version: 2.6.0-dev
+version: 2.6.0
 libraryPathDependencies: misra-c-coding-standards
 extractor: cpp

--- a/cpp/autosar/src/qlpack.yml
+++ b/cpp/autosar/src/qlpack.yml
@@ -1,4 +1,4 @@
 name: autosar-cpp-coding-standards
-version: 2.6.0-dev
+version: 2.6.0
 suites: codeql-suites
 libraryPathDependencies: common-cpp-coding-standards

--- a/cpp/autosar/test/qlpack.yml
+++ b/cpp/autosar/test/qlpack.yml
@@ -1,4 +1,4 @@
 name: autosar-cpp-coding-standards-tests
-version: 2.6.0-dev
+version: 2.6.0
 libraryPathDependencies: autosar-cpp-coding-standards
 extractor: cpp

--- a/cpp/cert/src/qlpack.yml
+++ b/cpp/cert/src/qlpack.yml
@@ -1,4 +1,4 @@
 name: cert-cpp-coding-standards
-version: 2.6.0-dev
+version: 2.6.0
 suites: codeql-suites
 libraryPathDependencies: common-cpp-coding-standards

--- a/cpp/cert/test/qlpack.yml
+++ b/cpp/cert/test/qlpack.yml
@@ -1,4 +1,4 @@
 name: cert-cpp-coding-standards-tests
-version: 2.6.0-dev
+version: 2.6.0
 libraryPathDependencies: cert-cpp-coding-standards
 extractor: cpp

--- a/cpp/common/src/qlpack.yml
+++ b/cpp/common/src/qlpack.yml
@@ -1,3 +1,3 @@
 name: common-cpp-coding-standards
-version: 2.6.0-dev
+version: 2.6.0
 libraryPathDependencies: codeql-cpp

--- a/cpp/common/test/qlpack.yml
+++ b/cpp/common/test/qlpack.yml
@@ -1,4 +1,4 @@
 name: common-cpp-coding-standards-tests
-version: 2.6.0-dev
+version: 2.6.0
 libraryPathDependencies: common-cpp-coding-standards
 extractor: cpp

--- a/cpp/misra/src/qlpack.yml
+++ b/cpp/misra/src/qlpack.yml
@@ -1,3 +1,3 @@
 name: misra-cpp-coding-standards
-version: 2.6.0-dev
+version: 2.6.0
 libraryPathDependencies: common-cpp-coding-standards

--- a/cpp/misra/test/qlpack.yml
+++ b/cpp/misra/test/qlpack.yml
@@ -1,4 +1,4 @@
 name: misra-cpp-coding-standards-tests
-version: 2.6.0-dev
+version: 2.6.0
 libraryPathDependencies: misra-cpp-coding-standards
 extractor: cpp

--- a/cpp/report/src/qlpack.yml
+++ b/cpp/report/src/qlpack.yml
@@ -1,3 +1,3 @@
 name: report-cpp-coding-standards
-version: 2.6.0-dev
+version: 2.6.0
 libraryPathDependencies: codeql-cpp


### PR DESCRIPTION
## Description

Version Bump. 

## Change request type

 - [x] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [ ] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)