### PR TITLE
Add basic single translation unit query suites

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -185,12 +185,10 @@
             "type": "pickString",
             "options": [
                 "Allocations",
-                "Banned",
                 "BannedFunctions",
+                "BannedLibraries",
                 "BannedSyntax",
                 "BannedTypes",
-                "Classes",
-                "Classes",
                 "Classes",
                 "Comments",
                 "Contracts1",

--- a/change_notes/2022-08-17-add-single-translation-unit-suites.md
+++ b/change_notes/2022-08-17-add-single-translation-unit-suites.md
@@ -1,0 +1,3 @@
+ - Added the `autosar-single-translation-unit.qls` and `cert-single-translation-unit.qls` query suites for C++.
+     - These include a subset of queries which are suitable for running over databases including only a single translation unit.
+     - The initial version includes rules from the "Banned*" C++ packages. Future updates will add additional queries into this suite as they are identified as suitable.

--- a/cpp/autosar/src/codeql-suites/autosar-advisory.qls
+++ b/cpp/autosar/src/codeql-suites/autosar-advisory.qls
@@ -1,4 +1,4 @@
-- description: AUTOSAR C++14 Guidelines 19-11 (Advisory)
+- description: AUTOSAR C++14 Guidelines 20-11 (Advisory)
 - qlpack: autosar-cpp-coding-standards
 - include:
     kind:

--- a/cpp/autosar/src/codeql-suites/autosar-audit.qls
+++ b/cpp/autosar/src/codeql-suites/autosar-audit.qls
@@ -1,4 +1,4 @@
-- description: AUTOSAR C++14 Guidelines 19-11 (Audit)
+- description: AUTOSAR C++14 Guidelines 20-11 (Audit)
 - qlpack: autosar-cpp-coding-standards
 - include:
     kind:

--- a/cpp/autosar/src/codeql-suites/autosar-default.qls
+++ b/cpp/autosar/src/codeql-suites/autosar-default.qls
@@ -1,4 +1,4 @@
-- description: AUTOSAR C++14 Guidelines 19-11 (Default)
+- description: AUTOSAR C++14 Guidelines 20-11 (Default)
 - qlpack: autosar-cpp-coding-standards
 - include:
     kind:

--- a/cpp/autosar/src/codeql-suites/autosar-required.qls
+++ b/cpp/autosar/src/codeql-suites/autosar-required.qls
@@ -1,4 +1,4 @@
-- description: AUTOSAR C++14 Guidelines 19-11 (Required)
+- description: AUTOSAR C++14 Guidelines 20-11 (Required)
 - qlpack: autosar-cpp-coding-standards
 - include:
     kind:

--- a/cpp/autosar/src/codeql-suites/autosar-single-translation-unit.qls
+++ b/cpp/autosar/src/codeql-suites/autosar-single-translation-unit.qls
@@ -1,0 +1,12 @@
+- description: AUTOSAR C++14 Guidelines 20-11 (Single Translation Unit)
+- qlpack: autosar-cpp-coding-standards
+- include:
+    kind:
+    - problem
+    - path-problem
+    tags contain:
+    - scope/single-translation-unit
+- exclude:
+    tags contain:
+    - external/autosar/audit
+    - external/autosar/default-disabled

--- a/cpp/autosar/src/rules/A0-4-2/TypeLongDoubleUsed.ql
+++ b/cpp/autosar/src/rules/A0-4-2/TypeLongDoubleUsed.ql
@@ -9,6 +9,7 @@
  * @tags external/autosar/id/a0-4-2
  *       correctness
  *       readability
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A11-3-1/FriendDeclarationsUsed.ql
+++ b/cpp/autosar/src/rules/A11-3-1/FriendDeclarationsUsed.ql
@@ -8,6 +8,7 @@
  * @tags external/autosar/id/a11-3-1
  *       correctness
  *       security
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A17-0-1/ReservedIdentifiersMacrosAndFunctionsAreDefinedRedefinedOrUndefined.ql
+++ b/cpp/autosar/src/rules/A17-0-1/ReservedIdentifiersMacrosAndFunctionsAreDefinedRedefinedOrUndefined.ql
@@ -14,6 +14,7 @@
  * @tags external/autosar/id/a17-0-1
  *       correctness
  *       maintainability
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A18-0-1/CLibraryFacilitiesNotAccessedThroughCPPLibraryHeaders.ql
+++ b/cpp/autosar/src/rules/A18-0-1/CLibraryFacilitiesNotAccessedThroughCPPLibraryHeaders.ql
@@ -9,6 +9,7 @@
  * @tags external/autosar/id/a18-0-1
  *       correctness
  *       readability
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A18-0-3/LocaleFunctionsUsed.ql
+++ b/cpp/autosar/src/rules/A18-0-3/LocaleFunctionsUsed.ql
@@ -14,6 +14,7 @@
  * @problem.severity warning
  * @tags external/autosar/id/a18-0-3
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A18-0-3/LocaleMacrosUsed.ql
+++ b/cpp/autosar/src/rules/A18-0-3/LocaleMacrosUsed.ql
@@ -9,6 +9,7 @@
  * @problem.severity warning
  * @tags external/autosar/id/a18-0-3
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A18-0-3/LocaleTypeLConvUsed.ql
+++ b/cpp/autosar/src/rules/A18-0-3/LocaleTypeLConvUsed.ql
@@ -8,6 +8,7 @@
  * @problem.severity warning
  * @tags external/autosar/id/a18-0-3
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A18-1-1/CStyleArraysUsed.ql
+++ b/cpp/autosar/src/rules/A18-1-1/CStyleArraysUsed.ql
@@ -8,6 +8,7 @@
  * @problem.severity error
  * @tags external/autosar/id/a18-1-1
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A18-1-2/VectorboolSpecializationUsed.ql
+++ b/cpp/autosar/src/rules/A18-1-2/VectorboolSpecializationUsed.ql
@@ -9,6 +9,7 @@
  * @problem.severity warning
  * @tags external/autosar/id/a18-1-2
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A18-1-3/AutoPtrTypeUsed.ql
+++ b/cpp/autosar/src/rules/A18-1-3/AutoPtrTypeUsed.ql
@@ -7,6 +7,7 @@
  * @problem.severity warning
  * @tags external/autosar/id/a18-1-3
  *       maintainability
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A18-5-1/FunctionsMallocCallocReallocAndFreeUsed.ql
+++ b/cpp/autosar/src/rules/A18-5-1/FunctionsMallocCallocReallocAndFreeUsed.ql
@@ -8,6 +8,7 @@
  * @problem.severity error
  * @tags external/autosar/id/a18-5-1
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A18-9-1/BindUsed.ql
+++ b/cpp/autosar/src/rules/A18-9-1/BindUsed.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @tags external/autosar/id/a18-9-1
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A2-11-1/VolatileKeywordUsed.ql
+++ b/cpp/autosar/src/rules/A2-11-1/VolatileKeywordUsed.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @tags external/autosar/id/a2-11-1
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/design
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated

--- a/cpp/autosar/src/rules/A2-13-3/TypeWcharTUsed.ql
+++ b/cpp/autosar/src/rules/A2-13-3/TypeWcharTUsed.ql
@@ -8,6 +8,7 @@
  * @tags external/autosar/id/a2-13-3
  *       correctness
  *       readability
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/architecture
  *       external/autosar/allocated-target/design
  *       external/autosar/allocated-target/implementation

--- a/cpp/autosar/src/rules/A26-5-1/PseudorandomNumbersGeneratedUsingRand.ql
+++ b/cpp/autosar/src/rules/A26-5-1/PseudorandomNumbersGeneratedUsingRand.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @tags external/autosar/id/a26-5-1
  *       security
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A5-16-1/TernaryConditionalOperatorUsedAsSubExpression.ql
+++ b/cpp/autosar/src/rules/A5-16-1/TernaryConditionalOperatorUsedAsSubExpression.ql
@@ -8,6 +8,7 @@
  * @problem.severity error
  * @tags external/autosar/id/a5-16-1
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A5-2-1/DynamicCastShouldNotBeUsed.ql
+++ b/cpp/autosar/src/rules/A5-2-1/DynamicCastShouldNotBeUsed.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @tags external/autosar/id/a5-2-1
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/advisory

--- a/cpp/autosar/src/rules/A5-2-2/TraditionalCStyleCastsUsed.ql
+++ b/cpp/autosar/src/rules/A5-2-2/TraditionalCStyleCastsUsed.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @tags external/autosar/id/a5-2-2
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A5-2-4/ReinterpretCastUsed.ql
+++ b/cpp/autosar/src/rules/A5-2-4/ReinterpretCastUsed.ql
@@ -8,6 +8,7 @@
  * @tags external/autosar/id/a5-2-4
  *       correctness
  *       security
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A6-6-1/GotoStatementUsed.ql
+++ b/cpp/autosar/src/rules/A6-6-1/GotoStatementUsed.ql
@@ -8,6 +8,7 @@
  * @tags external/autosar/id/a6-6-1
  *       correctness
  *       security
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A7-1-4/RegisterKeywordUsed.ql
+++ b/cpp/autosar/src/rules/A7-1-4/RegisterKeywordUsed.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @tags external/autosar/id/a7-1-4
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A7-1-6/TypedefSpecifierUsed.ql
+++ b/cpp/autosar/src/rules/A7-1-6/TypedefSpecifierUsed.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @tags external/autosar/id/a7-1-6
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A7-4-1/AsmDeclarationUsed.ql
+++ b/cpp/autosar/src/rules/A7-4-1/AsmDeclarationUsed.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @tags external/autosar/id/a7-4-1
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A8-4-1/FunctionsDefinedUsingTheEllipsisNotation.ql
+++ b/cpp/autosar/src/rules/A8-4-1/FunctionsDefinedUsingTheEllipsisNotation.ql
@@ -8,6 +8,7 @@
  * @tags external/autosar/id/a8-4-1
  *       correctness
  *       security
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/A9-5-1/UnionsUsed.ql
+++ b/cpp/autosar/src/rules/A9-5-1/UnionsUsed.ql
@@ -8,6 +8,7 @@
  * @problem.severity error
  * @tags external/autosar/id/a9-5-1
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/M17-0-5/SetjmpMacroAndTheLongjmpFunctionUsed.ql
+++ b/cpp/autosar/src/rules/M17-0-5/SetjmpMacroAndTheLongjmpFunctionUsed.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @tags external/autosar/id/m17-0-5
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/M18-0-3/LibraryFunctionsAbortExitGetenvAndSystemFromLibraryCstdlibUsed.ql
+++ b/cpp/autosar/src/rules/M18-0-3/LibraryFunctionsAbortExitGetenvAndSystemFromLibraryCstdlibUsed.ql
@@ -8,6 +8,7 @@
  * @tags external/autosar/id/m18-0-3
  *       correctness
  *       security
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/M18-0-4/TimeHandlingFunctionsOfLibraryCtimeUsed.ql
+++ b/cpp/autosar/src/rules/M18-0-4/TimeHandlingFunctionsOfLibraryCtimeUsed.ql
@@ -8,6 +8,7 @@
  * @tags external/autosar/id/m18-0-4
  *       correctness
  *       security
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/M18-0-5/UnboundedFunctionsOfLibraryCstringUsed.ql
+++ b/cpp/autosar/src/rules/M18-0-5/UnboundedFunctionsOfLibraryCstringUsed.ql
@@ -8,6 +8,7 @@
  * @tags external/autosar/id/m18-0-5
  *       security
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/M18-2-1/MacroOffsetofUsed.ql
+++ b/cpp/autosar/src/rules/M18-2-1/MacroOffsetofUsed.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @tags external/autosar/id/m18-2-1
  *       security
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/M18-7-1/CsignalFunctionsUsed.ql
+++ b/cpp/autosar/src/rules/M18-7-1/CsignalFunctionsUsed.ql
@@ -8,6 +8,7 @@
  * @tags external/autosar/id/m18-7-1
  *       maintainability
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/M18-7-1/CsignalTypesUsed.ql
+++ b/cpp/autosar/src/rules/M18-7-1/CsignalTypesUsed.ql
@@ -8,6 +8,7 @@
  * @tags external/autosar/id/m18-7-1
  *       maintainability
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/M19-3-1/ErrnoUsed.ql
+++ b/cpp/autosar/src/rules/M19-3-1/ErrnoUsed.ql
@@ -10,6 +10,7 @@
  * @tags external/autosar/id/m19-3-1
  *       correctness
  *       maintainability
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/M27-0-1/CstdioFunctionsUsed.ql
+++ b/cpp/autosar/src/rules/M27-0-1/CstdioFunctionsUsed.ql
@@ -9,6 +9,7 @@
  * @tags external/autosar/id/m27-0-1
  *       maintainability
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/M27-0-1/CstdioMacrosUsed.ql
+++ b/cpp/autosar/src/rules/M27-0-1/CstdioMacrosUsed.ql
@@ -9,6 +9,7 @@
  * @tags external/autosar/id/m27-0-1
  *       maintainability
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/M27-0-1/CstdioTypesUsed.ql
+++ b/cpp/autosar/src/rules/M27-0-1/CstdioTypesUsed.ql
@@ -9,6 +9,7 @@
  * @tags external/autosar/id/m27-0-1
  *       maintainability
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/M5-18-1/CommaOperatorUsed.ql
+++ b/cpp/autosar/src/rules/M5-18-1/CommaOperatorUsed.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @tags external/autosar/id/m5-18-1
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/M7-3-4/UsingDirectivesUsed.ql
+++ b/cpp/autosar/src/rules/M7-3-4/UsingDirectivesUsed.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @tags external/autosar/id/m7-3-4
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/M7-3-6/UsingDeclarationsUsedInHeaderFiles.ql
+++ b/cpp/autosar/src/rules/M7-3-6/UsingDeclarationsUsedInHeaderFiles.ql
@@ -8,6 +8,7 @@
  * @problem.severity error
  * @tags external/autosar/id/m7-3-6
  *       correctness
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/enforcement/automated
  *       external/autosar/obligation/required

--- a/cpp/autosar/src/rules/M7-4-1/UsageOfAssemblerNotDocumented.ql
+++ b/cpp/autosar/src/rules/M7-4-1/UsageOfAssemblerNotDocumented.ql
@@ -8,6 +8,7 @@
  * @tags external/autosar/id/m7-4-1
  *       readability
  *       maintainability
+ *       scope/single-translation-unit
  *       external/autosar/allocated-target/implementation
  *       external/autosar/audit
  *       external/autosar/enforcement/non-automated

--- a/cpp/cert/src/codeql-suites/cert-single-translation-unit.qls
+++ b/cpp/cert/src/codeql-suites/cert-single-translation-unit.qls
@@ -1,0 +1,11 @@
+- description: CERT C++ 2016 (Single Translation Unit)
+- qlpack: cert-cpp-coding-standards
+- include:
+    kind:
+    - problem
+    - path-problem
+    tags contain:
+    - scope/single-translation-unit
+- exclude:
+    tags contain:
+    - external/cert/default-disabled

--- a/cpp/cert/src/rules/DCL50-CPP/DoNotDefineACStyleVariadicFunction.ql
+++ b/cpp/cert/src/rules/DCL50-CPP/DoNotDefineACStyleVariadicFunction.ql
@@ -8,6 +8,7 @@
  * @tags external/cert/id/dcl50-cpp
  *       correctness
  *       security
+ *       scope/single-translation-unit
  *       external/cert/obligation/rule
  */
 

--- a/cpp/cert/src/rules/ERR52-CPP/DoNotUseSetjmpOrLongjmp.ql
+++ b/cpp/cert/src/rules/ERR52-CPP/DoNotUseSetjmpOrLongjmp.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @tags external/cert/id/err52-cpp
  *       correctness
+ *       scope/single-translation-unit
  *       external/cert/obligation/rule
  */
 

--- a/cpp/cert/src/rules/MSC50-CPP/DoNotUseRandForGeneratingPseudorandomNumbers.ql
+++ b/cpp/cert/src/rules/MSC50-CPP/DoNotUseRandForGeneratingPseudorandomNumbers.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @tags external/cert/id/msc50-cpp
  *       security
+ *       scope/single-translation-unit
  *       external/cert/obligation/rule
  */
 

--- a/cpp/cert/src/rules/OOP57-CPP/PreferSpecialMemberFunctionsAndOverloadedOperatorsToCStandardLibraryFunctions.ql
+++ b/cpp/cert/src/rules/OOP57-CPP/PreferSpecialMemberFunctionsAndOverloadedOperatorsToCStandardLibraryFunctions.ql
@@ -7,6 +7,7 @@
  * @problem.severity error
  * @tags external/cert/id/oop57-cpp
  *       correctness
+ *       scope/single-translation-unit
  *       external/cert/obligation/rule
  */
 

--- a/rule_packages/cpp/BannedFunctions.json
+++ b/rule_packages/cpp/BannedFunctions.json
@@ -17,7 +17,8 @@
           "severity": "error",
           "short_name": "FunctionsMallocCallocReallocAndFreeUsed",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -40,7 +41,8 @@
           "severity": "error",
           "short_name": "BindUsed",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -62,9 +64,10 @@
           "precision": "very-high",
           "severity": "error",
           "short_name": "PseudorandomNumbersGeneratedUsingRand",
-          "shared_implementation_short_name" : "DoNotUseRandForGeneratingPseudorandomNumbers",
+          "shared_implementation_short_name": "DoNotUseRandForGeneratingPseudorandomNumbers",
           "tags": [
-            "security"
+            "security",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -87,7 +90,8 @@
           "severity": "error",
           "short_name": "SetjmpMacroAndTheLongjmpFunctionUsed",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -111,7 +115,8 @@
           "short_name": "LibraryFunctionsAbortExitGetenvAndSystemFromLibraryCstdlibUsed",
           "tags": [
             "correctness",
-            "security"
+            "security",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -135,7 +140,8 @@
           "short_name": "TimeHandlingFunctionsOfLibraryCtimeUsed",
           "tags": [
             "correctness",
-            "security"
+            "security",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -159,7 +165,8 @@
           "short_name": "UnboundedFunctionsOfLibraryCstringUsed",
           "tags": [
             "security",
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -182,7 +189,8 @@
           "severity": "error",
           "short_name": "MacroOffsetofUsed",
           "tags": [
-            "security"
+            "security",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -203,7 +211,8 @@
           "severity": "error",
           "short_name": "DoNotUseSetjmpOrLongjmp",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -221,9 +230,10 @@
           "precision": "very-high",
           "severity": "error",
           "short_name": "DoNotUseRandForGeneratingPseudorandomNumbers",
-          "shared_implementation_short_name" : "DoNotUseRandForGeneratingPseudorandomNumbers",
+          "shared_implementation_short_name": "DoNotUseRandForGeneratingPseudorandomNumbers",
           "tags": [
-            "security"
+            "security",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -242,7 +252,8 @@
           "severity": "error",
           "short_name": "PreferSpecialMemberFunctionsAndOverloadedOperatorsToCStandardLibraryFunctions",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],

--- a/rule_packages/cpp/BannedLibraries.json
+++ b/rule_packages/cpp/BannedLibraries.json
@@ -18,7 +18,8 @@
           "short_name": "ReservedIdentifiersMacrosAndFunctionsAreDefinedRedefinedOrUndefined",
           "tags": [
             "correctness",
-            "maintainability"
+            "maintainability",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -42,7 +43,8 @@
           "short_name": "CLibraryFacilitiesNotAccessedThroughCPPLibraryHeaders",
           "tags": [
             "correctness",
-            "readability"
+            "readability",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -65,7 +67,8 @@
           "severity": "warning",
           "short_name": "LocaleFunctionsUsed",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         },
         {
@@ -76,7 +79,8 @@
           "severity": "warning",
           "short_name": "LocaleMacrosUsed",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         },
         {
@@ -87,7 +91,8 @@
           "severity": "warning",
           "short_name": "LocaleTypeLConvUsed",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -111,7 +116,8 @@
           "short_name": "CsignalFunctionsUsed",
           "tags": [
             "maintainability",
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         },
         {
@@ -123,7 +129,8 @@
           "short_name": "CsignalTypesUsed",
           "tags": [
             "maintainability",
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -147,7 +154,8 @@
           "short_name": "ErrnoUsed",
           "tags": [
             "correctness",
-            "maintainability"
+            "maintainability",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -171,7 +179,8 @@
           "short_name": "CstdioFunctionsUsed",
           "tags": [
             "maintainability",
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         },
         {
@@ -183,7 +192,8 @@
           "short_name": "CstdioMacrosUsed",
           "tags": [
             "maintainability",
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         },
         {
@@ -195,7 +205,8 @@
           "short_name": "CstdioTypesUsed",
           "tags": [
             "maintainability",
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -220,7 +231,8 @@
           "short_name": "UsageOfAssemblerNotDocumented",
           "tags": [
             "readability",
-            "maintainability"
+            "maintainability",
+            "scope/single-translation-unit"
           ]
         }
       ],

--- a/rule_packages/cpp/BannedSyntax.json
+++ b/rule_packages/cpp/BannedSyntax.json
@@ -18,7 +18,8 @@
           "short_name": "FriendDeclarationsUsed",
           "tags": [
             "correctness",
-            "security"
+            "security",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -41,7 +42,8 @@
           "severity": "error",
           "short_name": "CStyleArraysUsed",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -65,7 +67,8 @@
           "severity": "error",
           "short_name": "VolatileKeywordUsed",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -88,7 +91,8 @@
           "severity": "error",
           "short_name": "TernaryConditionalOperatorUsedAsSubExpression",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -111,7 +115,8 @@
           "severity": "error",
           "short_name": "DynamicCastShouldNotBeUsed",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -134,7 +139,8 @@
           "severity": "error",
           "short_name": "TraditionalCStyleCastsUsed",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -158,7 +164,8 @@
           "short_name": "ReinterpretCastUsed",
           "tags": [
             "correctness",
-            "security"
+            "security",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -182,7 +189,8 @@
           "short_name": "GotoStatementUsed",
           "tags": [
             "correctness",
-            "security"
+            "security",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -205,7 +213,8 @@
           "severity": "error",
           "short_name": "RegisterKeywordUsed",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -228,7 +237,8 @@
           "severity": "error",
           "short_name": "TypedefSpecifierUsed",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -251,7 +261,8 @@
           "severity": "error",
           "short_name": "AsmDeclarationUsed",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -275,7 +286,8 @@
           "short_name": "FunctionsDefinedUsingTheEllipsisNotation",
           "tags": [
             "correctness",
-            "security"
+            "security",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -298,7 +310,8 @@
           "severity": "error",
           "short_name": "UnionsUsed",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -322,7 +335,8 @@
           "short_name": "CommaOperatorUsed",
           "shared_implementation_short_name": "CommaOperatorUsed",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -345,7 +359,8 @@
           "severity": "error",
           "short_name": "UsingDirectivesUsed",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -368,7 +383,8 @@
           "severity": "error",
           "short_name": "UsingDeclarationsUsedInHeaderFiles",
           "tags": [
-            "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -390,7 +406,8 @@
           "short_name": "DoNotDefineACStyleVariadicFunction",
           "tags": [
             "correctness",
-            "security"
+            "security",
+            "scope/single-translation-unit"
           ]
         }
       ],

--- a/rule_packages/cpp/BannedTypes.json
+++ b/rule_packages/cpp/BannedTypes.json
@@ -18,7 +18,8 @@
           "short_name": "TypeLongDoubleUsed",
           "tags": [
             "correctness",
-            "readability"
+            "readability",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -41,7 +42,8 @@
           "severity": "warning",
           "short_name": "VectorboolSpecializationUsed",
           "tags": [
-              "correctness"
+            "correctness",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -64,7 +66,8 @@
           "severity": "warning",
           "short_name": "AutoPtrTypeUsed",
           "tags": [
-            "maintainability"
+            "maintainability",
+            "scope/single-translation-unit"
           ]
         }
       ],
@@ -90,7 +93,8 @@
           "short_name": "TypeWcharTUsed",
           "tags": [
             "correctness",
-            "readability"
+            "readability",
+            "scope/single-translation-unit"
           ]
         }
       ],

--- a/schemas/rule-package.schema.json
+++ b/schemas/rule-package.schema.json
@@ -287,7 +287,9 @@
                             "external/autosar/audit",
                             "external/autosar/default-disabled",
                             "external/cert/default-disabled",
-                            "external/autosar/strict"
+                            "external/autosar/strict",
+                            "scope/single-translation-unit",
+                            "scope/system"
                         ]
                     },
                     "minLength": 1


### PR DESCRIPTION
## Description

This PR adds two new query suites for C++, `autosar-single-translation-unit.qls` and `cert-single-translation-unit.qls` which are used to run queries which do not require a whole program analysis. Specifically, they can be run on a database representing a single compilation (i.e. translation unit) without introducing new false positives compared to a whole program analysis.

To enable this information to be stored with the metadata for each query, I have added a new tag `scope/single-translation-unit`. In addition, I anticipate adding another tag `scope/system` for queries which are confirmed as requiring a system wide program analysis. The terminology is copied from MISRA C 2012, which already specifies the scope for each rule.

Unfortunately CERT C++ and AUTOSAR C++ do not provide such scoping information, so we will need to review queries individually to determine which are assigned to each scope. For the initial release of this query suite I have reviewed the following rule packages:
 * `BannedFunctions`
 * `BannedLibraries`
 * `BannedSyntax`
 * `BannedTypes`

I choose these packages as I believed they had a high likelihood of being single-translation-unit suitable. As it turned out, all 49 of the queries in these packages were `scope/single-translation-unit`.

We will review additional rule packages in future releases to expand the set of queries included in this suite.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)