### PR TITLE
C++: Pull in the latest version of `TaintedPath.ql` from CodeQL

### DIFF
--- a/c/cert/src/rules/FIO32-C/DoNotPerformFileOperationsOnDevices.ql
+++ b/c/cert/src/rules/FIO32-C/DoNotPerformFileOperationsOnDevices.ql
@@ -12,6 +12,7 @@
  */
 
 import cpp
+import codingstandards.c.cert
 import semmle.code.cpp.security.FunctionWithWrappers
 import semmle.code.cpp.security.Security
 import semmle.code.cpp.ir.IR
@@ -126,6 +127,7 @@ from
   FileFunction fileFunction, Expr taintedArg, Expr taintSource, TaintedPathConfiguration cfg,
   DataFlow::PathNode sourceNode, DataFlow::PathNode sinkNode, string taintCause, string callChain
 where
+  not isExcluded(taintedArg, IO3Package::doNotPerformFileOperationsOnDevicesQuery()) and
   taintedArg = asSinkExpr(sinkNode.getNode()) and
   fileFunction.outermostWrapperFunctionCall(taintedArg, callChain) and
   cfg.hasFilteredFlowPath(sourceNode, sinkNode) and

--- a/c/cert/src/rules/FIO32-C/DoNotPerformFileOperationsOnDevices.ql
+++ b/c/cert/src/rules/FIO32-C/DoNotPerformFileOperationsOnDevices.ql
@@ -12,11 +12,11 @@
  */
 
 import cpp
-import codingstandards.c.cert
 import semmle.code.cpp.security.FunctionWithWrappers
 import semmle.code.cpp.security.Security
-import semmle.code.cpp.security.TaintTracking
-import TaintedWithPath
+import semmle.code.cpp.ir.IR
+import semmle.code.cpp.ir.dataflow.TaintTracking
+import DataFlow::PathGraph
 
 // Query TaintedPath.ql from the CodeQL standard library
 /**
@@ -45,20 +45,92 @@ class FileFunction extends FunctionWithWrappers {
   override predicate interestingArg(int arg) { arg = 0 }
 }
 
-class TaintedPathConfiguration extends TaintTrackingConfiguration {
-  override predicate isSink(Element tainted) {
-    exists(FileFunction fileFunction | fileFunction.outermostWrapperFunctionCall(tainted, _))
+Expr asSourceExpr(DataFlow::Node node) {
+  result = node.asConvertedExpr()
+  or
+  result = node.asDefiningArgument()
+}
+
+Expr asSinkExpr(DataFlow::Node node) {
+  result =
+    node.asOperand()
+        .(SideEffectOperand)
+        .getUse()
+        .(ReadSideEffectInstruction)
+        .getArgumentDef()
+        .getUnconvertedResultExpression()
+}
+
+/**
+ * Holds for a variable that has any kind of upper-bound check anywhere in the program.
+ * This is biased towards being inclusive and being a coarse overapproximation because
+ * there are a lot of valid ways of doing an upper bounds checks if we don't consider
+ * where it occurs, for example:
+ * ```cpp
+ *   if (x < 10) { sink(x); }
+ *
+ *   if (10 > y) { sink(y); }
+ *
+ *   if (z > 10) { z = 10; }
+ *   sink(z);
+ * ```
+ */
+predicate hasUpperBoundsCheck(Variable var) {
+  exists(RelationalOperation oper, VariableAccess access |
+    oper.getAnOperand() = access and
+    access.getTarget() = var and
+    // Comparing to 0 is not an upper bound check
+    not oper.getAnOperand().getValue() = "0"
+  )
+}
+
+class TaintedPathConfiguration extends TaintTracking::Configuration {
+  TaintedPathConfiguration() { this = "TaintedPathConfiguration" }
+
+  override predicate isSource(DataFlow::Node node) { isUserInput(asSourceExpr(node), _) }
+
+  override predicate isSink(DataFlow::Node node) {
+    exists(FileFunction fileFunction |
+      fileFunction.outermostWrapperFunctionCall(asSinkExpr(node), _)
+    )
+  }
+
+  override predicate isSanitizerIn(DataFlow::Node node) { this.isSource(node) }
+
+  override predicate isSanitizer(DataFlow::Node node) {
+    node.asExpr().(Call).getTarget().getUnspecifiedType() instanceof ArithmeticType
+    or
+    exists(LoadInstruction load, Variable checkedVar |
+      load = node.asInstruction() and
+      checkedVar = load.getSourceAddress().(VariableAddressInstruction).getAstVariable() and
+      hasUpperBoundsCheck(checkedVar)
+    )
+  }
+
+  predicate hasFilteredFlowPath(DataFlow::PathNode source, DataFlow::PathNode sink) {
+    this.hasFlowPath(source, sink) and
+    // The use of `isUserInput` in `isSink` in combination with `asSourceExpr` causes
+    // duplicate results. Filter these duplicates. The proper solution is to switch to
+    // using `LocalFlowSource` and `RemoteFlowSource`, but this currently only supports
+    // a subset of the cases supported by `isUserInput`.
+    not exists(DataFlow::PathNode source2 |
+      this.hasFlowPath(source2, sink) and
+      asSourceExpr(source.getNode()) = asSourceExpr(source2.getNode())
+    |
+      not exists(source.getNode().asConvertedExpr()) and exists(source2.getNode().asConvertedExpr())
+    )
   }
 }
 
 from
