### PR TITLE
Removed Unneeded Predicate Clause

### DIFF
--- a/change_notes/2022-07-21-performance-fix-to-deadlock-query.md
+++ b/change_notes/2022-07-21-performance-fix-to-deadlock-query.md
@@ -1,0 +1,4 @@
+- `CON53-CPP` - `DeadlockByLockingInPredefinedOrder.ql`
+  - Optimized performance by removing unneeded conditionals. 
+- `CON35-C` - `DeadlockByLockingInPredefinedOrder.ql`
+  - Optimized performance by removing unneeded conditionals. 

--- a/change_notes/2022-07-21-performance-fix-to-deadlock-query.md
+++ b/change_notes/2022-07-21-performance-fix-to-deadlock-query.md
@@ -1,4 +1,4 @@
 - `CON53-CPP` - `DeadlockByLockingInPredefinedOrder.ql`
   - Optimized performance by removing unneeded conditionals. 
-- `CON35-C` - `DeadlockByLockingInPredefinedOrder.ql`
+- `CON35-C`  - `DeadlockByLockingInPredefinedOrder.ql`
   - Optimized performance by removing unneeded conditionals. 

--- a/cpp/common/src/codingstandards/cpp/rules/preventdeadlockbylockinginpredefinedorder/PreventDeadlockByLockingInPredefinedOrder.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/preventdeadlockbylockinginpredefinedorder/PreventDeadlockByLockingInPredefinedOrder.qll
@@ -25,7 +25,6 @@ predicate getAnOrderedLockPair(
   lock2 = node.coveredByLock() and
   not lock1 = lock2 and
   lock1.getEnclosingFunction() = lock2.getEnclosingFunction() and
-  node.(Expr).getEnclosingFunction() = lock1.getEnclosingFunction() and
   exists(Location l1Loc, Location l2Loc |
     l1Loc = lock1.getLocation() and
     l2Loc = lock2.getLocation()


### PR DESCRIPTION
## Description

This unneeded condition was causing performance problems. 

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     -
 - [ ] Queries have been modified for the following rules:
     -  CON35-C
     - CON53-CPP

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)