### PR TITLE
Tests for DeadCode1

### DIFF
--- a/c/misra/test/rules/RULE-2-1/test.c
+++ b/c/misra/test/rules/RULE-2-1/test.c
@@ -1,0 +1,44 @@
+void test_switch(int p1) {
+  int l1 = 0;
+  switch (p1) {
+    l1 = p1; // NON_COMPLIANT[FALSE_NEGATIVE]
+  case 1:
+    break;
+  default:
+    break;
+  }
+}
+
+int test_after_return() {
+  return 0;
+  int l1 = 0; // NON_COMPLIANT - function has returned by this point
+}
+
+int test_constant_condition() {
+  if (0) { // NON_COMPLIANT
+    return 1;
+  } else { // COMPLIANT
+    return 2;
+  }
+}
+
+int test_for_loop() {
+  for (int i = 0; i < 10; i++) { // COMPLIANT[FALSE_POSITIVE] - not sure why i
+                                 // gets reported by M0-1-1
+    if (0) {                     // NON_COMPLIANT
+      return 1;
+    } else { // COMPLIANT
+      return 2;
+    }
+  }
+  return 1; // NON_COMPLIANT[FALSE_NEGATIVE] but a compiler warning is emitted
+            // if omitted so maybe not?
+}
+
+int test_while_loop() {
+  int i;
+  while (0) { // NON_COMPLIANT
+    i++;
+  }
+  return i;
+}

--- a/rules.csv
+++ b/rules.csv
@@ -620,7 +620,7 @@ c,MISRA-C-2012,RULE-1-1,Yes,Required,,,"The program shall contain no violations 
 c,MISRA-C-2012,RULE-1-2,Yes,Advisory,,,Language extensions should not be used,,Language,Easy,
 c,MISRA-C-2012,RULE-1-3,Yes,Required,,,There shall be no occurrence of undefined or critical unspecified behaviour,,Language,Hard,
 c,MISRA-C-2012,RULE-1-4,Yes,Required,,,Emergent language features shall not be used,,Language,Medium,
-c,MISRA-C-2012,RULE-2-1,Yes,Required,,,A project shall not contain unreachable code,M0-1-1,DeadCode,Import,
+c,MISRA-C-2012,RULE-2-1,Yes,Required,,,A project shall not contain unreachable code,M0-1-1,DeadCode1,Import,
 c,MISRA-C-2012,RULE-2-2,Yes,Required,,,There shall be no dead code,M0-1-9,DeadCode,Import,
 c,MISRA-C-2012,RULE-2-3,Yes,Advisory,,,A project should not contain unused type declarations,A0-1-6,DeadCode,Import,
 c,MISRA-C-2012,RULE-2-4,Yes,Advisory,,,A project should not contain unused tag declarations,,DeadCode,Easy,


### PR DESCRIPTION
## Description


## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [x] Queries have been added for the following rules:
     - RULE-2-1
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)