### PR TITLE
EssentialTypes: Improve performance.

### DIFF
--- a/c/misra/src/codingstandards/c/misra/EssentialTypes.qll
+++ b/c/misra/src/codingstandards/c/misra/EssentialTypes.qll
@@ -146,6 +146,7 @@ EssentialTypeCategory getEssentialTypeCategory(Type type) {
 /**
  * Gets the essential type of the given expression `e`, considering any explicit conversions.
  */
+pragma[nomagic]
 Type getEssentialType(Expr e) {
   if e.hasExplicitConversion()
   then

--- a/c/misra/src/rules/RULE-10-5/InappropriateEssentialTypeCast.ql
+++ b/c/misra/src/rules/RULE-10-5/InappropriateEssentialTypeCast.ql
@@ -49,16 +49,23 @@ predicate isIncompatibleEssentialTypeCast(EssentialTypeCategory fromCat, Essenti
     ]
 }
 
+predicate isCastTypes(
+  Cast c, Type essentialFromType, Type essentialToType, EssentialTypeCategory fromCategory,
+  EssentialTypeCategory toCategory
+) {
+  essentialFromType = getEssentialTypeBeforeConversions(c.getExpr()) and
+  essentialToType = c.getType() and
+  fromCategory = getEssentialTypeCategory(essentialFromType) and
+  toCategory = getEssentialTypeCategory(essentialToType)
+}
+
 from
   Cast c, Type essentialFromType, Type essentialToType, EssentialTypeCategory fromCategory,
   EssentialTypeCategory toCategory, string message
 where
   not isExcluded(c, EssentialTypesPackage::inappropriateEssentialTypeCastQuery()) and
   not c.isImplicit() and
-  essentialFromType = getEssentialTypeBeforeConversions(c.getExpr()) and
-  essentialToType = c.getType() and
-  fromCategory = getEssentialTypeCategory(essentialFromType) and
-  toCategory = getEssentialTypeCategory(essentialToType) and
+  isCastTypes(c, essentialFromType, essentialToType, fromCategory, toCategory) and
   isIncompatibleEssentialTypeCast(fromCategory, toCategory) and
   (
     if fromCategory = EssentiallyEnumType() and toCategory = EssentiallyEnumType()

--- a/change_notes/2023-03-16-essential-types-performance.md
+++ b/change_notes/2023-03-16-essential-types-performance.md
@@ -1,0 +1,12 @@
+ * The performance of the following queries related to essential types have been improved:
+   * `Rule 10.1`
+   * `Rule 10.2`
+   * `Rule 10.3`
+   * `Rule 10.4`
+   * `Rule 10.5`
+   * `Rule 10.6`
+   * `Rule 10.7`
+   * `Rule 10.8`
+   * `Rule 14.1`
+   * `Rule 21.14`
+   * `Rule 21.16`


### PR DESCRIPTION
## Description

Address two observed performance issues with the EssentialTypes rules when run with CodeQL CLI 2.10.5.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)