### PR TITLE
Tests for Language2

### DIFF
--- a/c/misra/test/rules/RULE-1-4/test.c
+++ b/c/misra/test/rules/RULE-1-4/test.c
@@ -1,0 +1,26 @@
+#include <stdalign.h>    //NON_COMPLIANT
+#include <stdatomic.h>   //NON_COMPLIANT
+#include <stdnoreturn.h> //NON_COMPLIANT
+#include <threads.h>     //NON_COMPLIANT
+
+#define MACRO(x) _Generic((x), int : 0, long : 1) // NON_COMPLIANT
+#define __STDC_WANT_LIB_EXT1__ 0                  // COMPLIANT
+
+_Noreturn void f0(); // NON_COMPLIANT
+
+typedef int new_type;                     // COMPLIANT
+typedef _Atomic new_type atomic_new_type; // NON_COMPLIANT
+
+void f(int p) {
+  int i0 = _Generic(p, int : 0, long : 1); // NON_COMPLIANT
+
+  _Atomic int i; // NON_COMPLIANT
+
+  _Alignas(4) int i1;    // NON_COMPLIANT
+  alignas(4) int i2;     // NON_COMPLIANT
+  int a = _Alignof(int); // NON_COMPLIANT
+  int a1 = alignof(int); // NON_COMPLIANT
+
+  static thread_local int i3;  // NON_COMPLIANT
+  static _Thread_local int i4; // NON_COMPLIANT
+}

--- a/c/misra/test/rules/RULE-1-4/test1.c
+++ b/c/misra/test/rules/RULE-1-4/test1.c
@@ -1,0 +1,1 @@
+#define __STDC_WANT_LIB_EXT1__ 1 // NON_COMPLIANT

--- a/rules.csv
+++ b/rules.csv
@@ -14,7 +14,7 @@ cpp,AUTOSAR,A1-1-2,Yes,Required,Non-Automated,Implementation / Toolchain,A warni
 cpp,AUTOSAR,A1-1-3,Yes,Required,Non-Automated,Toolchain,An optimization option that disregards strict standard compliance shall not be turned on in the chosen compiler.,,Toolchain,Easy,Note: this is currently only possible for compilations that do not use response files.
 cpp,AUTOSAR,A1-2-1,No,Required,Non-Automated,Toolchain,"When using a compiler toolchain (including preprocessor, compiler itself, linker, C++ standard libraries) in safety-related software, the tool confidence level (TCL) shall be determined. In case of TCL2 or TCL3, the compiler shall undergo a 'Qualification of a software tool', as per ISO 26262-8.11.4.6 [6].",,,,Allocated target not covered by CodeQL
 cpp,AUTOSAR,A1-4-1,No,Required,Non-Automated,Implementation / Verification,Code metrics and their valid boundaries shall be defined and code shall comply with defined boundaries of code metrics.,,,,Allocated target not covered by CodeQL
-cpp,AUTOSAR,A1-4-3,No,Advisory,Automated,Implementation,All code should compile free of compiler warnings.,,,,"This should be checked via the compiler output, rather than CodeQL, which adds unecessary steps."
+cpp,AUTOSAR,A1-4-3,No,Advisory,Automated,Implementation,All code should compile free of compiler warnings.,,,,"This should be checked via the compiler output, rather than CodeQL, which adds unnecessary steps."
 cpp,AUTOSAR,A10-0-1,Yes,Required,Non-Automated,Design,Public inheritance shall be used to implement 'is-a' relationship.,,Inheritance,Audit,Report a list of Inheritance relationships.
 cpp,AUTOSAR,A10-0-2,Yes,Required,Non-Automated,Design,Membership or non-public inheritance shall be used to implement 'has-a' relationship.,,Inheritance,Audit,Report a list of membership relationships.
 cpp,AUTOSAR,A10-1-1,Yes,Required,Automated,Implementation,Class shall not be derived from more than one base class which is not an interface class.,,Inheritance,Easy,
@@ -600,7 +600,7 @@ c,CERT-C,STR37-C,Yes,Rule,,,Arguments to character-handling functions must be re
 c,CERT-C,STR38-C,Yes,Rule,,,Do not confuse narrow and wide character strings and functions,,Strings3,Medium,
 c,CERT-C,WIN30-C,OutOfScope,Rule,,,Properly pair allocation and deallocation functions,DCL54-CPP,,Easy,
 c,MISRA-C-2012,RULE-1-1,No,Required,,,Any implementation-defined behaviour on which the output of the program depends shall be documented and understood,,,,
-c,MISRA-C-2012,RULE-2-1,Yes,Required,,,All source files shall compile without any compilation errors,A1-4-3,Language,Medium,
+c,MISRA-C-2012,DIR-2-1,No,Required,,,All source files shall compile without any compilation errors,A1-4-3,Language,Medium,"This should be checked via the compiler output, rather than CodeQL, which adds unnecessary steps."
 c,MISRA-C-2012,RULE-3-1,No,Required,,,All code shall be traceable to documented requirements,,,,
 c,MISRA-C-2012,RULE-4-1,No,Required,,,Run-time failures shall be minimized,,,,
 c,MISRA-C-2012,RULE-4-2,Yes,Advisory,,,All usage of assembly language should be documented,M7-4-1,Language,Import,

--- a/rules.csv
+++ b/rules.csv
@@ -619,7 +619,7 @@ c,MISRA-C-2012,RULE-4-14,Yes,Required,,,The validity of values received from ext
 c,MISRA-C-2012,RULE-1-1,Yes,Required,,,"The program shall contain no violations of the standard C syntax and constraints, and shall not exceed the implementation�s translation limits",,Language,Easy,
 c,MISRA-C-2012,RULE-1-2,Yes,Advisory,,,Language extensions should not be used,,Language,Easy,
 c,MISRA-C-2012,RULE-1-3,Yes,Required,,,There shall be no occurrence of undefined or critical unspecified behaviour,,Language,Hard,
-c,MISRA-C-2012,RULE-1-4,Yes,Required,,,Emergent language features shall not be used,,Language,Medium,
+c,MISRA-C-2012,RULE-1-4,Yes,Required,,,Emergent language features shall not be used,,Language2,Medium,
 c,MISRA-C-2012,RULE-2-1,Yes,Required,,,A project shall not contain unreachable code,M0-1-1,DeadCode,Import,
 c,MISRA-C-2012,RULE-2-2,Yes,Required,,,There shall be no dead code,M0-1-9,DeadCode,Import,
 c,MISRA-C-2012,RULE-2-3,Yes,Advisory,,,A project should not contain unused type declarations,A0-1-6,DeadCode,Import,


### PR DESCRIPTION
## Description

tests for package Language 2

I think RULE-1-1 is compiler covered, if we are assuming/currently supporting one compiler - it seems its more about edge cases from other compilers. also no concrete `NON_COMPLIANT` examples are given in the rule description.

I also think DIR-2-1 is compiler covered, both because it seems to be an import of A1-4-3 (which is compiler covered) but also because the compiler does seem like the best place to report compiler errors

The DIR-4-2 test will be the exact same as M7-4-1 test , checked and I agree its a plain import and the test for M7-4-1 doesnt have anything c++ specific. I forget what we do when we want to share the test file, rather than copy the content?

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [x] Queries have been added for the following rules:
     - RULE-1-4
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)