### PR TITLE
s/`getFieldExpr`/`getAFieldExpr` and s/`getElementExpr`/`getAnElementExpr`

### DIFF
--- a/c/misra/src/rules/RULE-13-1/InitializerListsContainPersistentSideEffects.ql
+++ b/c/misra/src/rules/RULE-13-1/InitializerListsContainPersistentSideEffects.ql
@@ -25,8 +25,8 @@ from AggregateLiteral initList, SideEffect effect
 where
   not isExcluded(initList, SideEffects1Package::initializerListsContainPersistentSideEffectsQuery()) and
   (
-    initList.(ArrayOrVectorAggregateLiteral).getElementExpr(_) = effect
+    initList.(ArrayOrVectorAggregateLiteral).getAnElementExpr(_) = effect
     or
-    initList.(ClassAggregateLiteral).getFieldExpr(_) = effect
+    initList.(ClassAggregateLiteral).getAFieldExpr(_) = effect
   )
 select initList, "Initializer list constains persistent $@", effect, "side effect"

--- a/c/misra/src/rules/RULE-17-5/ArrayFunctionArgumentNumberOfElements.ql
+++ b/c/misra/src/rules/RULE-17-5/ArrayFunctionArgumentNumberOfElements.ql
@@ -42,7 +42,7 @@ class ArrayParameter extends Parameter {
  * int arr2[2] = {1, 2, 3};
  * ```
  */
-int countElements(ArrayAggregateLiteral l) { result = count(l.getElementExpr(_)) }
+int countElements(ArrayAggregateLiteral l) { result = count(l.getAnElementExpr(_)) }
 
 class SmallArrayConfig extends DataFlow::Configuration {
   SmallArrayConfig() { this = "SmallArrayConfig" }

--- a/c/misra/src/rules/RULE-21-14/MemcmpUsedToCompareNullTerminatedStrings.ql
+++ b/c/misra/src/rules/RULE-21-14/MemcmpUsedToCompareNullTerminatedStrings.ql
@@ -30,7 +30,7 @@ class NullTerminatedStringToMemcmpConfiguration extends TaintTracking::Configura
       // The array element type is an essentially character type
       getEssentialTypeCategory(aal.getElementType()) = EssentiallyCharacterType() and
       // Includes a null terminator somewhere in the array initializer
-      aal.getElementExpr(_).getValue().toInt() = 0
+      aal.getAnElementExpr(_).getValue().toInt() = 0
     |
       // For local variables, use the array aggregate literal as the source
       aal = source.asExpr()

--- a/c/misra/src/rules/RULE-9-4/RepeatedInitializationOfAggregateObjectElement.ql
+++ b/c/misra/src/rules/RULE-9-4/RepeatedInitializationOfAggregateObjectElement.ql
@@ -38,7 +38,7 @@ string getNestedArrayIndexString(Expr e) {
           any(int elementIndex |
             exists(ArrayAggregateLiteral parent |
               parent = getNthParent(e, pragma[only_bind_into](depth + 1)) and
-              parent.getElementExpr(elementIndex) = getNthParent(e, pragma[only_bind_into](depth))
+              parent.getAnElementExpr(elementIndex) = getNthParent(e, pragma[only_bind_into](depth))
             )
           |
             elementIndex
@@ -54,9 +54,9 @@ string getNestedArrayIndexString(Expr e) {
  */
 language[monotonicAggregates]
 int getMaxDepth(ArrayAggregateLiteral al) {
-  if not exists(al.getElementExpr(_).(ArrayAggregateLiteral))
+  if not exists(al.getAnElementExpr(_).(ArrayAggregateLiteral))
   then result = 0
-  else result = 1 + max(Expr child | child = al.getElementExpr(_) | getMaxDepth(child))
+  else result = 1 + max(Expr child | child = al.getAnElementExpr(_) | getMaxDepth(child))
 }
 
 // internal recursive predicate for `hasMultipleInitializerExprsForSameIndex`
@@ -66,8 +66,8 @@ predicate hasMultipleInitializerExprsForSameIndexInternal(
   exists(int shared_index, Expr al1_expr, Expr al2_expr |
     // an `Expr` initializing an element of the same index in both `al1` and `al2`
     shared_index = [0 .. al1.getArraySize() - 1] and
-    al1_expr = al1.getElementExpr(shared_index) and
-    al2_expr = al2.getElementExpr(shared_index) and
+    al1_expr = al1.getAnElementExpr(shared_index) and
+    al2_expr = al2.getAnElementExpr(shared_index) and
     // but not the same `Expr`
     not al1_expr = al2_expr and
     (
@@ -98,7 +98,7 @@ predicate hasMultipleInitializerExprsForSameIndex(ArrayAggregateLiteral root, Ex
  * This predicate is therefore unable to distinguish the individual duplicate expressions.
  */
 predicate hasMultipleInitializerExprsForSameField(ClassAggregateLiteral root, Field f) {
-  count(root.getFieldExpr(f)) > 1
+  count(root.getAFieldExpr(f)) > 1
 }
 
 from

--- a/cpp/autosar/src/rules/A5-1-1/LiteralValueUsedOutsideTypeInit.ql
+++ b/cpp/autosar/src/rules/A5-1-1/LiteralValueUsedOutsideTypeInit.ql
@@ -43,7 +43,7 @@ where
   // Macro expansions are morally excluded
   not l = any(MacroInvocation mi).getAnExpandedElement() and
   // Aggregate literal
-  not l = any(ArrayOrVectorAggregateLiteral aal).getElementExpr(_).getAChild*() and
+  not l = any(ArrayOrVectorAggregateLiteral aal).getAnElementExpr(_).getAChild*() and
   // Ignore x - 1 expressions
   not exists(SubExpr se | se.getRightOperand() = l and l.getValue() = "1")
 select l,

--- a/cpp/autosar/src/rules/A8-4-9/InOutParametersDeclaredAsTNotModified.ql
+++ b/cpp/autosar/src/rules/A8-4-9/InOutParametersDeclaredAsTNotModified.ql
@@ -60,7 +60,7 @@ where
     //also not having a nonconst member accessed through the param
     notUsedAsQualifierForNonConst(p) and
     not exists(ClassAggregateLiteral l, Field f |
-      DataFlow::localExprFlow(p.getAnAccess(), l.getFieldExpr(f)) and
+      DataFlow::localExprFlow(p.getAnAccess(), l.getAFieldExpr(f)) and
       not f.isConst()
     ) and
     // Exclude parameters that are used to initialize member fields.


### PR DESCRIPTION
## Description

We're deprecating these two predicates in favor of two new predicates. This PR replaces the uses of the to-be-deprecated predicates with semantically-identical predicates.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)