### PR TITLE
Replace `isDefined` by `hasDefinition`

### DIFF
--- a/cpp/autosar/src/rules/A12-1-1/ExplicitConstructorBaseClassInitialization.ql
+++ b/cpp/autosar/src/rules/A12-1-1/ExplicitConstructorBaseClassInitialization.ql
@@ -35,7 +35,7 @@ where
     not init.isCompilerGenerated()
   ) and
   // Must be a defined constructor
-  c.isDefined() and
+  c.hasDefinition() and
   // Not a compiler-generated constructor
   not c.isCompilerGenerated() and
   // Not a defaulted constructor

--- a/cpp/autosar/src/rules/A2-10-4/IdentifierNameOfStaticFunctionReusedInNamespace.ql
+++ b/cpp/autosar/src/rules/A2-10-4/IdentifierNameOfStaticFunctionReusedInNamespace.ql
@@ -17,7 +17,7 @@ import codingstandards.cpp.autosar
 
 class CandidateFunction extends Function {
   CandidateFunction() {
-    isDefined() and
+    hasDefinition() and
     isStatic() and
     not isMember() and
     not (

--- a/cpp/autosar/src/rules/A3-1-1/ViolationsOfOneDefinitionRule.ql
+++ b/cpp/autosar/src/rules/A3-1-1/ViolationsOfOneDefinitionRule.ql
@@ -65,7 +65,7 @@ where
     or
     //an non-const object defined in a header
     exists(GlobalOrNamespaceVariable object |
-      object.isDefined() and
+      object.hasDefinition() and
       not (
         object.isConstexpr()
         or

--- a/cpp/common/src/codingstandards/cpp/TrivialType.qll
+++ b/cpp/common/src/codingstandards/cpp/TrivialType.qll
@@ -48,7 +48,7 @@ predicate hasTrivialMoveConstructor(Class c) {
   forall(Class baseClass | baseClass = c.getABaseClass() | hasTrivialMoveConstructor(baseClass)) and
   // The class has to be defined, otherwise we may not see the information required to deduce
   // whether it does or does not have a trivial move constructor
-  c.isDefined()
+  c.hasDefinition()
 }
 
 /** A trivial copy or move constructor (see [class.copy]/12). */


### PR DESCRIPTION
## Description

The member predicate `isDefined` of `Declaration` is marked as deprecated in its QLDoc and mentions that `hasDefinition` should be used instead. Use `hasDefinition`. Note that `isDefined` is implemented as `this.hasDefinition()`.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - A12-1-1
     - A2-10-4
     - A3-1-1

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)