### PR TITLE
Do not use deprecated `getFullSignature` but use `getIdentityString` instead

### DIFF
--- a/change_notes/2023-03-06-A13-2-2-message.md
+++ b/change_notes/2023-03-06-A13-2-2-message.md
@@ -1,0 +1,2 @@
+ - `A13-2-2` - `BinaryOperatorAndBitwiseOperatorReturnAPrvalue.ql`
+   - The formatting of the query output message has been changed and operators are now displayed starting with the return type instead of ending with it.

--- a/cpp/autosar/src/rules/A13-2-2/BinaryOperatorAndBitwiseOperatorReturnAPrvalue.ql
+++ b/cpp/autosar/src/rules/A13-2-2/BinaryOperatorAndBitwiseOperatorReturnAPrvalue.ql
@@ -17,6 +17,7 @@
 import cpp
 import codingstandards.cpp.autosar
 import codingstandards.cpp.Operator
+import semmle.code.cpp.Print
 
 from Operator o
 where
@@ -30,5 +31,5 @@ where
     o.getType() instanceof ReferenceType
   )
 select o,
-  "User-defined bitwise or arithmetic operator " + o.getFullSignature() +
+  "User-defined bitwise or arithmetic operator " + getIdentityString(o) +
     " does not return a prvalue."

--- a/cpp/autosar/test/rules/A13-2-2/BinaryOperatorAndBitwiseOperatorReturnAPrvalue.expected
+++ b/cpp/autosar/test/rules/A13-2-2/BinaryOperatorAndBitwiseOperatorReturnAPrvalue.expected
@@ -1,4 +1,4 @@
-| test.cpp:16:9:16:17 | operator- | User-defined bitwise or arithmetic operator operator-(const A &, int) -> const A does not return a prvalue. |
-| test.cpp:20:4:20:12 | operator\| | User-defined bitwise or arithmetic operator operator\|(const A &, const A &) -> A * does not return a prvalue. |
-| test.cpp:24:9:24:18 | operator<< | User-defined bitwise or arithmetic operator operator<<(const A &, const A &) -> const A does not return a prvalue. |
-| test.cpp:34:6:34:14 | operator+ | User-defined bitwise or arithmetic operator NS_C::operator+(const C &, const C &) -> int & does not return a prvalue. |
+| test.cpp:16:9:16:17 | operator- | User-defined bitwise or arithmetic operator A const operator-(A const&, int) does not return a prvalue. |
+| test.cpp:20:4:20:12 | operator\| | User-defined bitwise or arithmetic operator A* operator\|(A const&, A const&) does not return a prvalue. |
+| test.cpp:24:9:24:18 | operator<< | User-defined bitwise or arithmetic operator A const operator<<(A const&, A const&) does not return a prvalue. |
+| test.cpp:34:6:34:14 | operator+ | User-defined bitwise or arithmetic operator int& NS_C::operator+(C const&, C const&) does not return a prvalue. |


### PR DESCRIPTION
## Description

The member predicate `getFullSignature` of `Function` is marked as deprecated in its QLDoc and mentions that `getIdentityString` should be used instead. Use `getIdentityString`. Note that both `getFullSignature` and `getIdentityString` are expensive to compute. It might be better to use a cheaper alternative here.

Please check carefully that this does not cause any performance regressions on OpenPilot. I'm not properly set up to test this with CodeQL 2.9.4.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - A13-2-2

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [ x Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ x Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)