### PR TITLE
Reformat test files with clang-format v14

### DIFF
--- a/cpp/autosar/test/rules/A5-1-9/test.cpp
+++ b/cpp/autosar/test/rules/A5-1-9/test.cpp
@@ -86,16 +86,16 @@ void test_noncompliant() {
 #include <string>
 class Test_issue468 {
 public:
-  template <typename... As> static void LogInfo(const As &... rest) {
+  template <typename... As> static void LogInfo(const As &...rest) {
     [](const std::string &s) -> void { LogInfo(s); }; // COMPLIANT
   }
-  template <typename... As> static void LogWarn(const As &... rest) {
+  template <typename... As> static void LogWarn(const As &...rest) {
     [](const std::string &s) -> void { LogWarn(s); }; // COMPLIANT
   }
-  template <typename... As> static void LogError(const As &... rest) {
+  template <typename... As> static void LogError(const As &...rest) {
     [](const std::string &s) -> void { LogError(s); }; // NON_COMPLIANT
   }
-  template <typename... As> static void LogFatal(const As &... rest) {
+  template <typename... As> static void LogFatal(const As &...rest) {
     [](const std::string &s) -> void { LogError(s); }; // NON_COMPLIANT
   }
   void instantiate() {

--- a/cpp/autosar/test/rules/A5-2-2/test.cpp
+++ b/cpp/autosar/test/rules/A5-2-2/test.cpp
@@ -45,12 +45,12 @@ void test_cpp_style_cast() {
 class A5_2_2a {
 public:
   template <typename... As>
-  static void Foo(const std::string &name, As &&... rest) {
+  static void Foo(const std::string &name, As &&...rest) {
     Fun(Log(
         std::forward<As>(rest)...)); // COMPLIANT - reported as a false positive
   }
 
-  template <typename... As> static std::string Log(As &&... tail) {
+  template <typename... As> static std::string Log(As &&...tail) {
     return std::string();
   }
 

--- a/cpp/autosar/test/rules/A7-2-2/EnumerationUnderlyingBaseTypeNotExplicitlyDefined.expected
+++ b/cpp/autosar/test/rules/A7-2-2/EnumerationUnderlyingBaseTypeNotExplicitlyDefined.expected
@@ -1,2 +1,2 @@
 | test.cpp:1:6:1:6 | C | Base type of enumeration is not explicitly specified. |
-| test.cpp:3:12:3:12 | A | Base type of enumeration is not explicitly specified. |
+| test.cpp:5:12:5:12 | A | Base type of enumeration is not explicitly specified. |

--- a/cpp/autosar/test/rules/A7-2-2/test.cpp
+++ b/cpp/autosar/test/rules/A7-2-2/test.cpp
@@ -1,8 +1,16 @@
 enum C // NON_COMPLIANT
-{ c1 };
+{
+  c1
+};
 enum class A // NON_COMPLIANT
-{ a1 };
+{
+  a1
+};
 enum class B : int // COMPLIANT
-{ b1 };
+{
+  b1
+};
 enum D : int // COMPLIANT
-{ d1 };
+{
+  d1
+};

--- a/cpp/autosar/test/rules/A7-2-3/EnumerationsNotDeclaredAsScopedEnumClasses.expected
+++ b/cpp/autosar/test/rules/A7-2-3/EnumerationsNotDeclaredAsScopedEnumClasses.expected
@@ -1,2 +1,2 @@
 | test.cpp:1:6:1:6 | C | Enum C is not a scoped enum. |
-| test.cpp:11:6:11:6 | D | Enum D is not a scoped enum. |
+| test.cpp:21:6:21:6 | D | Enum D is not a scoped enum. |

--- a/cpp/autosar/test/rules/A7-2-3/test.cpp
+++ b/cpp/autosar/test/rules/A7-2-3/test.cpp
@@ -1,12 +1,24 @@
 enum C // NON_COMPLIANT
-{ c1 };
+{
+  c1
+};
 enum class A // COMPLIANT - Violates a different rule (A7-2-2)
-{ a1 };
+{
+  a1
+};
 enum struct A1 // COMPLIANT - Violates a different rule (A7-2-2)
-{ a12 };
+{
+  a12
+};
 enum class B : int // COMPLIANT
-{ b1 };
+{
+  b1
+};
 enum struct B1 : int // COMPLIANT
-{ b12 };
+{
+  b12
+};
 enum D : int // NON_COMPLIANT
-{ d1 };
+{
+  d1
+};

--- a/cpp/autosar/test/rules/A7-2-4/NoneFirstOrAllEnumeratorsNotInitialized.expected
+++ b/cpp/autosar/test/rules/A7-2-4/NoneFirstOrAllEnumeratorsNotInitialized.expected
@@ -1,4 +1,4 @@
-| test.cpp:9:12:9:13 | A2 | Neither none, the first, or all enumerated constants are initialized in this enumeration. |
-| test.cpp:33:14:33:15 | B3 | Neither none, the first, or all enumerated constants are initialized in this enumeration. |
-| test.cpp:45:6:45:6 | D | Neither none, the first, or all enumerated constants are initialized in this enumeration. |
-| test.cpp:53:6:53:7 | E1 | Neither none, the first, or all enumerated constants are initialized in this enumeration. |
+| test.cpp:13:12:13:13 | A2 | Neither none, the first, or all enumerated constants are initialized in this enumeration. |
+| test.cpp:47:14:47:15 | B3 | Neither none, the first, or all enumerated constants are initialized in this enumeration. |
+| test.cpp:63:6:63:6 | D | Neither none, the first, or all enumerated constants are initialized in this enumeration. |
+| test.cpp:75:6:75:7 | E1 | Neither none, the first, or all enumerated constants are initialized in this enumeration. |

--- a/cpp/autosar/test/rules/A7-2-4/test.cpp
+++ b/cpp/autosar/test/rules/A7-2-4/test.cpp
@@ -1,55 +1,79 @@
 enum class A // COMPLIANT
-{ a1 };
+{
+  a1
+};
 
 enum class A1 // COMPLIANT
-{ a1 = 0,
+{
+  a1 = 0,
   a2 = 1,
-  a3 = 2 };
+  a3 = 2
+};
 
 enum class A2 // NON_COMPLIANT
-{ a1,
+{
+  a1,
   a2 = 0,
-  a3 };
+  a3
+};
 
 enum class A3 // COMPLIANT
-{ a1 = 0,
+{
+  a1 = 0,
   a2,
-  a3 };
+  a3
+};
 
 enum class B : int // COMPLIANT
-{ b1 };
+{
+  b1
+};
 
 enum class B1 : int // COMPLIANT
-{ b1,
+{
+  b1,
   b2,
-  b3 };
+  b3
+};
 
 enum class B2 : int // COMPLIANT
-{ b1 = 0,
+{
+  b1 = 0,
   b2,
-  b3 };
+  b3
+};
 
 int f() {
   enum class B3 : int // NON_COMPLIANT
-  { b1,
+  {
+    b1,
     b2 = 0,
-    b3 = 0 };
+    b3 = 0
+  };
 
   return 0;
 }
 
 enum C // COMPLIANT
-{ c1,
-  c2 };
+{
+  c1,
+  c2
+};
 
 enum D // NON_COMPLIANT
-{ d1,
-  d2 = 0 };
+{
+  d1,
+  d2 = 0
+};
 
 enum E : int // COMPLIANT
-{ e1,
-  e2 };
+{
+  e1,
+  e2
+};
 
 enum E1 : int // NON_COMPLIANT
-{ e11,
-  e22 = 0 };
+{
+  e11,
+  e22 = 0
+};

--- a/cpp/autosar/test/rules/A8-4-5/test.cpp
+++ b/cpp/autosar/test/rules/A8-4-5/test.cpp
@@ -48,7 +48,7 @@ public:
 
 // template type
 template <typename T, typename... X>
-T test_forward(X &&... f) {        // forward parameter
+T test_forward(X &&...f) {         // forward parameter
   return T{std::forward<X>(f)...}; // COMPLIANT
 }
 

--- a/cpp/autosar/test/rules/A8-4-6/test.cpp
+++ b/cpp/autosar/test/rules/A8-4-6/test.cpp
@@ -10,8 +10,8 @@ public:
   explicit TestClass2(const std::vector<int> &v);
 };
 // template type
-template <typename T, typename... X> T make(X &&... x) { // forward param
-  return T{std::forward<X>(x)...};                       // COMPLIANT
+template <typename T, typename... X> T make(X &&...x) { // forward param
+  return T{std::forward<X>(x)...};                      // COMPLIANT
 }
 // template type
 template <typename T, typename U> T make2(U &&x) { // forward param

--- a/cpp/autosar/test/rules/M6-4-5/test.cpp
+++ b/cpp/autosar/test/rules/M6-4-5/test.cpp
@@ -40,6 +40,6 @@ void test_switchclause_termination2(int expression) {
       k = i;
     }
   default: // NON_COMPLIANT
-           ;
+      ;
   }
 }

--- a/cpp/autosar/test/rules/M8-4-4/test.cpp
+++ b/cpp/autosar/test/rules/M8-4-4/test.cpp
@@ -25,7 +25,7 @@ void test_function_identifier_f2() {
 
 template <typename F> static void Log(const F kF) {}
 
-template <typename... As> static void LogFatal(const As &... rest) {
+template <typename... As> static void LogFatal(const As &...rest) {
   Log([](const std::string &s) -> void {}); // COMPLIANT
 }
 


### PR DESCRIPTION
## Description

Reformat test files using clang-format v14

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed