### PR TITLE
Typo Fixes in test.c for RULE-6-1 and RULE-6-2

### DIFF
--- a/c/misra/test/rules/RULE-6-1/test.c
+++ b/c/misra/test/rules/RULE-6-1/test.c
@@ -4,12 +4,12 @@ enum Color { R, G, B };
 
 struct SampleStruct {
   int x1 : 2;          // NON_COMPLIANT - not explicitly signed or unsigned
-  unsigned int x2 : 2; // COMPILANT - explicitly unsigned
-  signed int x3 : 2;   // COMPILANT - explicitly signed
+  unsigned int x2 : 2; // COMPLIANT - explicitly unsigned
+  signed int x3 : 2;   // COMPLIANT - explicitly signed
   UINT16 x4 : 2;       // COMPLIANT - type alias resolves to a compliant type
   signed long x5 : 2; // NON_COMPLIANT - cannot declare bit field for long, even
                       // if it's signed
-  signed char x6 : 2; // NON_COMPILANT - cannot declare bit field for char, even
+  signed char x6 : 2; // NON_COMPLIANT - cannot declare bit field for char, even
                       // if it's signed
-  enum Color x7 : 3;  // NON_COMPILANT - cannot declare bit field for enum
+  enum Color x7 : 3;  // NON_COMPLIANT - cannot declare bit field for enum
 } sample_struct;

--- a/c/misra/test/rules/RULE-6-2/test.c
+++ b/c/misra/test/rules/RULE-6-2/test.c
@@ -1,17 +1,17 @@
 #include <stdint.h>
 
 struct SampleStruct {
-  int x1 : 1; // NON_COMPILANT: very likely be signed, but if it's not, the
+  int x1 : 1; // NON_COMPLIANT: very likely be signed, but if it's not, the
               // query will automatically handle it since we use signed(), not
               // isExplicitlySigned().
-  signed int x2 : 1; // NON_COMPILANT: single-bit named field with a signed type
+  signed int x2 : 1; // NON_COMPLIANT: single-bit named field with a signed type
   signed char
-      x3 : 1; // NON_COMPILANT: single-bit named field with a signed type
+      x3 : 1; // NON_COMPLIANT: single-bit named field with a signed type
   signed short
-      x4 : 1; // NON_COMPILANT: single-bit named field with a signed type
+      x4 : 1; // NON_COMPLIANT: single-bit named field with a signed type
   unsigned int
-      x5 : 1; // COMPILANT: single-bit named field but with an unsigned type
-  signed int x6 : 2; // COMPILANT: named field with a signed type but declared
+      x5 : 1; // COMPLIANT: single-bit named field but with an unsigned type
+  signed int x6 : 2; // COMPLIANT: named field with a signed type but declared
                      // to carry more than 1 bit
-  signed char : 1;   // COMPILANT: single-bit bit-field but unnamed
+  signed char : 1;   // COMPLIANT: single-bit bit-field but unnamed
 } sample_struct;


### PR DESCRIPTION
## Description

Typo fix in test.c for both RULE-6-1 and RULE-6-2: COMPLIANT, not COMPILANT.

`compilant` is [third-person](https://en.wiktionary.org/wiki/Appendix:Glossary#third_person) [plural](https://en.wiktionary.org/wiki/Appendix:Glossary#plural_number) [present](https://en.wiktionary.org/wiki/Appendix:Glossary#present_tense) [active](https://en.wiktionary.org/wiki/Appendix:Glossary#active_voice) [indicative](https://en.wiktionary.org/wiki/Appendix:Glossary#indicative_mood) of [compīlō](https://en.wiktionary.org/wiki/compilo#Latin) in Latin, according to Wiktionary. However, I did not mean that.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)