### PR TITLE
Pointers3: Add test cases

### DIFF
--- a/c/cert/test/rules/EXP32-C/test.c
+++ b/c/cert/test/rules/EXP32-C/test.c
@@ -1,0 +1,38 @@
+volatile int *volatile_f();
+
+void test_cast_away_volatile() {
+  volatile int *l1 = volatile_f(); // COMPLIANT
+  int *l2 = (int *)l1;             // NON_COMPLIANT
+  int *l3 = (int *)volatile_f();   // NON_COMPLIANT
+  *l2; // Volatile object is accessed through a non-volatile pointer
+}
+
+void test_volatile_lost_by_assignment() {
+  static volatile int val = 0;
+  static int *non_compliant_pointer;
+  static volatile int **compliant_pointer_to_pointer;
+  compliant_pointer_to_pointer = &non_compliant_pointer; // NON_COMPLIANT
+  *compliant_pointer_to_pointer = &val;
+  *non_compliant_pointer; // Volatile object is accessed through a non-volatile
+                          // pointer
+}
+
+void test_volatile_lost_by_assignment_and_cast() {
+  static volatile int val = 0;
+  static int *non_compliant_pointer;
+  static volatile int **compliant_pointer_to_pointer;
+  compliant_pointer_to_pointer =
+      (int **)&non_compliant_pointer; // NON_COMPLIANT
+  *compliant_pointer_to_pointer = &val;
+  *non_compliant_pointer; // Volatile object is accessed through a non-volatile
+                          // pointer
+}
+
+void test_volatile_not_lost_by_assignment_and_cast() {
+  static volatile int val = 0;
+  static volatile int *compliant_pointer;
+  static volatile int **compliant_pointer_to_pointer;
+  compliant_pointer_to_pointer = &compliant_pointer; // COMPLIANT
+  *compliant_pointer_to_pointer = &val;
+  *compliant_pointer; // Volatile object is accessed through a volatile pointer
+}

