### PR TITLE
Declarations3: fix RULE-5-5

### DIFF
--- a/c/common/src/codingstandards/c/Identifiers.qll
+++ b/c/common/src/codingstandards/c/Identifiers.qll
@@ -12,5 +12,8 @@ class InterestingIdentifiers extends Declaration {
     exists(this.getADeclarationLocation())
   }
 
-  string getSignificantName() { result = this.getName().prefix(31) }
+  //this definition of significant relies on the number of significant characters for a macro name (C99)
+  //this is used on macro name comparisons only
+  //not necessarily against other types of identifiers
+  string getSignificantNameComparedToMacro() { result = this.getName().prefix(63) }
 }

--- a/c/misra/src/rules/RULE-5-5/IdentifiersNotDistinctFromMacroNames.ql
+++ b/c/misra/src/rules/RULE-5-5/IdentifiersNotDistinctFromMacroNames.ql
@@ -22,10 +22,12 @@ where
   not isExcluded(i, Declarations3Package::identifiersNotDistinctFromMacroNamesQuery()) and
   mName = iName and
   (
-    //C99 states the first 31 characters of external identifiers are significant
-    //C90 states the first 6 characters of external identifiers are significant and case is not required to be significant
+    //C99 states the first 63 characters of macro identifiers are significant
+    //C90 states the first 31 characters of macro identifiers are significant
     //C90 is not currently considered by this rule
-    if m.getName().length() > 31 then mName = m.getName().prefix(31) else mName = m.getName()
+    if m.getName().length() > 63 then mName = m.getName().prefix(63) else mName = m.getName()
   ) and
-  if i.getName().length() > 31 then iName = i.getSignificantName() else iName = i.getName()
+  if i.getName().length() > 63
+  then iName = i.getSignificantNameComparedToMacro()
+  else iName = i.getName()
 select m, "Macro name is nonunique compared to $@.", i, i.getName()

--- a/c/misra/test/rules/RULE-5-5/IdentifiersNotDistinctFromMacroNames.expected
+++ b/c/misra/test/rules/RULE-5-5/IdentifiersNotDistinctFromMacroNames.expected
@@ -1,2 +1,2 @@
 | test.c:1:1:1:23 | #define Sum(x,y) x + y | Macro name is nonunique compared to $@. | test.c:4:5:4:7 | Sum | Sum |
-| test.c:6:1:6:42 | #define iltiqzxgfqsgigwfuyntzghvzltueeaZ ; | Macro name is nonunique compared to $@. | test.c:7:12:7:43 | iltiqzxgfqsgigwfuyntzghvzltueeaQ | iltiqzxgfqsgigwfuyntzghvzltueeaQ |
+| test.c:6:1:6:72 | #define iltiqzxgfqsgigwfuyntzghvzltueatcxqnqofnnvjyszmcsylyohvqaosjbqyyA | Macro name is nonunique compared to $@. | test.c:11:5:11:68 | iltiqzxgfqsgigwfuyntzghvzltueatcxqnqofnnvjyszmcsylyohvqaosjbqyyB | iltiqzxgfqsgigwfuyntzghvzltueatcxqnqofnnvjyszmcsylyohvqaosjbqyyB |

--- a/c/misra/test/rules/RULE-5-5/test.c
+++ b/c/misra/test/rules/RULE-5-5/test.c
@@ -3,5 +3,12 @@
 
 int Sum;
 
-#define iltiqzxgfqsgigwfuyntzghvzltueeaZ ;   // NON_COMPLIANT - length 32
-static int iltiqzxgfqsgigwfuyntzghvzltueeaQ; // NON_COMPLIANT - length 32
+#define iltiqzxgfqsgigwfuyntzghvzltueatcxqnqofnnvjyszmcsylyohvqaosjbqyyA // NON_COMPLIANT
+                                                                         // -
+                                                                         // length
+                                                                         // 64
+static int
+    iltiqzxgfqsgigwfuyntzghvzltueatcxqnqofnnvjyszmcsylyohvqaosjbqyyB; // NON_COMPLIANT
+                                                                      // -
+                                                                      // length
+                                                                      // 64


### PR DESCRIPTION
## Description

fix RULE-5-5, (for C99 defn distinct macro name, was previously using C90 - in scenario where distinct defn was required to be chosen)
no change note as Decl3 not yet in release

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - RULE-5-5

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)