### PR TITLE
M0-1-4: Exclude constexpr variables whose constant is used in a template argument

### DIFF
--- a/change_notes/2022-11-02-m0-1-4-single-use-with-templates.md
+++ b/change_notes/2022-11-02-m0-1-4-single-use-with-templates.md
@@ -1,0 +1,2 @@
+ - `M0-1-4` - `SingleUseMemberPODVariable.ql`
+   - Reduce false positives by excluding any constexpr variable whose constant value is used as an argument to a template.

--- a/cpp/autosar/test/rules/M0-1-4/SingleUseMemberPODVariable.expected
+++ b/cpp/autosar/test/rules/M0-1-4/SingleUseMemberPODVariable.expected
@@ -1,3 +1,4 @@
+| test.cpp:36:24:36:29 | unused | Member POD variable unused in C1 is only $@. | test.cpp:36:31:36:31 | initializer for unused | used once |
 | test_global_or_namespace.cpp:16:7:16:7 | x | Member POD variable x in GA is only $@. | test_global_or_namespace.cpp:38:6:38:6 | x | used once |
 | test_global_or_namespace.cpp:54:7:54:7 | x | Member POD variable x in N1A is only $@. | test_global_or_namespace.cpp:76:6:76:6 | x | used once |
 | test_member.cpp:5:7:5:8 | m2 | Member POD variable m2 in A is only $@. | test_member.cpp:9:21:9:25 | constructor init of field m2 | used once |

--- a/cpp/autosar/test/rules/M0-1-4/test.cpp
+++ b/cpp/autosar/test/rules/M0-1-4/test.cpp
@@ -36,6 +36,6 @@ class C1 {
   static constexpr int unused{1}; // NON_COMPLIANT
   static constexpr int used{2};   // COMPLIANT
   int test_use() { return used; }
-  static constexpr int size{3};               // COMPLIANT[FALSE_POSITIVE]
+  static constexpr int size{3};               // COMPLIANT
   std::array<bool, size> array{false, false}; // size is used here
 };

--- a/cpp/autosar/test/rules/M0-1-4/test.cpp
+++ b/cpp/autosar/test/rules/M0-1-4/test.cpp
@@ -1,5 +1,5 @@
 /** Test cases for `SingleUseLocalPODVariable.ql` */
-
+#include <array>
 class A {};
 
 class B {
@@ -31,3 +31,11 @@ void test_templates() {
   f1<C>(); // Does not trigger a NON_COMPLIANT case in f1(), because C is not a
            // POD type
 }
+
+class C1 {
+  static constexpr int unused{1}; // NON_COMPLIANT
+  static constexpr int used{2};   // COMPLIANT
+  int test_use() { return used; }
+  static constexpr int size{3};               // COMPLIANT[FALSE_POSITIVE]
+  std::array<bool, size> array{false, false}; // size is used here
+};


### PR DESCRIPTION
## Description

Fixes #6.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)