-  FileFunction fileFunction, Expr taintedArg, Expr taintSource, PathNode sourceNode,
-  PathNode sinkNode, string taintCause, string callChain
+  FileFunction fileFunction, Expr taintedArg, Expr taintSource, TaintedPathConfiguration cfg,
+  DataFlow::PathNode sourceNode, DataFlow::PathNode sinkNode, string taintCause, string callChain
 where
-  not isExcluded(taintedArg, IO3Package::doNotPerformFileOperationsOnDevicesQuery()) and
+  taintedArg = asSinkExpr(sinkNode.getNode()) and
   fileFunction.outermostWrapperFunctionCall(taintedArg, callChain) and
-  taintedWithPath(taintSource, taintedArg, sourceNode, sinkNode) and
+  cfg.hasFilteredFlowPath(sourceNode, sinkNode) and
+  taintSource = asSourceExpr(sourceNode.getNode()) and
   isUserInput(taintSource, taintCause)
 select taintedArg, sourceNode, sinkNode,
-  "This argument to a file access function is derived from $@ and then passed to " + callChain,
+  "This argument to a file access function is derived from $@ and then passed to " + callChain + ".",
   taintSource, "user input (" + taintCause + ")"

--- a/c/cert/test/rules/FIO32-C/DoNotPerformFileOperationsOnDevices.expected
+++ b/c/cert/test/rules/FIO32-C/DoNotPerformFileOperationsOnDevices.expected
@@ -1,36 +1,16 @@
 edges
-| test.c:20:15:20:23 | array to pointer conversion | test.c:21:8:21:16 | (const char *)... |
-| test.c:20:15:20:23 | array to pointer conversion | test.c:21:8:21:16 | file_name |
-| test.c:20:15:20:23 | array to pointer conversion | test.c:21:8:21:16 | file_name indirection |
-| test.c:20:15:20:23 | file_name | test.c:21:8:21:16 | (const char *)... |
-| test.c:20:15:20:23 | file_name | test.c:21:8:21:16 | file_name |
 | test.c:20:15:20:23 | file_name | test.c:21:8:21:16 | file_name indirection |
-| test.c:20:15:20:23 | scanf output argument | test.c:21:8:21:16 | (const char *)... |
-| test.c:20:15:20:23 | scanf output argument | test.c:21:8:21:16 | file_name |
 | test.c:20:15:20:23 | scanf output argument | test.c:21:8:21:16 | file_name indirection |
-| test.c:45:15:45:23 | array to pointer conversion | test.c:46:29:46:37 | (LPCTSTR)... |
-| test.c:45:15:45:23 | array to pointer conversion | test.c:46:29:46:37 | file_name |
-| test.c:45:15:45:23 | array to pointer conversion | test.c:46:29:46:37 | file_name indirection |
-| test.c:45:15:45:23 | file_name | test.c:46:29:46:37 | (LPCTSTR)... |
-| test.c:45:15:45:23 | file_name | test.c:46:29:46:37 | file_name |
 | test.c:45:15:45:23 | file_name | test.c:46:29:46:37 | file_name indirection |
