### PR TITLE
Use 'getAnElementExpr' instead of 'getElementExpr', and 'getAFieldExpr' instead of 'getFieldExpr'.

### DIFF
--- a/c/misra/src/codingstandards/c/misra/EssentialTypes.qll
+++ b/c/misra/src/codingstandards/c/misra/EssentialTypes.qll
@@ -365,12 +365,12 @@ predicate isAssignmentToEssentialType(Type lValueEssentialType, Expr rValue) {
   // Initializing an array
   exists(ArrayAggregateLiteral aal |
     lValueEssentialType = aal.getElementType() and
-    rValue = aal.getElementExpr(_)
+    rValue = aal.getAnElementExpr(_)
   )
   or
   // Initializing a struct or union
   exists(ClassAggregateLiteral cal, Field field |
     lValueEssentialType = field.getType() and
-    rValue = cal.getFieldExpr(field)
+    rValue = cal.getAFieldExpr(field)
   )
 }

--- a/cpp/autosar/src/rules/A12-1-5/InitializerHashCons.qll
+++ b/cpp/autosar/src/rules/A12-1-5/InitializerHashCons.qll
@@ -891,7 +891,7 @@ private predicate mk_FieldCons(
   analyzableClassAggregateLiteral(cal) and
   cal.getUnspecifiedType() = c and
   exists(Expr e |
-    e = cal.getFieldExpr(f).getFullyConverted() and
+    e = cal.getAFieldExpr(f).getFullyConverted() and
     f.getInitializationOrder() = i and
     (
       hc = hashCons(e) and
@@ -907,9 +907,9 @@ private predicate mk_FieldCons(
 private predicate analyzableClassAggregateLiteral(ClassAggregateLiteral cal) {
   forall(int i | exists(cal.getChild(i)) |
     strictcount(cal.getChild(i).getFullyConverted()) = 1 and
-    strictcount(Field f | cal.getChild(i) = cal.getFieldExpr(f)) = 1 and
+    strictcount(Field f | cal.getChild(i) = cal.getAFieldExpr(f)) = 1 and
     strictcount(Field f, int j |
-      cal.getFieldExpr(f) = cal.getChild(i) and j = f.getInitializationOrder()
+      cal.getAFieldExpr(f) = cal.getChild(i) and j = f.getInitializationOrder()
     ) = 1
   )
 }

--- a/cpp/autosar/src/rules/A5-1-9/LambdaEquivalence.qll
+++ b/cpp/autosar/src/rules/A5-1-9/LambdaEquivalence.qll
@@ -989,7 +989,7 @@ private module HashCons {
     analyzableClassAggregateLiteral(cal) and
     cal.getUnspecifiedType() = c and
     exists(Expr e |
-      e = cal.getFieldExpr(f).getFullyConverted() and
+      e = cal.getAFieldExpr(f).getFullyConverted() and
       f.getInitializationOrder() = i and
       (
         hc = hashConsExpr(e) and
@@ -1005,9 +1005,9 @@ private module HashCons {
   private predicate analyzableClassAggregateLiteral(ClassAggregateLiteral cal) {
     forall(int i | exists(cal.getChild(i)) |
       strictcount(cal.getChild(i).getFullyConverted()) = 1 and
-      strictcount(Field f | cal.getChild(i) = cal.getFieldExpr(f)) = 1 and
+      strictcount(Field f | cal.getChild(i) = cal.getAFieldExpr(f)) = 1 and
       strictcount(Field f, int j |
-        cal.getFieldExpr(f) = cal.getChild(i) and j = f.getInitializationOrder()
+        cal.getAFieldExpr(f) = cal.getChild(i) and j = f.getInitializationOrder()
       ) = 1
     )
   }

--- a/cpp/common/src/codingstandards/cpp/StructuralEquivalence.qll
+++ b/cpp/common/src/codingstandards/cpp/StructuralEquivalence.qll
@@ -989,7 +989,7 @@ private module HashCons {
     analyzableClassAggregateLiteral(cal) and
     cal.getUnspecifiedType() = c and
     exists(Expr e |
-      e = cal.getFieldExpr(f).getFullyConverted() and
+      e = cal.getAFieldExpr(f).getFullyConverted() and
       f.getInitializationOrder() = i and
       (
         hc = hashConsExpr(e) and
@@ -1005,9 +1005,9 @@ private module HashCons {
   private predicate analyzableClassAggregateLiteral(ClassAggregateLiteral cal) {
     forall(int i | exists(cal.getChild(i)) |
       strictcount(cal.getChild(i).getFullyConverted()) = 1 and
-      strictcount(Field f | cal.getChild(i) = cal.getFieldExpr(f)) = 1 and
+      strictcount(Field f | cal.getChild(i) = cal.getAFieldExpr(f)) = 1 and
       strictcount(Field f, int j |
-        cal.getFieldExpr(f) = cal.getChild(i) and j = f.getInitializationOrder()
+        cal.getAFieldExpr(f) = cal.getChild(i) and j = f.getInitializationOrder()
       ) = 1
     )
   }

--- a/cpp/common/src/codingstandards/cpp/enhancements/AggregateLiteralEnhancements.qll
+++ b/cpp/common/src/codingstandards/cpp/enhancements/AggregateLiteralEnhancements.qll
@@ -114,7 +114,7 @@ module ClassAggregateLiterals {
       exists(Expr compilerGeneratedVal, int index, Expr previousExpr |
         // Identify the candidate expression which may be compiler generated
         compilerGeneratedVal = cal.getChild(index) and
-        compilerGeneratedVal = cal.getFieldExpr(f) and
+        compilerGeneratedVal = cal.getAFieldExpr(f) and
         // Find the previous expression for this aggregate literal
         previousExpr = getPreviousExpr(cal, index)
       |
@@ -201,7 +201,7 @@ class InferredAggregateLiteral extends AggregateLiteral {
 predicate isExprValueInitialized(AggregateLiteral al, Expr e) {
   // This expression is a value initialized field
   exists(Field f |
-    e = al.(ClassAggregateLiteral).getFieldExpr(f) and
+    e = al.(ClassAggregateLiteral).getAFieldExpr(f) and
     ClassAggregateLiterals::isValueInitialized(al, f)
   )
   or
@@ -236,7 +236,7 @@ predicate isLeadingZeroInitialized(AggregateLiteral a) {
     // Or because it's a class aggregate, and all other fields are value initialized
     forall(Field f |
       f = a.getType().(Class).getAField() and
-      not a.(ClassAggregateLiteral).getFieldExpr(f) = a.getChild(0)
+      not a.(ClassAggregateLiteral).getAFieldExpr(f) = a.getChild(0)
     |
       ClassAggregateLiterals::isValueInitialized(a, f)
     )

--- a/cpp/common/src/codingstandards/cpp/rules/useinitializerbracestomatchaggregatetypestructure/UseInitializerBracesToMatchAggregateTypeStructure.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/useinitializerbracestomatchaggregatetypestructure/UseInitializerBracesToMatchAggregateTypeStructure.qll
@@ -28,7 +28,7 @@ query predicate problems(
   exists(string parentDescription |
     // For class aggergate literal parents, report which field is being assigned to
     exists(ClassAggregateLiteral cal, Field field |
-      cal.getFieldExpr(field) = inferredAggregateLiteral and
+      cal.getAFieldExpr(field) = inferredAggregateLiteral and
       parentDescription = "to field $@" and
       explanationElement = field
     |
@@ -37,15 +37,15 @@ query predicate problems(
     or
     // For array aggregate literal parents, report which index is being assigned to
     exists(ArrayAggregateLiteral aal, int elementIndex |
-      aal.getElementExpr(elementIndex) = inferredAggregateLiteral and
+      aal.getAnElementExpr(elementIndex) = inferredAggregateLiteral and
       parentDescription = "to index " + elementIndex + " in $@" and
       explanationElement = aal and
       explanationDescription = "array of type " + aal.getType().getName()
     )
     or
     // In some cases, we seem to have missing link, so provide a basic message
-    not any(ArrayAggregateLiteral aal).getElementExpr(_) = inferredAggregateLiteral and
-    not any(ClassAggregateLiteral aal).getFieldExpr(_) = inferredAggregateLiteral and
+    not any(ArrayAggregateLiteral aal).getAnElementExpr(_) = inferredAggregateLiteral and
+    not any(ClassAggregateLiteral aal).getAFieldExpr(_) = inferredAggregateLiteral and
     parentDescription = "to an unnamed field of $@" and
     explanationElement = inferredAggregateLiteral.getParent() and
     explanationDescription = " " + explanationElement.(Expr).getType().getName()


### PR DESCRIPTION
## Description

We're deprecating these two predicates in favor of two new predicates. This PR replaces the uses of the to-be-deprecated predicates with semantically-identical predicates.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)