### PR TITLE
A5-2-2: Exclude template parameters, explain limitations

### DIFF
--- a/change_notes/2023-01-09-cstylecasts-template-parameters.md
+++ b/change_notes/2023-01-09-cstylecasts-template-parameters.md
@@ -1,0 +1,2 @@
+ - `A5-2-2`
+   - `CStyleCasts.ql` - exclude template parameters to avoid false positives when using the "functional notation" syntax. In addition, provide a greater explanation on limitations of this query.

--- a/cpp/autosar/test/rules/A5-2-2/test.cpp
+++ b/cpp/autosar/test/rules/A5-2-2/test.cpp
@@ -6,7 +6,7 @@ int foo() { return 1; }
 void test_c_style_cast() {
   double f = 3.14;
   std::uint32_t n1 = (std::uint32_t)f; // NON_COMPLIANT - C-style cast
-  std::uint32_t n2 = unsigned(f);      // NON_COMPLIANT - functional cast
+  std::uint32_t n2 = unsigned(f);      // COMPLIANT[FALSE_POSITIVE]
 
   std::uint8_t n3 = 1;
   std::uint8_t n4 = 1;
@@ -45,12 +45,12 @@ void test_cpp_style_cast() {
 class A5_2_2a {
 public:
   template <typename... As>
-  static void Foo(const std::string &name, As &&...rest) {
+  static void Foo(const std::string &name, As &&... rest) {
     Fun(Log(
         std::forward<As>(rest)...)); // COMPLIANT - reported as a false positive
   }
 
-  template <typename... As> static std::string Log(As &&...tail) {
+  template <typename... As> static std::string Log(As &&... tail) {
     return std::string();
   }
 
@@ -86,4 +86,40 @@ void test_macro_cast() {
   LIBRARY_NO_CAST_ADD_TWO((int)1.0); // NON_COMPLIANT - library macro with
                                      // c-style cast in argument, written by
                                      // user so should be reported
+}
+
+class D {
+public:
+  D(int x) : fx(x), fy(0) {}
+  D(int x, int y) : fx(x), fy(y) {}
+
+private:
+  int fx;
+  int fy;
+};
+
+D testNonFunctionalCast() {
+  return (D)1; // NON_COMPLIANT[FALSE_NEGATIVE]
+}
+
+D testFunctionalCast() {
+  return D(1); // COMPLIANT
+}
+
+D testFunctionalCastMulti() {
+  return D(1, 2); // COMPLIANT
+}
+
+template <typename T> T testFunctionalCastTemplate() {
+  return T(1); // COMPLIANT[FALSE_POSITIVE]
+}
+
+template <typename T> T testFunctionalCastTemplateMulti() {
+  return T(1, 2); // COMPLIANT
+}
+
+void testFunctionalCastTemplateUse() {
+  testFunctionalCastTemplate<D>();
+  testFunctionalCastTemplate<int>();
+  testFunctionalCastTemplateMulti<D>();
 }

--- a/rule_packages/cpp/BannedSyntax.json
+++ b/rule_packages/cpp/BannedSyntax.json
@@ -141,7 +141,14 @@
           "tags": [
             "correctness",
             "scope/single-translation-unit"
-          ]
+          ],
+          "implementation_scope": {
+            "description": "This query has the following limitations:",
+            "items": [
+              "It erroneously reports functional notation casts on primitive types (e.g. int(x)) as traditional C-style casts.",
+              "It will not report C-Style casts that result in a direct initialization via a constructor call with the given argument."
+            ]
+          }
         }
       ],
       "title": "Traditional C-style casts shall not be used."


### PR DESCRIPTION
## Description

The scope of this rule is intended to be so-called "c-style" casts. Unfortunately, our query for this rule has both false positives and false negatives due the way such casts are modelled in CodeQL.

Firstly, the `CStyleCast` CodeQL class includes "function notation" casts such as:
```
int(x);
A(x); // where `A` is some type with a suitable single argument constructor
```
I don't believe these are intended to part of the AUTOSAR rule, as they are not legal C casts, and therefore I don't think they count as "C-Style". Furthermore, the distinction is lost at the database schema level, so there's no universal query-level approach to distinguish between c-style and functional notation casts.

Secondly, if a c-style (or functional notation) cast results in a constructor call to a single argument constructor, the `CStyleCast` is not added to the database, and instead is replaced with the direct `ConstructorCall`. Again, at a database schema level, there is no universal way to determine if a particular constructor call was created from a cast, as the information has been lost.

As a consequence this query:
 - Produces false positives when primitive types are cast using the "functional notation" syntax.
 - Produces false negatives when a C-style cast is converted to a `ConstructorCall` e.g. when the argument type is compatible with a single-argument constructor.

This PR:
 * Adds the clarifications above to the query, the tests and the `implementation_scope`.
 * Addresses one small edge case that we _can_ control, by not reporting casts on template parameters, and instead relying on reporting casts in the specific instantiations of the class. This avoid false positives where the functional notation cast is used to "call" a constructor e.g. `T(x)`, and where in the instantiation the cast will be replaced with a `ConstructorCall` and therefore not reported. In practice, I believe this will remove the most common cause of false positives.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `A5-2-2`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)