--- a/c/cert/test/rules/EXP36-C/test.c
+++ b/c/cert/test/rules/EXP36-C/test.c
@@ -1,0 +1,156 @@
+#include <stdalign.h>
+#include <stddef.h>
+
+void test_direct_cast_alignment() {
+  char c1 = 1;   // assuming 1-byte alignment
+  (char *)&c1;   // COMPLIANT
+  (short *)&c1;  // NON_COMPLIANT
+  (int *)&c1;    // NON_COMPLIANT
+  (long *)&c1;   // NON_COMPLIANT
+  (float *)&c1;  // NON_COMPLIANT
+  (double *)&c1; // NON_COMPLIANT
+
+  short s1 = 1;  // assuming 2-byte alignment
+  (char *)&s1;   // COMPLIANT
+  (short *)&s1;  // COMPLIANT
+  (int *)&s1;    // NON_COMPLIANT
+  (long *)&s1;   // NON_COMPLIANT
+  (float *)&c1;  // NON_COMPLIANT
+  (double *)&c1; // NON_COMPLIANT
+
+  int i1 = 1;    // assuming 4-byte alignment
+  (char *)&i1;   // COMPLIANT
+  (short *)&i1;  // COMPLIANT
+  (int *)&i1;    // COMPLIANT
+  (float *)&c1;  // COMPLIANT
+  (long *)&i1;   // NON_COMPLIANT - assuming 8 byte alignment for longs
+  (double *)&c1; // NON_COMPLIANT
+
+  float f1 = 1;  // assuming 4-byte alignment
+  (char *)&f1;   // COMPLIANT
+  (short *)&f1;  // COMPLIANT
+  (int *)&f1;    // COMPLIANT
+  (float *)&f1;  // COMPLIANT
+  (long *)&f1;   // NON_COMPLIANT
+  (double *)&f1; // NON_COMPLIANT
+
+  long l1 = 1;   // assuming 8-byte alignment
+  (char *)&l1;   // COMPLIANT
+  (short *)&l1;  // COMPLIANT
+  (int *)&l1;    // COMPLIANT
+  (float *)&c1;  // COMPLIANT
+  (long *)&l1;   // COMPLIANT
+  (double *)&c1; // COMPLIANT
+
+  double d1 = 1; // assuming 8-byte alignment
+  (char *)&d1;   // COMPLIANT
+  (short *)&d1;  // COMPLIANT
+  (int *)&d1;    // COMPLIANT
+  (float *)&d1;  // COMPLIANT
+  (long *)&d1;   // COMPLIANT
+  (double *)&d1; // COMPLIANT
+}
+
+void custom_aligned_types() {
+  alignas(int) char c1 = 1;
+  (char *)&c1;   // COMPLIANT
+  (short *)&c1;  // COMPLIANT
+  (int *)&c1;    // COMPLIANT
+  (float *)&c1;  // COMPLIANT
+  (long *)&c1;   // NON_COMPLIANT
+  (double *)&c1; // NON_COMPLIANT
+
+  alignas(32) char c2 = 1;
+  (char *)&c2;   // COMPLIANT
+  (short *)&c2;  // COMPLIANT
+  (int *)&c2;    // COMPLIANT
+  (float *)&c2;  // COMPLIANT
+  (long *)&c2;   // NON_COMPLIANT
+  (double *)&c2; // NON_COMPLIANT
+}
+
+void test_via_void_direct() {
+  char c1 = 1;
+  void *v1 = &c1;
+  (char *)v1;   // COMPLIANT
+  (short *)v1;  // NON_COMPLIANT
+  (int *)v1;    // NON_COMPLIANT
+  (float *)v1;  // NON_COMPLIANT
+  (long *)v1;   // NON_COMPLIANT
+  (double *)v1; // NON_COMPLIANT
+
+  short s1 = 1;
+  void *v2 = &s1;
+  (char *)v2;   // COMPLIANT
+  (short *)v2;  // COMPLIANT
+  (int *)v2;    // NON_COMPLIANT
+  (float *)v2;  // NON_COMPLIANT
+  (long *)v2;   // NON_COMPLIANT
+  (double *)v2; // NON_COMPLIANT
+
+  int i1 = 1;
+  void *v3 = &i1;
+  (char *)v3;   // COMPLIANT
+  (short *)v3;  // COMPLIANT
+  (int *)v3;    // COMPLIAN
+  (float *)v3;  // COMPLIANT
+  (long *)v3;   // NON_COMPLIANT - assuming 8 byte alignment for longs
+  (double *)v3; // NON_COMPLIANT - but only on x64
+
+  float f1 = 1;
+  void *v4 = &f1;
+  (char *)v4;   // COMPLIANT
+  (short *)v4;  // COMPLIANT
+  (int *)v4;    // COMPLIANT
+  (float *)v4;  // COMPLIANT
+  (long *)v4;   // NON_COMPLIANT - assuming 8 byte alignment for longs
+  (double *)v4; // NON_COMPLIANT
+
+  long l1 = 1;
+  void *v5 = &l1;
+  (char *)v5;   // COMPLIANT
+  (short *)v5;  // COMPLIANT
+  (int *)v5;    // COMPLIANT
+  (float *)v5;  // COMPLIANT
+  (long *)v5;   // COMPLIANT
+  (double *)v5; // COMPLIANT
+
+  double d1 = 1;
+  void *v6 = &d1;
+  (char *)v6;   // COMPLIANT
+  (short *)v6;  // COMPLIANT
+  (int *)v6;    // COMPLIANT
+  (float *)v6;  // COMPLIANT
+  (long *)v6;   // COMPLIANT
+  (double *)v6; // COMPLIANT
+}
+
+int *cast_away(void *v) {
+  return (int *)v; // compliance depends on context
+}
+
+void test_via_void_indirect() {
+  char c1 = 1;
+  cast_away((void *)c1); // NON_COMPLIANT
+
+  int i1 = 1;
+  cast_away((void *)i1); // COMPLIANT
+}
+
+struct S1 {
+  char c1;
+  unsigned char data[8];
+};
+
+struct S2 {
+  char c1;
+  alignas(size_t) unsigned char data[8];
+};
+
+void test_struct_alignment() {
+  S1 s1;
+  (size_t *)&s1.data; // NON_COMPLIANT
+
+  S2 s2;
+  (size_t *)&s2.data; // COMPLIANT
+}

--- a/c/cert/test/rules/EXP39-C/test.c
+++ b/c/cert/test/rules/EXP39-C/test.c
@@ -1,0 +1,81 @@
+void test_incompatible_arithmetic() {
+  float f = 0.0f;
+  int *p = (int *)&f; // NON_COMPLIANT - arithmetic types are not compatible
+                      // with each other
+  (*p)++;
+
+  short s[2];
+  (int *)&s; // NON_COMPLIANT
+
+  (short(*)[4]) & s; // NON_COMPLIANT - array of size 2 is not compatible with
+                     // array of size 4 (n1570 6.7.6.2 paragraph 7)
+  (short(*)[2]) & s; // COMPLIANT
+
+  // char may be signed or unsigned, and so is not compatible with either
+  char c1;
+  (signed char *)&c1;   // NON_COMPLIANT
+  (unsigned char *)&c1; // NON_COMPLIANT
+  (char *)&c1;          // NON_COMPLIANT
+
+  // int is defined as signed, so is compatible with all the signed versions
+  // (long, short etc. are similar)
+  int i1;
+  (signed int *)&i1;   // COMPLIANT
+  (int *)&i1;          // COMPLIANT
+  (signed *)&i1;       // COMPLIANT
+  (unsigned int *)&i1; // NON_COMPLIANT
+  (const int *)&i1;    // NON_COMPLIANT
+}
+
+struct {
+  int a;
+} * s1;
+struct {
+  int a;
+} * s2;
+struct S1 {
+  int a;
+} * s3;
+struct S1 *s4;
+
+// TODO test across files
+void test_incompatible_structs() {
+  // s1 and s2 do not have tags, and are therefore not compatible
+  s1 = s2; // NON_COMPLIANT
+  // s3 tag is inconsistent with s1 tag
+  s1 = s3; // NON_COMPLIANT
+  s3 = s1; // NON_COMPLIANT
+  // s4 tag is consistent with s3 tag
+  s3 = s4; // COMPLIANT
+  s4 = s3; // COMPLIANT
+}
+
+enum E1 { E1A, E1B };
+enum E2 { E2A, E2B };
+
+void test_enums() {
+  enum E1 e1 = E1A;
+  enum E2 e2 = e1; // COMPLIANT
+  // Enums are also compatible with one of `char`, a signed integer type or an
+  // unsigned integer type. It is implementation defined which is used, so
+  // choose an appropriate type below for this test
+  (int *)&e1; // COMPLIANT
+}
+
+int *void_cast(void *v) { return (int *)v; }
+
+void test_indirect_cast() {
+  float f1 = 0.0f;
+  void_cast(&f1); // NON_COMPLIANT
+  int i1 = 0;
+  void_cast(&i1); // COMPLIANT
+}
+
+signed f(int y) { return y; }
+int g(signed int x) { return x; }
+
+// 6.7.6.3 p15
+void test_compatible_functions() {
+  signed (*f1)(int) = &g;     // COMPLIANT
+  int (*g1)(signed int) = &f; // COMPLIANT
+}