-| test.c:45:15:45:23 | scanf output argument | test.c:46:29:46:37 | (LPCTSTR)... |
-| test.c:45:15:45:23 | scanf output argument | test.c:46:29:46:37 | file_name |
 | test.c:45:15:45:23 | scanf output argument | test.c:46:29:46:37 | file_name indirection |
-subpaths
 nodes
-| test.c:20:15:20:23 | array to pointer conversion | semmle.label | array to pointer conversion |
 | test.c:20:15:20:23 | file_name | semmle.label | file_name |
 | test.c:20:15:20:23 | scanf output argument | semmle.label | scanf output argument |
-| test.c:21:8:21:16 | (const char *)... | semmle.label | (const char *)... |
-| test.c:21:8:21:16 | file_name | semmle.label | file_name |
 | test.c:21:8:21:16 | file_name indirection | semmle.label | file_name indirection |
-| test.c:45:15:45:23 | array to pointer conversion | semmle.label | array to pointer conversion |
 | test.c:45:15:45:23 | file_name | semmle.label | file_name |
 | test.c:45:15:45:23 | scanf output argument | semmle.label | scanf output argument |
-| test.c:46:29:46:37 | (LPCTSTR)... | semmle.label | (LPCTSTR)... |
-| test.c:46:29:46:37 | file_name | semmle.label | file_name |
 | test.c:46:29:46:37 | file_name indirection | semmle.label | file_name indirection |
+subpaths
 #select
-| test.c:21:8:21:16 | file_name | test.c:20:15:20:23 | file_name | test.c:21:8:21:16 | file_name | This argument to a file access function is derived from $@ and then passed to func(file_name), which calls fopen((unnamed parameter 0)) | test.c:20:15:20:23 | file_name | user input (scanf) |
-| test.c:46:29:46:37 | file_name | test.c:45:15:45:23 | file_name | test.c:46:29:46:37 | file_name | This argument to a file access function is derived from $@ and then passed to CreateFile(lpFileName) | test.c:45:15:45:23 | file_name | user input (scanf) |
+| test.c:21:8:21:16 | file_name | test.c:20:15:20:23 | file_name | test.c:21:8:21:16 | file_name indirection | This argument to a file access function is derived from $@ and then passed to func(file_name), which calls fopen((unnamed parameter 0)). | test.c:20:15:20:23 | file_name | user input (scanf) |
+| test.c:46:29:46:37 | file_name | test.c:45:15:45:23 | file_name | test.c:46:29:46:37 | file_name indirection | This argument to a file access function is derived from $@ and then passed to CreateFile(lpFileName). | test.c:45:15:45:23 | file_name | user input (scanf) |

--- a/change_notes/2022-12-06-remove-use-of-default-taint-tracking.md
+++ b/change_notes/2022-12-06-remove-use-of-default-taint-tracking.md
@@ -1,0 +1,2 @@
+ - `FIO32-C` - `DoNotPerformFileOperationsOnDevices.ql`:
+   - The query was rewritten to no longer depend of the `DefaultTaintTracking` library, which will be deprecated.


### PR DESCRIPTION
## Description

(Note that this PR targets the `next` branch, which is used by the CodeQL CI to detect changes that break `github/codeql-coding-standards`. The changes from this PR should eventually be merged to `main`.)

We plan to deprecate the `DefaultTaintTracking` library. As part of this all queries depending on the library will need to be rewritten. For coding standards this affects `DoNotPerformFileOperationsOnDevices.ql` from FIO32-C, which is a copy of CodeQL's `TaintedPath.ql`. This PR pulls in the initial rewrite we did on the CodeQL side [here](https://github.com/github/codeql/pull/11435). The performance we measured is similar to that of the old version, we do see some result changes, which we accepted on the CodeQL side (the query is/was quite noisy in any case).

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - FIO32-C

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)