### PR TITLE
__func__ excluded from C-style queries

### DIFF
--- a/change_notes/2023-05-02-func-c-style.md
+++ b/change_notes/2023-05-02-func-c-style.md
@@ -1,0 +1,3 @@
+ * Exclude the use of `__func__` from certain queries, as it is the proscribed way to return the name of the current function:
+   * `A27-0-4` - Use of the value returned by `__func__` is no longer flagged as a use of C-style strings.
+   * `A18-1-1` - `__func__` is no longer flagged as a declaration of a variable using C-style arrays.

--- a/cpp/autosar/src/rules/A18-1-1/CStyleArraysUsed.ql
+++ b/cpp/autosar/src/rules/A18-1-1/CStyleArraysUsed.ql
@@ -30,5 +30,7 @@ class StaticConstExprArrayDataMember extends MemberVariable {
 from Variable v
 where
   not isExcluded(v, BannedSyntaxPackage::cStyleArraysUsedQuery()) and
-  exists(ArrayType a | v.getType() = a | not v instanceof StaticConstExprArrayDataMember)
+  exists(ArrayType a | v.getType() = a | not v instanceof StaticConstExprArrayDataMember) and
+  // Exclude the compiler generated __func__ as it is the only way to access the function name information
+  not v.getName() = "__func__"
 select v, "Variable " + v.getName() + " declares a c-style array."

--- a/cpp/autosar/src/rules/A27-0-4/CStyleStringsUsed.ql
+++ b/cpp/autosar/src/rules/A27-0-4/CStyleStringsUsed.ql
@@ -36,5 +36,6 @@ where
     e = any(FunctionCall fc).getArgument(_) and
     e.getUnspecifiedType().(PointerType).getBaseType*() instanceof CharType
   ) and
-  DataFlow::localFlow(DataFlow::exprNode(cs), DataFlow::exprNode(e))
+  DataFlow::localFlow(DataFlow::exprNode(cs), DataFlow::exprNode(e)) and
+  not cs = any(LocalVariable lv | lv.getName() = "__func__").getInitializer().getExpr()
 select cs, "Usage of C-style string in $@.", e, "expression"

--- a/cpp/autosar/test/rules/A18-1-1/test.cpp
+++ b/cpp/autosar/test/rules/A18-1-1/test.cpp
@@ -10,5 +10,7 @@ int test_c_arrays() {
 
   int x[100];                 // NON_COMPLIANT
   constexpr int a[]{0, 1, 2}; // NON_COMPLIANT
+
+  __func__; // COMPLAINT
   return 0;
 }

--- a/cpp/autosar/test/rules/A27-0-4/test.cpp
+++ b/cpp/autosar/test/rules/A27-0-4/test.cpp
@@ -26,4 +26,5 @@ void f2() {
   f1(a1);
   f1(a2);
   f1(s.c_str()); // NON_COMPLIANT
+  __func__;
 }


### PR DESCRIPTION
## Description

Exclude `__func__` from queries that prohibit c-style strings and arrays, as it is the proscribed way to return the function name.

Fixes #302.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `A18-1-1`
     - `A27-0-4`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)