### PR TITLE
Fix references to pack names after pack renaming

### DIFF
--- a/c/cert/src/codeql-suites/cert-default.qls
+++ b/c/cert/src/codeql-suites/cert-default.qls
@@ -1,5 +1,5 @@
 - description: CERT C 2016 (Default)
-- qlpack: cert-c-coding-standards
+- qlpack: codeql/cert-c-coding-standards
 - include:
     kind:
     - problem

--- a/c/misra/src/codeql-suites/misra-default.qls
+++ b/c/misra/src/codeql-suites/misra-default.qls
@@ -1,5 +1,5 @@
 - description: MISRA C 2012 (Default)
-- qlpack: misra-c-coding-standards
+- qlpack: codeql/misra-c-coding-standards
 - include:
     kind:
     - problem

--- a/cpp/autosar/src/codeql-suites/autosar-advisory.qls
+++ b/cpp/autosar/src/codeql-suites/autosar-advisory.qls
@@ -1,5 +1,5 @@
 - description: AUTOSAR C++14 Guidelines 20-11 (Advisory)
-- qlpack: autosar-cpp-coding-standards
+- qlpack: codeql/autosar-cpp-coding-standards
 - include:
     kind:
     - problem

--- a/cpp/autosar/src/codeql-suites/autosar-audit.qls
+++ b/cpp/autosar/src/codeql-suites/autosar-audit.qls
@@ -1,5 +1,5 @@
 - description: AUTOSAR C++14 Guidelines 20-11 (Audit)
-- qlpack: autosar-cpp-coding-standards
+- qlpack: codeql/autosar-cpp-coding-standards
 - include:
     kind:
     - problem

--- a/cpp/autosar/src/codeql-suites/autosar-default.qls
+++ b/cpp/autosar/src/codeql-suites/autosar-default.qls
@@ -1,5 +1,5 @@
 - description: AUTOSAR C++14 Guidelines 20-11 (Default)
-- qlpack: autosar-cpp-coding-standards
+- qlpack: codeql/autosar-cpp-coding-standards
 - include:
     kind:
     - problem

--- a/cpp/autosar/src/codeql-suites/autosar-required.qls
+++ b/cpp/autosar/src/codeql-suites/autosar-required.qls
@@ -1,5 +1,5 @@
 - description: AUTOSAR C++14 Guidelines 20-11 (Required)
-- qlpack: autosar-cpp-coding-standards
+- qlpack: codeql/autosar-cpp-coding-standards
 - include:
     kind:
     - problem

--- a/cpp/autosar/src/codeql-suites/autosar-single-translation-unit.qls
+++ b/cpp/autosar/src/codeql-suites/autosar-single-translation-unit.qls
@@ -1,5 +1,5 @@
 - description: AUTOSAR C++14 Guidelines 20-11 (Single Translation Unit)
-- qlpack: autosar-cpp-coding-standards
+- qlpack: codeql/autosar-cpp-coding-standards
 - include:
     kind:
     - problem

--- a/cpp/cert/src/codeql-suites/cert-default.qls
+++ b/cpp/cert/src/codeql-suites/cert-default.qls
@@ -1,5 +1,5 @@
 - description: CERT C++ 2016 (Default)
-- qlpack: cert-cpp-coding-standards
+- qlpack: codeql/cert-cpp-coding-standards
 - include:
     kind:
     - problem

--- a/cpp/cert/src/codeql-suites/cert-single-translation-unit.qls
+++ b/cpp/cert/src/codeql-suites/cert-single-translation-unit.qls
@@ -1,5 +1,5 @@
 - description: CERT C++ 2016 (Single Translation Unit)
-- qlpack: cert-cpp-coding-standards
+- qlpack: codeql/cert-cpp-coding-standards
 - include:
     kind:
     - problem


### PR DESCRIPTION
## Description

(Note that this PR targets the next branch, which is used by the CodeQL CI to detect changes that break github/codeql-coding-standards. The changes from this PR should eventually be merged to main.)

In https://github.com/github/codeql-coding-standards/pull/4 the pack names used in the suite definitions we not updated, while the packs were renamed. Fix this.

## Change request type

 - [x] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [ ] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)