### PR TITLE
Fix formatting shared query ConstLikeReturnValue

### DIFF
--- a/c/common/test/rules/constlikereturnvalue/ConstLikeReturnValue.expected
+++ b/c/common/test/rules/constlikereturnvalue/ConstLikeReturnValue.expected
@@ -1,7 +1,7 @@
 problems
-| test.c:8:8:8:12 | c_str | The object returned by the function getenv should not be modified. | test.c:15:16:15:21 | call to getenv | call to getenv | test.c:8:8:8:12 | c_str | c_str |
-| test.c:64:5:64:9 | conv4 | The object returned by the function localeconv should not be modified. | test.c:61:11:61:20 | call to localeconv | call to localeconv | test.c:64:5:64:9 | conv4 | conv4 |
-| test.c:73:5:73:8 | conv | The object returned by the function localeconv should not be modified. | test.c:69:25:69:34 | call to localeconv | call to localeconv | test.c:73:5:73:8 | conv | conv |
+| test.c:8:8:8:12 | c_str | test.c:15:16:15:21 | call to getenv | test.c:8:8:8:12 | c_str | The object returned by the function getenv should not be modified. |
+| test.c:64:5:64:9 | conv4 | test.c:61:11:61:20 | call to localeconv | test.c:64:5:64:9 | conv4 | The object returned by the function localeconv should not be modified. |
+| test.c:73:5:73:8 | conv | test.c:69:25:69:34 | call to localeconv | test.c:73:5:73:8 | conv | The object returned by the function localeconv should not be modified. |
 edges
 | test.c:5:18:5:22 | c_str | test.c:8:8:8:12 | c_str |
 | test.c:15:16:15:21 | call to getenv | test.c:21:9:21:12 | env1 |

--- a/cpp/common/src/codingstandards/cpp/rules/constlikereturnvalue/ConstLikeReturnValue.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/constlikereturnvalue/ConstLikeReturnValue.qll
@@ -52,8 +52,7 @@ class DFConf extends DataFlow::Configuration {
 }
 
 query predicate problems(
-  Element e, string message, DataFlow::PathNode source, string sourcetext, DataFlow::PathNode sink,
-  string sinktext
+  Element e, DataFlow::PathNode source, DataFlow::PathNode sink, string message
 ) {
   not isExcluded(e, getQuery()) and
   // the modified object comes from a call to one of the ENV functions
@@ -61,7 +60,5 @@ query predicate problems(
   e = sink.getNode().asExpr() and
   message =
     "The object returned by the function " +
-      source.getNode().asExpr().(FunctionCall).getTarget().getName() + " should not be modified." and
-  sourcetext = source.toString() and
-  sinktext = sink.toString()
+      source.getNode().asExpr().(FunctionCall).getTarget().getName() + " should not be modified."
 }


### PR DESCRIPTION
## Description

currently in main this query is not able to run (and one other that relies on the same shared) because of formatting of the `problems` predicate, see trace:

```
codeql database analyze --threads=8 databases/commaai-openpilot-72d1744d830bc249d8761a1d843a98fb0ced49fe-cpp --format=sarifv2.1.0 --output=result.sarif  --rerun c/cert/src/rules/ENV30-C/DoNotModifyTheReturnValueOfCertainFunctions.ql
Running queries.
Interpreting results.

A fatal error occurred: Could not process query metadata for c/cert/src/rules/ENV30-C/DoNotModifyTheReturnValueOfCertainFunctions.ql.
Error was: Expected result pattern(s) are not present for path-problem query: Expected one of the patterns to start with [entity, entity, entity, string] columns. [INVALID_RESULT_PATTERNS]
```

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)