### PR TITLE
Rename isPOD to isPod to silence deprecation warnings

### DIFF
--- a/cpp/autosar/src/codingstandards/cpp/HardwareOrProtocolInterface.qll
+++ b/cpp/autosar/src/codingstandards/cpp/HardwareOrProtocolInterface.qll
@@ -39,7 +39,7 @@ class DefinedSizeType extends Type {
 
 class DefinedSizeClass extends Class {
   DefinedSizeClass() {
-    this.isPOD() and
+    this.isPod() and
     forall(Field f | f = this.getAField() | f.getType() instanceof DefinedSizeType)
   }
 }

--- a/cpp/autosar/src/rules/A11-0-1/NonPodTypeShouldBeDefinedAsClass.ql
+++ b/cpp/autosar/src/rules/A11-0-1/NonPodTypeShouldBeDefinedAsClass.ql
@@ -22,5 +22,5 @@ import codingstandards.cpp.Typehelpers
 from Struct s
 where
   not isExcluded(s, ClassesPackage::nonPodTypeShouldBeDefinedAsClassQuery()) and
-  not s.isPOD()
+  not s.isPod()
 select s, "Non-POD type defined as struct instead of class."

--- a/cpp/autosar/src/rules/A12-0-2/OperationsAssumingMemoryLayoutPerformedOnObjects.ql
+++ b/cpp/autosar/src/rules/A12-0-2/OperationsAssumingMemoryLayoutPerformedOnObjects.ql
@@ -19,7 +19,7 @@ import cpp
 import codingstandards.cpp.autosar
 
 class Object extends Class {
-  Object() { not this.(Struct).isPOD() }
+  Object() { not this.(Struct).isPod() }
 }
 
 predicate isPointerToObject(Expr e) {

--- a/cpp/autosar/src/rules/A9-6-1/DataTypesUsedForInterfacingWithHardwareOrProtocolsMustBeTrivialAndStandardLayout.ql
+++ b/cpp/autosar/src/rules/A9-6-1/DataTypesUsedForInterfacingWithHardwareOrProtocolsMustBeTrivialAndStandardLayout.ql
@@ -23,6 +23,6 @@ from HardwareOrProtocolInterfaceClass c
 where
   not isExcluded(c,
     ClassesPackage::dataTypesUsedForInterfacingWithHardwareOrProtocolsMustBeTrivialAndStandardLayoutQuery()) and
-  not c.isPOD()
+  not c.isPod()
 select c,
   "Data type used for hardware interface or communication protocol is not standard layout and trivial."

--- a/cpp/autosar/src/rules/M11-0-1/MemberDataInNonPodClassTypesNotPrivate.ql
+++ b/cpp/autosar/src/rules/M11-0-1/MemberDataInNonPodClassTypesNotPrivate.ql
@@ -17,7 +17,7 @@ import cpp
 import codingstandards.cpp.autosar
 
 class NonPODType extends Class {
-  NonPODType() { not this.isPOD() }
+  NonPODType() { not this.isPod() }
 }
 
 from NonPODType p, Field f

--- a/cpp/common/src/codingstandards/cpp/TrivialType.qll
+++ b/cpp/common/src/codingstandards/cpp/TrivialType.qll
@@ -284,7 +284,7 @@ predicate isTrivialType(Type t) {
 /** A POD type as defined by [basic.types]/9. */
 class PODType extends Type {
   PODType() {
-    this.(Class).isPOD()
+    this.(Class).isPod()
     or
     isScalarType(this)
     or


### PR DESCRIPTION
## Description

This PR targets the `next` branch.

I want to rename a bunch of acronyms to use camelCase/PascalCase to follow our own style guide for QL.  
(See this draft PR: https://github.com/github/codeql/pull/10153).   

When I do that 4 tests in this repo start to fail because of deprecation warnings because if the `idPOD()` predicate. 
I'll let them fail for now, and after I've merged the semmle-code PR I'll fix the deprecation warnings. 

## Change request type
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)

## Rules with added or modified queries

 - [x] No rules added

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed