### PR TITLE
Rule 20.12: Improve performance

### DIFF
--- a/c/misra/src/rules/RULE-20-12/MacroParameterUsedAsHashOperand.ql
+++ b/c/misra/src/rules/RULE-20-12/MacroParameterUsedAsHashOperand.ql
@@ -19,7 +19,7 @@ import codingstandards.cpp.Macro
 
 from FunctionLikeMacro m, MacroInvocation mi, int i, string expanded, string param
 where
-  not isExcluded(m, Preprocessor2Package::macroParameterUsedAsHashOperandQuery()) and
+  not isExcluded(mi, Preprocessor2Package::macroParameterUsedAsHashOperandQuery()) and
   mi = m.getAnInvocation() and
   param = m.getParameter(i) and
   (
@@ -31,9 +31,6 @@ where
   // This check ensure there is an expansion that is used.
   expanded = mi.getExpandedArgument(i) and
   not expanded = "" and
-  exists(Macro furtherExpandedMacro |
-    mi.getUnexpandedArgument(i).matches(furtherExpandedMacro.getName() + "%")
-  )
+  not mi.getUnexpandedArgument(i) = mi.getExpandedArgument(i)
 select m,
-  "Macro " + m.getName() + " contains use of parameter " + m.getParameter(i) +
-    " used in multiple contexts."
+  "Macro " + m.getName() + " contains use of parameter " + param + " used in multiple contexts."

--- a/change_notes/2023-03-07-20-12-perf.md
+++ b/change_notes/2023-03-07-20-12-perf.md
@@ -1,0 +1,1 @@
+ * `Rule 20.12` - the performance of this rule has been improved.


### PR DESCRIPTION
## Description

This commit optimizes the from-where-select clause of this query, which was highlighted as one of the slowest predicates for our C query suites.

This commit makes the following changes:
 * Avoid repetition of `m.getParameter(i)`, which caused a cross product
 * Change the way we identify "further expanded macro"
 * Modify the `isExcluded` predicate to reference the macro invocation not the macro.

@rvermeulen I think you wrote this rule originally, so I would appreciate a review. In particular, the change from

```codeql
  exists(Macro furtherExpandedMacro |
    mi.getUnexpandedArgument(i).matches(furtherExpandedMacro.getName() + "%")
  )
```

to

```codeql
not mi.getUnexpandedArgument(i) = mi.getExpandedArgument(i)
```

Achieves what you originally intended.

@mbaluda @jsinglet this addresses one of the slowest performing predicates that was highlighted in https://github.com/github/codeql-coding-standards/pull/226, although the slow performance is **not** related to the upgrade itself.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `Rule 20.12`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the .ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)