--- a/c/cert/test/rules/EXP39-C/test.c
+++ b/c/cert/test/rules/EXP39-C/test.c
@@ -79,3 +79,21 @@ void test_compatible_functions() {
   signed (*f1)(int) = &g;     // COMPLIANT
   int (*g1)(signed int) = &f; // COMPLIANT
 }
+
+struct S2 {
+  int a;
+  int b;
+};
+
+struct S3 {
+  int a;
+  int b;
+};
+
+void test_realloc() {
+  struct S2 *s2 = (struct S2 *)malloc(sizeof(struct S2));
+  struct S3 *s3 = (struct S3 *)realloc(s2, sizeof(struct S3));
+  s3->a; // NON_COMPLIANT
+  memset(s3, 0, sizeof(struct S3));
+  s3->a; // COMPLIANT
+}

--- a/c/cert/test/rules/EXP43-C/test.c
+++ b/c/cert/test/rules/EXP43-C/test.c
@@ -1,0 +1,76 @@
+#include <stddef.h>
+#include <string.h>
+
+int *restrict g1;
+int *restrict g2;
+
+void test_global_local() {
+  int *restrict i1 = g1; // COMPLIANT
+  int *restrict i2 = g2; // COMPLIANT
+  int *restrict i3 = i2; // NON_COMPLIANT
+  g1 = g2;               // NON_COMPLIANT
+  i1 = i2;               // NON_COMPLIANT
+}
+
+void copy(int *restrict p1, int *restrict p2, size_t s) {
+  for (size_t i = 0; i < s; ++i) {
+    p2[i] = p1[i];
+  }
+}
+
+void test_restrict_params() {
+  int i1 = 1;
+  int i2 = 2;
+  copy(&i1, &i1, 1); // NON_COMPLIANT
+  copy(&i1, &i2, 1); // COMPLIANT
+
+  int x[10];
+  copy(x[0], x[1], 1); // COMPLIANT - non overlapping
+  copy(x[0], x[1], 2); // NON_COMPLIANT - overlapping
+}
+
+void test_strcpy() {
+  char s1[] = "my test string";
+  char s2[] = "my other string";
+  strcpy(&s1, &s1 + 3); // NON_COMPLIANT
+  strcpy(&s2, &s1);     // COMPLIANT
+}
+
+void test_strcpy_s() {
+  char s1[] = "my test string";
+  char s2[] = "my other string";
+  strcpy_s(&s1, &s1 + 3);         // NON_COMPLIANT
+  strcpy_s(&s2, sizeof(s2), &s1); // COMPLIANT
+}
+
+void test_memcpy() {
+  char s1[] = "my test string";
+  char s2[] = "my other string";
+  memcpy(&s1, &s1 + 3, 5); // NON_COMPLIANT
+  memcpy(&s2, &s1 + 3, 5); // COMPLIANT
+}
+
+void test_memcpy_s() {
+  char s1[] = "my test string";
+  char s2[] = "my other string";
+  memcpy_s(&s1, sizeof(s1), &s1 + 3, 5); // NON_COMPLIANT
+  memcpy_s(&s2, sizeof(s2), &s1 + 3, 5); // COMPLIANT
+}
+
+void test_memmove() {
+  char s1[] = "my test string";
+  char s2[] = "my other string";
+  memmove(&s1, &s1 + 3, 5); // COMPLIANT
+  memmove(&s2, &s1 + 3, 5); // COMPLIANT
+}
+
+void test_scanf() {
+  char s1[200] = "%10s";
+  scanf(&s2, &s2 + 4); // NON_COMPLIANT
+}
+
+// TODO also consider the following:
+// strncpy(), strncpy_s()
+// strcat(), 	strcat_s()
+// strncat(),	strncat_s()
+// strtok_s()


### PR DESCRIPTION
## Description

Adds test cases for the `Pointers3` package.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)