### PR TITLE
fix #1230 + 1157

### DIFF
--- a/c/cert/test/rules/ARR39-C/DoNotAddOrSubtractAScaledIntegerToAPointer.expected.clang
+++ b/c/cert/test/rules/ARR39-C/DoNotAddOrSubtractAScaledIntegerToAPointer.expected.clang
@@ -1,0 +1,23 @@
+edges
+| test.c:7:13:7:14 | p1 | test.c:9:9:9:10 | p1 |
+| test.c:16:19:16:41 | __builtin_offsetof | test.c:18:26:18:31 | offset |
+| test.c:16:19:16:41 | __builtin_offsetof | test.c:29:6:29:11 | offset |
+| test.c:17:17:17:26 | sizeof(<expr>) | test.c:23:9:23:12 | size |
+| test.c:29:6:29:11 | offset | test.c:7:13:7:14 | p1 |
+nodes
+| test.c:7:13:7:14 | p1 | semmle.label | p1 |
+| test.c:9:9:9:10 | p1 | semmle.label | p1 |
+| test.c:16:19:16:41 | __builtin_offsetof | semmle.label | __builtin_offsetof |
+| test.c:17:17:17:26 | sizeof(<expr>) | semmle.label | sizeof(<expr>) |
+| test.c:18:26:18:31 | offset | semmle.label | offset |
+| test.c:23:9:23:12 | size | semmle.label | size |
+| test.c:25:9:25:18 | sizeof(<expr>) | semmle.label | sizeof(<expr>) |
+| test.c:27:17:27:26 | sizeof(<expr>) | semmle.label | sizeof(<expr>) |
+| test.c:29:6:29:11 | offset | semmle.label | offset |
+subpaths
+#select
+| test.c:9:9:9:10 | p1 | test.c:16:19:16:41 | __builtin_offsetof | test.c:9:9:9:10 | p1 | Scaled integer used in pointer arithmetic. |
+| test.c:18:26:18:31 | offset | test.c:16:19:16:41 | __builtin_offsetof | test.c:18:26:18:31 | offset | Scaled integer used in pointer arithmetic. |
+| test.c:23:9:23:12 | size | test.c:17:17:17:26 | sizeof(<expr>) | test.c:23:9:23:12 | size | Scaled integer used in pointer arithmetic. |
+| test.c:25:9:25:18 | sizeof(<expr>) | test.c:25:9:25:18 | sizeof(<expr>) | test.c:25:9:25:18 | sizeof(<expr>) | Scaled integer used in pointer arithmetic. |
+| test.c:27:17:27:26 | sizeof(<expr>) | test.c:27:17:27:26 | sizeof(<expr>) | test.c:27:17:27:26 | sizeof(<expr>) | Scaled integer used in pointer arithmetic. |

--- a/c/cert/test/rules/ARR39-C/DoNotAddOrSubtractAScaledIntegerToAPointer.expected.gcc
+++ b/c/cert/test/rules/ARR39-C/DoNotAddOrSubtractAScaledIntegerToAPointer.expected.gcc
@@ -1,0 +1,23 @@
+edges
+| test.c:7:13:7:14 | p1 | test.c:9:9:9:10 | p1 |
+| test.c:16:19:16:41 | __builtin_offsetof | test.c:18:26:18:31 | offset |
+| test.c:16:19:16:41 | __builtin_offsetof | test.c:29:6:29:11 | offset |
+| test.c:17:17:17:26 | sizeof(<expr>) | test.c:23:9:23:12 | size |
+| test.c:29:6:29:11 | offset | test.c:7:13:7:14 | p1 |
+nodes
+| test.c:7:13:7:14 | p1 | semmle.label | p1 |
+| test.c:9:9:9:10 | p1 | semmle.label | p1 |
+| test.c:16:19:16:41 | __builtin_offsetof | semmle.label | __builtin_offsetof |
+| test.c:17:17:17:26 | sizeof(<expr>) | semmle.label | sizeof(<expr>) |
+| test.c:18:26:18:31 | offset | semmle.label | offset |
+| test.c:23:9:23:12 | size | semmle.label | size |
+| test.c:25:9:25:18 | sizeof(<expr>) | semmle.label | sizeof(<expr>) |
+| test.c:27:17:27:26 | sizeof(<expr>) | semmle.label | sizeof(<expr>) |
+| test.c:29:6:29:11 | offset | semmle.label | offset |
+subpaths
+#select
+| test.c:9:9:9:10 | p1 | test.c:16:19:16:41 | __builtin_offsetof | test.c:9:9:9:10 | p1 | Scaled integer used in pointer arithmetic. |
+| test.c:18:26:18:31 | offset | test.c:16:19:16:41 | __builtin_offsetof | test.c:18:26:18:31 | offset | Scaled integer used in pointer arithmetic. |
+| test.c:23:9:23:12 | size | test.c:17:17:17:26 | sizeof(<expr>) | test.c:23:9:23:12 | size | Scaled integer used in pointer arithmetic. |
+| test.c:25:9:25:18 | sizeof(<expr>) | test.c:25:9:25:18 | sizeof(<expr>) | test.c:25:9:25:18 | sizeof(<expr>) | Scaled integer used in pointer arithmetic. |
+| test.c:27:17:27:26 | sizeof(<expr>) | test.c:27:17:27:26 | sizeof(<expr>) | test.c:27:17:27:26 | sizeof(<expr>) | Scaled integer used in pointer arithmetic. |


### PR DESCRIPTION
## Description

Fixes #1230 + 1157

## Change request type

 - [x] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [ ] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)