### PR TITLE
Replace `NULLMacro` by `NullMacro`

### DIFF
--- a/c/common/src/codingstandards/c/Pointers.qll
+++ b/c/common/src/codingstandards/c/Pointers.qll
@@ -9,7 +9,7 @@ import codingstandards.cpp.Type
  * A null pointer constant, which is either in the form `NULL` or `(void *)0`.
  */
 predicate isNullPointerConstant(Expr e) {
-  e.findRootCause() instanceof NULLMacro
+  e.findRootCause() instanceof NullMacro
   or
   exists(CStyleCast c |
     not c.isImplicit() and

--- a/cpp/common/src/codingstandards/cpp/enhancements/MacroEnhacements.qll
+++ b/cpp/common/src/codingstandards/cpp/enhancements/MacroEnhacements.qll
@@ -29,7 +29,7 @@ module MacroEnhancements {
   /** A use of the NULL macro. */
   class NULL extends StandardLibrary::Literal {
     NULL() {
-      exists(StandardLibrary::NULLMacro nm | this = nm.getAnInvocation().getAnExpandedElement())
+      exists(StandardLibrary::NullMacro nm | this = nm.getAnInvocation().getAnExpandedElement())
     }
   }
 }


### PR DESCRIPTION
## Description

This PR targets the `next` branch.

`NULLMacro` is deprecated from CodeQL 2.11.0 onwards. `NullMacro` is its direct replacement, use that.

The unit tests here are expected to fail, because an earlier version of CodeQL is targeted.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)