### PR TITLE
Fix exclusions for tests of shared queries

### DIFF
--- a/c/common/test/rules/closefilehandlewhennolongerneededshared/CloseFileHandleWhenNoLongerNeededShared.ql
+++ b/c/common/test/rules/closefilehandlewhennolongerneededshared/CloseFileHandleWhenNoLongerNeededShared.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.closefilehandlewhennolongerneededshared.CloseFileHandleWhenNoLongerNeededShared
+
+class TestFileQuery extends CloseFileHandleWhenNoLongerNeededSharedSharedQuery, TestQuery { }

--- a/c/common/test/rules/commaoperatorused/CommaOperatorUsed.ql
+++ b/c/common/test/rules/commaoperatorused/CommaOperatorUsed.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.commaoperatorused.CommaOperatorUsed
+
+class TestFileQuery extends CommaOperatorUsedSharedQuery, TestQuery { }

--- a/c/common/test/rules/constantunsignedintegerexpressionswraparound/ConstantUnsignedIntegerExpressionsWrapAround.ql
+++ b/c/common/test/rules/constantunsignedintegerexpressionswraparound/ConstantUnsignedIntegerExpressionsWrapAround.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.constantunsignedintegerexpressionswraparound.ConstantUnsignedIntegerExpressionsWrapAround
+
+class TestFileQuery extends ConstantUnsignedIntegerExpressionsWrapAroundSharedQuery, TestQuery { }

--- a/c/common/test/rules/constlikereturnvalue/ConstLikeReturnValue.ql
+++ b/c/common/test/rules/constlikereturnvalue/ConstLikeReturnValue.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.constlikereturnvalue.ConstLikeReturnValue
+
+class TestFileQuery extends ConstLikeReturnValueSharedQuery, TestQuery { }

--- a/c/common/test/rules/deadcode/DeadCode.ql
+++ b/c/common/test/rules/deadcode/DeadCode.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.deadcode.DeadCode
+
+class TestFileQuery extends DeadCodeSharedQuery, TestQuery { }

--- a/c/common/test/rules/declaredareservedidentifier/DeclaredAReservedIdentifier.expected
+++ b/c/common/test/rules/declaredareservedidentifier/DeclaredAReservedIdentifier.expected
@@ -1,4 +1,3 @@
-| file://:0:0:0:0 | __va_list_tag | Reserved identifier '__va_list_tag' is declared. |
 | test.c:2:1:2:23 | #define _RESERVED_MACRO | Reserved identifier '_RESERVED_MACRO' is declared. |
 | test.c:11:8:11:9 | _s | Reserved identifier '_s' is declared. |
 | test.c:15:6:15:7 | _f | Reserved identifier '_f' is declared. |

--- a/c/common/test/rules/declaredareservedidentifier/DeclaredAReservedIdentifier.ql
+++ b/c/common/test/rules/declaredareservedidentifier/DeclaredAReservedIdentifier.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.declaredareservedidentifier.DeclaredAReservedIdentifier
+
+class TestFileQuery extends DeclaredAReservedIdentifierSharedQuery, TestQuery { }

--- a/c/common/test/rules/dereferenceofnullpointer/DereferenceOfNullPointer.ql
+++ b/c/common/test/rules/dereferenceofnullpointer/DereferenceOfNullPointer.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.dereferenceofnullpointer.DereferenceOfNullPointer
+
+class TestFileQuery extends DereferenceOfNullPointerSharedQuery, TestQuery { }

--- a/c/common/test/rules/differentidentifiersnottypographicallyunambiguous/DifferentIdentifiersNotTypographicallyUnambiguous.ql
+++ b/c/common/test/rules/differentidentifiersnottypographicallyunambiguous/DifferentIdentifiersNotTypographicallyUnambiguous.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.differentidentifiersnottypographicallyunambiguous.DifferentIdentifiersNotTypographicallyUnambiguous
+
+class TestFileQuery extends DifferentIdentifiersNotTypographicallyUnambiguousSharedQuery, TestQuery { }

--- a/c/common/test/rules/donotaccessaclosedfile/DoNotAccessAClosedFile.ql
+++ b/c/common/test/rules/donotaccessaclosedfile/DoNotAccessAClosedFile.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotaccessaclosedfile.DoNotAccessAClosedFile
+
+class TestFileQuery extends DoNotAccessAClosedFileSharedQuery, TestQuery { }

--- a/c/common/test/rules/donotallowamutextogooutofscopewhilelocked/DoNotAllowAMutexToGoOutOfScopeWhileLocked.ql
+++ b/c/common/test/rules/donotallowamutextogooutofscopewhilelocked/DoNotAllowAMutexToGoOutOfScopeWhileLocked.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotallowamutextogooutofscopewhilelocked.DoNotAllowAMutexToGoOutOfScopeWhileLocked
+
+class TestFileQuery extends DoNotAllowAMutexToGoOutOfScopeWhileLockedSharedQuery, TestQuery { }

--- a/c/common/test/rules/donotcopyaddressofautostorageobjecttootherobject/DoNotCopyAddressOfAutoStorageObjectToOtherObject.ql
+++ b/c/common/test/rules/donotcopyaddressofautostorageobjecttootherobject/DoNotCopyAddressOfAutoStorageObjectToOtherObject.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotcopyaddressofautostorageobjecttootherobject.DoNotCopyAddressOfAutoStorageObjectToOtherObject
+
+class TestFileQuery extends DoNotCopyAddressOfAutoStorageObjectToOtherObjectSharedQuery, TestQuery { }

--- a/c/common/test/rules/donotdestroyamutexwhileitislocked/DoNotDestroyAMutexWhileItIsLocked.ql
+++ b/c/common/test/rules/donotdestroyamutexwhileitislocked/DoNotDestroyAMutexWhileItIsLocked.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotdestroyamutexwhileitislocked.DoNotDestroyAMutexWhileItIsLocked
+
+class TestFileQuery extends DoNotDestroyAMutexWhileItIsLockedSharedQuery, TestQuery { }

--- a/c/common/test/rules/donotsubtractpointersaddressingdifferentarrays/DoNotSubtractPointersAddressingDifferentArrays.ql
+++ b/c/common/test/rules/donotsubtractpointersaddressingdifferentarrays/DoNotSubtractPointersAddressingDifferentArrays.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotsubtractpointersaddressingdifferentarrays.DoNotSubtractPointersAddressingDifferentArrays
+
+class TestFileQuery extends DoNotSubtractPointersAddressingDifferentArraysSharedQuery, TestQuery { }

--- a/c/common/test/rules/donotusemorethantwolevelsofpointerindirection/DoNotUseMoreThanTwoLevelsOfPointerIndirection.ql
+++ b/c/common/test/rules/donotusemorethantwolevelsofpointerindirection/DoNotUseMoreThanTwoLevelsOfPointerIndirection.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotusemorethantwolevelsofpointerindirection.DoNotUseMoreThanTwoLevelsOfPointerIndirection
+
+class TestFileQuery extends DoNotUseMoreThanTwoLevelsOfPointerIndirectionSharedQuery, TestQuery { }

--- a/c/common/test/rules/donotusepointerarithmetictoaddressdifferentarrays/DoNotUsePointerArithmeticToAddressDifferentArrays.ql
+++ b/c/common/test/rules/donotusepointerarithmetictoaddressdifferentarrays/DoNotUsePointerArithmeticToAddressDifferentArrays.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotusepointerarithmetictoaddressdifferentarrays.DoNotUsePointerArithmeticToAddressDifferentArrays
+
+class TestFileQuery extends DoNotUsePointerArithmeticToAddressDifferentArraysSharedQuery, TestQuery { }

--- a/c/common/test/rules/donotuserandforgeneratingpseudorandomnumbers/DoNotUseRandForGeneratingPseudorandomNumbers.ql
+++ b/c/common/test/rules/donotuserandforgeneratingpseudorandomnumbers/DoNotUseRandForGeneratingPseudorandomNumbers.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotuserandforgeneratingpseudorandomnumbers.DoNotUseRandForGeneratingPseudorandomNumbers
+
+class TestFileQuery extends DoNotUseRandForGeneratingPseudorandomNumbersSharedQuery, TestQuery { }

--- a/c/common/test/rules/donotuserelationaloperatorswithdifferingarrays/DoNotUseRelationalOperatorsWithDifferingArrays.ql
+++ b/c/common/test/rules/donotuserelationaloperatorswithdifferingarrays/DoNotUseRelationalOperatorsWithDifferingArrays.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotuserelationaloperatorswithdifferingarrays.DoNotUseRelationalOperatorsWithDifferingArrays
+
+class TestFileQuery extends DoNotUseRelationalOperatorsWithDifferingArraysSharedQuery, TestQuery { }

--- a/c/common/test/rules/freememorywhennolongerneededshared/FreeMemoryWhenNoLongerNeededShared.ql
+++ b/c/common/test/rules/freememorywhennolongerneededshared/FreeMemoryWhenNoLongerNeededShared.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.freememorywhennolongerneededshared.FreeMemoryWhenNoLongerNeededShared
+
+class TestFileQuery extends FreeMemoryWhenNoLongerNeededSharedSharedQuery, TestQuery { }

--- a/c/common/test/rules/gotostatementcondition/GotoStatementCondition.ql
+++ b/c/common/test/rules/gotostatementcondition/GotoStatementCondition.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.gotostatementcondition.GotoStatementCondition
+
+class TestFileQuery extends GotoStatementConditionSharedQuery, TestQuery { }

--- a/c/common/test/rules/guardaccesstobitfields/GuardAccessToBitFields.ql
+++ b/c/common/test/rules/guardaccesstobitfields/GuardAccessToBitFields.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.guardaccesstobitfields.GuardAccessToBitFields
+
+class TestFileQuery extends GuardAccessToBitFieldsSharedQuery, TestQuery { }

--- a/c/common/test/rules/hashoperatorsused/HashOperatorsUsed.ql
+++ b/c/common/test/rules/hashoperatorsused/HashOperatorsUsed.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.hashoperatorsused.HashOperatorsUsed
+
+class TestFileQuery extends HashOperatorsUsedSharedQuery, TestQuery { }

--- a/c/common/test/rules/identifierhidden/IdentifierHidden.ql
+++ b/c/common/test/rules/identifierhidden/IdentifierHidden.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.identifierhidden.IdentifierHidden
+
+class TestFileQuery extends IdentifierHiddenSharedQuery, TestQuery { }

--- a/c/common/test/rules/identifierwithexternallinkageonedefinitionshared/IdentifierWithExternalLinkageOneDefinitionShared.ql
+++ b/c/common/test/rules/identifierwithexternallinkageonedefinitionshared/IdentifierWithExternalLinkageOneDefinitionShared.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.identifierwithexternallinkageonedefinitionshared.IdentifierWithExternalLinkageOneDefinitionShared
+
+class TestFileQuery extends IdentifierWithExternalLinkageOneDefinitionSharedSharedQuery, TestQuery { }

--- a/c/common/test/rules/ifelseterminationconstruct/IfElseTerminationConstruct.ql
+++ b/c/common/test/rules/ifelseterminationconstruct/IfElseTerminationConstruct.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.ifelseterminationconstruct.IfElseTerminationConstruct
+
+class TestFileQuery extends IfElseTerminationConstructSharedQuery, TestQuery { }

--- a/c/common/test/rules/includeguardsnotused/IncludeGuardsNotUsed.ql
+++ b/c/common/test/rules/includeguardsnotused/IncludeGuardsNotUsed.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.includeguardsnotused.IncludeGuardsNotUsed
+
+class TestFileQuery extends IncludeGuardsNotUsedSharedQuery, TestQuery { }

--- a/c/common/test/rules/informationleakageacrossboundaries/InformationLeakageAcrossBoundaries.ql
+++ b/c/common/test/rules/informationleakageacrossboundaries/InformationLeakageAcrossBoundaries.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.informationleakageacrossboundaries.InformationLeakageAcrossBoundaries
+
+class TestFileQuery extends InformationLeakageAcrossBoundariesSharedQuery, TestQuery { }

--- a/c/common/test/rules/invalidatedenvstringpointers/InvalidatedEnvStringPointers.ql
+++ b/c/common/test/rules/invalidatedenvstringpointers/InvalidatedEnvStringPointers.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.invalidatedenvstringpointers.InvalidatedEnvStringPointers
+
+class TestFileQuery extends InvalidatedEnvStringPointersSharedQuery, TestQuery { }

--- a/c/common/test/rules/invalidatedenvstringpointerswarn/InvalidatedEnvStringPointersWarn.ql
+++ b/c/common/test/rules/invalidatedenvstringpointerswarn/InvalidatedEnvStringPointersWarn.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.invalidatedenvstringpointerswarn.InvalidatedEnvStringPointersWarn
+
+class TestFileQuery extends InvalidatedEnvStringPointersWarnSharedQuery, TestQuery { }

--- a/c/common/test/rules/iofstreammissingpositioning/IOFstreamMissingPositioning.ql
+++ b/c/common/test/rules/iofstreammissingpositioning/IOFstreamMissingPositioning.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.iofstreammissingpositioning.IOFstreamMissingPositioning
+
+class TestFileQuery extends IOFstreamMissingPositioningSharedQuery, TestQuery { }

--- a/c/common/test/rules/macroparameternotenclosedinparentheses/MacroParameterNotEnclosedInParentheses.ql
+++ b/c/common/test/rules/macroparameternotenclosedinparentheses/MacroParameterNotEnclosedInParentheses.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.macroparameternotenclosedinparentheses.MacroParameterNotEnclosedInParentheses
+
+class TestFileQuery extends MacroParameterNotEnclosedInParenthesesSharedQuery, TestQuery { }

--- a/c/common/test/rules/memcmpusedtocomparepaddingdata/MemcmpUsedToComparePaddingData.ql
+++ b/c/common/test/rules/memcmpusedtocomparepaddingdata/MemcmpUsedToComparePaddingData.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.memcmpusedtocomparepaddingdata.MemcmpUsedToComparePaddingData
+
+class TestFileQuery extends MemcmpUsedToComparePaddingDataSharedQuery, TestQuery { }

--- a/c/common/test/rules/missingstaticspecifierfunctionredeclarationshared/MissingStaticSpecifierFunctionRedeclarationShared.ql
+++ b/c/common/test/rules/missingstaticspecifierfunctionredeclarationshared/MissingStaticSpecifierFunctionRedeclarationShared.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.missingstaticspecifierfunctionredeclarationshared.MissingStaticSpecifierFunctionRedeclarationShared
+
+class TestFileQuery extends MissingStaticSpecifierFunctionRedeclarationSharedSharedQuery, TestQuery { }

--- a/c/common/test/rules/nestedlabelinswitch/NestedLabelInSwitch.ql
+++ b/c/common/test/rules/nestedlabelinswitch/NestedLabelInSwitch.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nestedlabelinswitch.NestedLabelInSwitch
+
+class TestFileQuery extends NestedLabelInSwitchSharedQuery, TestQuery { }

--- a/c/common/test/rules/nonconstantformat/NonConstantFormat.ql
+++ b/c/common/test/rules/nonconstantformat/NonConstantFormat.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nonconstantformat.NonConstantFormat
+
+class TestFileQuery extends NonConstantFormatSharedQuery, TestQuery { }

--- a/c/common/test/rules/nonvoidfunctiondoesnotreturn/NonVoidFunctionDoesNotReturn.ql
+++ b/c/common/test/rules/nonvoidfunctiondoesnotreturn/NonVoidFunctionDoesNotReturn.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nonvoidfunctiondoesnotreturn.NonVoidFunctionDoesNotReturn
+
+class TestFileQuery extends NonVoidFunctionDoesNotReturnSharedQuery, TestQuery { }

--- a/c/common/test/rules/notdistinctidentifier/NotDistinctIdentifier.ql
+++ b/c/common/test/rules/notdistinctidentifier/NotDistinctIdentifier.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.notdistinctidentifier.NotDistinctIdentifier
+
+class TestFileQuery extends NotDistinctIdentifierSharedQuery, TestQuery { }

--- a/c/common/test/rules/onlyfreememoryallocateddynamicallyshared/OnlyFreeMemoryAllocatedDynamicallyShared.ql
+++ b/c/common/test/rules/onlyfreememoryallocateddynamicallyshared/OnlyFreeMemoryAllocatedDynamicallyShared.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.onlyfreememoryallocateddynamicallyshared.OnlyFreeMemoryAllocatedDynamicallyShared
+
+class TestFileQuery extends OnlyFreeMemoryAllocatedDynamicallySharedSharedQuery, TestQuery { }

--- a/c/common/test/rules/preprocessingdirectivewithinmacroargument/PreprocessingDirectiveWithinMacroArgument.ql
+++ b/c/common/test/rules/preprocessingdirectivewithinmacroargument/PreprocessingDirectiveWithinMacroArgument.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preprocessingdirectivewithinmacroargument.PreprocessingDirectiveWithinMacroArgument
+
+class TestFileQuery extends PreprocessingDirectiveWithinMacroArgumentSharedQuery, TestQuery { }

--- a/c/common/test/rules/preprocessorincludesforbiddenheadernames/PreprocessorIncludesForbiddenHeaderNames.ql
+++ b/c/common/test/rules/preprocessorincludesforbiddenheadernames/PreprocessorIncludesForbiddenHeaderNames.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preprocessorincludesforbiddenheadernames.PreprocessorIncludesForbiddenHeaderNames
+
+class TestFileQuery extends PreprocessorIncludesForbiddenHeaderNamesSharedQuery, TestQuery { }

--- a/c/common/test/rules/preprocessorincludespreceded/PreprocessorIncludesPreceded.ql
+++ b/c/common/test/rules/preprocessorincludespreceded/PreprocessorIncludesPreceded.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preprocessorincludespreceded.PreprocessorIncludesPreceded
+
+class TestFileQuery extends PreprocessorIncludesPrecededSharedQuery, TestQuery { }

--- a/c/common/test/rules/preservesafetywhenusingconditionvariables/PreserveSafetyWhenUsingConditionVariables.ql
+++ b/c/common/test/rules/preservesafetywhenusingconditionvariables/PreserveSafetyWhenUsingConditionVariables.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preservesafetywhenusingconditionvariables.PreserveSafetyWhenUsingConditionVariables
+
+class TestFileQuery extends PreserveSafetyWhenUsingConditionVariablesSharedQuery, TestQuery { }

--- a/c/common/test/rules/preventdeadlockbylockinginpredefinedorder/PreventDeadlockByLockingInPredefinedOrder.ql
+++ b/c/common/test/rules/preventdeadlockbylockinginpredefinedorder/PreventDeadlockByLockingInPredefinedOrder.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preventdeadlockbylockinginpredefinedorder.PreventDeadlockByLockingInPredefinedOrder
+
+class TestFileQuery extends PreventDeadlockByLockingInPredefinedOrderSharedQuery, TestQuery { }

--- a/c/common/test/rules/readofuninitializedmemory/ReadOfUninitializedMemory.ql
+++ b/c/common/test/rules/readofuninitializedmemory/ReadOfUninitializedMemory.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.readofuninitializedmemory.ReadOfUninitializedMemory
+
+class TestFileQuery extends ReadOfUninitializedMemorySharedQuery, TestQuery { }

--- a/c/common/test/rules/sectionsofcodeshallnotbecommentedout/SectionsOfCodeShallNotBeCommentedOut.ql
+++ b/c/common/test/rules/sectionsofcodeshallnotbecommentedout/SectionsOfCodeShallNotBeCommentedOut.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.sectionsofcodeshallnotbecommentedout.SectionsOfCodeShallNotBeCommentedOut
+
+class TestFileQuery extends SectionsOfCodeShallNotBeCommentedOutSharedQuery, TestQuery { }

--- a/c/common/test/rules/switchcasepositioncondition/SwitchCasePositionCondition.ql
+++ b/c/common/test/rules/switchcasepositioncondition/SwitchCasePositionCondition.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.switchcasepositioncondition.SwitchCasePositionCondition
+
+class TestFileQuery extends SwitchCasePositionConditionSharedQuery, TestQuery { }

--- a/c/common/test/rules/switchnotwellformed/SwitchNotWellFormed.ql
+++ b/c/common/test/rules/switchnotwellformed/SwitchNotWellFormed.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.switchnotwellformed.SwitchNotWellFormed
+
+class TestFileQuery extends SwitchNotWellFormedSharedQuery, TestQuery { }

--- a/c/common/test/rules/typeomitted/TypeOmitted.ql
+++ b/c/common/test/rules/typeomitted/TypeOmitted.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.typeomitted.TypeOmitted
+
+class TestFileQuery extends TypeOmittedSharedQuery, TestQuery { }

--- a/c/common/test/rules/uncheckedrangedomainpoleerrors/UncheckedRangeDomainPoleErrors.ql
+++ b/c/common/test/rules/uncheckedrangedomainpoleerrors/UncheckedRangeDomainPoleErrors.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.uncheckedrangedomainpoleerrors.UncheckedRangeDomainPoleErrors
+
+class TestFileQuery extends UncheckedRangeDomainPoleErrorsSharedQuery, TestQuery { }

--- a/c/common/test/rules/undefinedmacroidentifiers/UndefinedMacroIdentifiers.ql
+++ b/c/common/test/rules/undefinedmacroidentifiers/UndefinedMacroIdentifiers.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.undefinedmacroidentifiers.UndefinedMacroIdentifiers
+
+class TestFileQuery extends UndefinedMacroIdentifiersSharedQuery, TestQuery { }

--- a/c/common/test/rules/unnecessaryexposedidentifierdeclarationshared/UnnecessaryExposedIdentifierDeclarationShared.ql
+++ b/c/common/test/rules/unnecessaryexposedidentifierdeclarationshared/UnnecessaryExposedIdentifierDeclarationShared.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.unnecessaryexposedidentifierdeclarationshared.UnnecessaryExposedIdentifierDeclarationShared
+
+class TestFileQuery extends UnnecessaryExposedIdentifierDeclarationSharedSharedQuery, TestQuery { }

--- a/c/common/test/rules/unreachablecode/UnreachableCode.ql
+++ b/c/common/test/rules/unreachablecode/UnreachableCode.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.unreachablecode.UnreachableCode
+
+class TestFileQuery extends UnreachableCodeSharedQuery, TestQuery { }

--- a/c/common/test/rules/unusedparameter/UnusedParameter.ql
+++ b/c/common/test/rules/unusedparameter/UnusedParameter.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.unusedparameter.UnusedParameter
+
+class TestFileQuery extends UnusedParameterSharedQuery, TestQuery { }

--- a/c/common/test/rules/unusedtypedeclarations/UnusedTypeDeclarations.expected
+++ b/c/common/test/rules/unusedtypedeclarations/UnusedTypeDeclarations.expected
@@ -1,4 +1,3 @@
-| file://:0:0:0:0 | __va_list_tag | Type declaration __va_list_tag is not used. |
 | test.c:4:8:4:8 | A | Type declaration A is not used. |
 | test.c:7:18:7:18 | D | Type declaration D is not used. |
 | test.c:28:11:28:11 | R | Type declaration R is not used. |

--- a/c/common/test/rules/unusedtypedeclarations/UnusedTypeDeclarations.ql
+++ b/c/common/test/rules/unusedtypedeclarations/UnusedTypeDeclarations.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.unusedtypedeclarations.UnusedTypeDeclarations
+
+class TestFileQuery extends UnusedTypeDeclarationsSharedQuery, TestQuery { }

--- a/c/common/test/rules/usageofassemblernotdocumented/UsageOfAssemblerNotDocumented.ql
+++ b/c/common/test/rules/usageofassemblernotdocumented/UsageOfAssemblerNotDocumented.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.usageofassemblernotdocumented.UsageOfAssemblerNotDocumented
+
+class TestFileQuery extends UsageOfAssemblerNotDocumentedSharedQuery, TestQuery { }

--- a/c/common/test/rules/useinitializerbracestomatchaggregatetypestructure/UseInitializerBracesToMatchAggregateTypeStructure.ql
+++ b/c/common/test/rules/useinitializerbracestomatchaggregatetypestructure/UseInitializerBracesToMatchAggregateTypeStructure.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.useinitializerbracestomatchaggregatetypestructure.UseInitializerBracesToMatchAggregateTypeStructure
+
+class TestFileQuery extends UseInitializerBracesToMatchAggregateTypeStructureSharedQuery, TestQuery { }

--- a/c/common/test/rules/useonlyarrayindexingforpointerarithmetic/UseOnlyArrayIndexingForPointerArithmetic.ql
+++ b/c/common/test/rules/useonlyarrayindexingforpointerarithmetic/UseOnlyArrayIndexingForPointerArithmetic.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.useonlyarrayindexingforpointerarithmetic.UseOnlyArrayIndexingForPointerArithmetic
+
+class TestFileQuery extends UseOnlyArrayIndexingForPointerArithmeticSharedQuery, TestQuery { }

--- a/c/common/test/rules/wrapspuriousfunctioninloop/WrapSpuriousFunctionInLoop.ql
+++ b/c/common/test/rules/wrapspuriousfunctioninloop/WrapSpuriousFunctionInLoop.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.wrapspuriousfunctioninloop.WrapSpuriousFunctionInLoop
+
+class TestFileQuery extends WrapSpuriousFunctionInLoopSharedQuery, TestQuery { }

--- a/c/misra/src/rules/RULE-20-10/PreprocessorHashOperatorsShouldNotBeUsed.ql
+++ b/c/misra/src/rules/RULE-20-10/PreprocessorHashOperatorsShouldNotBeUsed.ql
@@ -15,7 +15,7 @@ import cpp
 import codingstandards.c.misra
 import codingstandards.cpp.rules.hashoperatorsused.HashOperatorsUsed
 
-class HashOperatorsUsedInQuery extends HashOperatorsUsedQuery {
+class HashOperatorsUsedInQuery extends HashOperatorsUsedSharedQuery {
   HashOperatorsUsedInQuery() {
     this = Preprocessor1Package::preprocessorHashOperatorsShouldNotBeUsedQuery()
   }

--- a/c/misra/src/rules/RULE-20-2/ForbiddenCharactersInHeaderFileName.ql
+++ b/c/misra/src/rules/RULE-20-2/ForbiddenCharactersInHeaderFileName.ql
@@ -15,7 +15,7 @@ import cpp
 import codingstandards.c.misra
 import codingstandards.cpp.rules.preprocessorincludesforbiddenheadernames.PreprocessorIncludesForbiddenHeaderNames
 
-class PreprocessorIncludesForbiddenHeaderNames extends PreprocessorIncludesForbiddenHeaderNamesQuery {
+class PreprocessorIncludesForbiddenHeaderNames extends PreprocessorIncludesForbiddenHeaderNamesSharedQuery {
   PreprocessorIncludesForbiddenHeaderNames() {
     this = Preprocessor1Package::forbiddenCharactersInHeaderFileNameQuery()
   }

--- a/c/misra/src/rules/RULE-20-9/IdentifiersUsedInPreprocessorExpression.ql
+++ b/c/misra/src/rules/RULE-20-9/IdentifiersUsedInPreprocessorExpression.ql
@@ -17,7 +17,7 @@ import cpp
 import codingstandards.c.misra
 import codingstandards.cpp.rules.undefinedmacroidentifiers.UndefinedMacroIdentifiers
 
-class UndefinedMacroIdentifiersUsedInQuery extends UndefinedMacroIdentifiersQuery {
+class UndefinedMacroIdentifiersUsedInQuery extends UndefinedMacroIdentifiersSharedQuery {
   UndefinedMacroIdentifiersUsedInQuery() {
     this = Preprocessor1Package::identifiersUsedInPreprocessorExpressionQuery()
   }

--- a/cpp/autosar/src/rules/A15-3-5/ClassTypeExceptionNotCaughtByReference.ql
+++ b/cpp/autosar/src/rules/A15-3-5/ClassTypeExceptionNotCaughtByReference.ql
@@ -17,7 +17,7 @@ import cpp
 import codingstandards.cpp.autosar
 import codingstandards.cpp.rules.catchexceptionsbylvaluereference.CatchExceptionsByLvalueReference
 
-class ClassTypeExceptionNotCaughtByReference extends CatchExceptionsByLValueReferenceSharedQuery {
+class ClassTypeExceptionNotCaughtByReference extends CatchExceptionsByLvalueReferenceSharedQuery {
   ClassTypeExceptionNotCaughtByReference() {
     this = Exceptions2Package::classTypeExceptionNotCaughtByReferenceQuery()
   }

--- a/cpp/autosar/src/rules/A16-2-1/CharactersOccurInHeaderFileNameOrInIncludeDirective.ql
+++ b/cpp/autosar/src/rules/A16-2-1/CharactersOccurInHeaderFileNameOrInIncludeDirective.ql
@@ -17,7 +17,7 @@ import cpp
 import codingstandards.cpp.autosar
 import codingstandards.cpp.rules.preprocessorincludesforbiddenheadernames.PreprocessorIncludesForbiddenHeaderNames
 
-class CharactersOccurInHeaderFileNameOrInIncludeDirectiveQuery extends PreprocessorIncludesForbiddenHeaderNamesQuery {
+class CharactersOccurInHeaderFileNameOrInIncludeDirectiveQuery extends PreprocessorIncludesForbiddenHeaderNamesSharedQuery {
   CharactersOccurInHeaderFileNameOrInIncludeDirectiveQuery() {
     this = MacrosPackage::charactersOccurInHeaderFileNameOrInIncludeDirectiveQuery()
   }

--- a/cpp/autosar/src/rules/M16-0-7/UndefinedMacroIdentifiersUsedIn.ql
+++ b/cpp/autosar/src/rules/M16-0-7/UndefinedMacroIdentifiersUsedIn.ql
@@ -19,7 +19,7 @@ import cpp
 import codingstandards.cpp.autosar
 import codingstandards.cpp.rules.undefinedmacroidentifiers.UndefinedMacroIdentifiers
 
-class UndefinedMacroIdentifiersUsedInQuery extends UndefinedMacroIdentifiersQuery {
+class UndefinedMacroIdentifiersUsedInQuery extends UndefinedMacroIdentifiersSharedQuery {
   UndefinedMacroIdentifiersUsedInQuery() {
     this = MacrosPackage::charactersOccurInHeaderFileNameOrInIncludeDirectiveQuery()
   }

--- a/cpp/autosar/src/rules/M16-3-2/HashOperatorsShouldNotBeUsed.ql
+++ b/cpp/autosar/src/rules/M16-3-2/HashOperatorsShouldNotBeUsed.ql
@@ -17,6 +17,6 @@ import cpp
 import codingstandards.cpp.autosar
 import codingstandards.cpp.rules.hashoperatorsused.HashOperatorsUsed
 
-class HashOperatorsShallNotBeUsedInQuery extends HashOperatorsUsedQuery {
+class HashOperatorsShallNotBeUsedInQuery extends HashOperatorsUsedSharedQuery {
   HashOperatorsShallNotBeUsedInQuery() { this = MacrosPackage::hashOperatorsShouldNotBeUsedQuery() }
 }

--- a/cpp/cert/src/rules/ERR61-CPP/CatchExceptionsByLvalueReference.ql
+++ b/cpp/cert/src/rules/ERR61-CPP/CatchExceptionsByLvalueReference.ql
@@ -15,7 +15,7 @@ import cpp
 import codingstandards.cpp.cert
 import codingstandards.cpp.rules.catchexceptionsbylvaluereference.CatchExceptionsByLvalueReference
 
-class CatchExceptionsByLvalueReferenceQuery extends CatchExceptionsByLValueReferenceSharedQuery {
+class CatchExceptionsByLvalueReferenceQuery extends CatchExceptionsByLvalueReferenceSharedQuery {
   CatchExceptionsByLvalueReferenceQuery() {
     this = Exceptions1Package::catchExceptionsByLvalueReferenceQuery()
   }

--- a/cpp/common/src/codingstandards/cpp/exclusions/RuleMetadata.qll
+++ b/cpp/common/src/codingstandards/cpp/exclusions/RuleMetadata.qll
@@ -5,7 +5,9 @@ private import codingstandards.cpp.guideline_recategorizations.GuidelineRecatego
 
 newtype TQuery =
   TQueryCPP(CPPRuleMetadata::TCPPQuery t) or
-  TQueryC(CRuleMetadata::TCQuery t)
+  TQueryC(CRuleMetadata::TCQuery t) or
+  /* A dummy query for testing purposes */
+  TQueryTestDummy()
 
 private predicate isMisraRuleCategory(string category) {
   category = ["disapplied", "advisory", "required", "mandatory"]
@@ -47,18 +49,27 @@ class EffectiveCategory extends TEffectiveCategory {
 
 class Query extends TQuery {
   string getQueryId() {
-    CPPRuleMetadata::isQueryMetadata(this, result, _, _) or
+    CPPRuleMetadata::isQueryMetadata(this, result, _, _)
+    or
     CRuleMetadata::isQueryMetadata(this, result, _, _)
+    or
+    this = TQueryTestDummy() and result = "cpp/test/dummy"
   }
 
   string getRuleId() {
-    CPPRuleMetadata::isQueryMetadata(this, _, result, _) or
+    CPPRuleMetadata::isQueryMetadata(this, _, result, _)
+    or
     CRuleMetadata::isQueryMetadata(this, _, result, _)
+    or
+    this = TQueryTestDummy() and result = "cpp-test-dummy"
   }
 
   string getCategory() {
-    CPPRuleMetadata::isQueryMetadata(this, _, _, result) or
+    CPPRuleMetadata::isQueryMetadata(this, _, _, result)
+    or
     CRuleMetadata::isQueryMetadata(this, _, _, result)
+    or
+    this = TQueryTestDummy() and result = "required"
   }
 
   EffectiveCategory getEffectiveCategory() {
@@ -71,4 +82,9 @@ class Query extends TQuery {
   }
 
   string toString() { result = getQueryId() }
+}
+
+/** A `Query` used for shared query test cases. */
+class TestQuery extends Query {
+  TestQuery() { this = TQueryTestDummy() }
 }

--- a/cpp/common/src/codingstandards/cpp/rules/catchexceptionsbylvaluereference/CatchExceptionsByLvalueReference.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/catchexceptionsbylvaluereference/CatchExceptionsByLvalueReference.qll
@@ -9,9 +9,9 @@ import codingstandards.cpp.Exclusions
 import codingstandards.cpp.TrivialType
 import codingstandards.cpp.exceptions.ExceptionFlow
 
-abstract class CatchExceptionsByLValueReferenceSharedQuery extends Query { }
+abstract class CatchExceptionsByLvalueReferenceSharedQuery extends Query { }
 
-Query getQuery() { result instanceof CatchExceptionsByLValueReferenceSharedQuery }
+Query getQuery() { result instanceof CatchExceptionsByLvalueReferenceSharedQuery }
 
 query predicate problems(Parameter catchParameter, string message) {
   exists(CatchBlock cb, HandlerType catchType |

--- a/cpp/common/src/codingstandards/cpp/rules/hashoperatorsused/HashOperatorsUsed.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/hashoperatorsused/HashOperatorsUsed.qll
@@ -2,9 +2,9 @@ import cpp
 import codingstandards.cpp.Customizations
 import codingstandards.cpp.Exclusions
 
-abstract class HashOperatorsUsedQuery extends Query { }
+abstract class HashOperatorsUsedSharedQuery extends Query { }
 
-Query getQuery() { result instanceof HashOperatorsUsedQuery }
+Query getQuery() { result instanceof HashOperatorsUsedSharedQuery }
 
 query predicate problems(Macro m, string message) {
   exists(string body |

--- a/cpp/common/src/codingstandards/cpp/rules/preprocessorincludesforbiddenheadernames/PreprocessorIncludesForbiddenHeaderNames.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/preprocessorincludesforbiddenheadernames/PreprocessorIncludesForbiddenHeaderNames.qll
@@ -2,9 +2,9 @@ import cpp
 import codingstandards.cpp.Customizations
 import codingstandards.cpp.Exclusions
 
-abstract class PreprocessorIncludesForbiddenHeaderNamesQuery extends Query { }
+abstract class PreprocessorIncludesForbiddenHeaderNamesSharedQuery extends Query { }
 
-Query getQuery() { result instanceof PreprocessorIncludesForbiddenHeaderNamesQuery }
+Query getQuery() { result instanceof PreprocessorIncludesForbiddenHeaderNamesSharedQuery }
 
 class InvalidInclude extends Include {
   InvalidInclude() { this.getIncludeText().regexpMatch("[\"<].*(['\"\\\\]|\\/\\*|\\/\\/).*[\">]") }

--- a/cpp/common/src/codingstandards/cpp/rules/undefinedmacroidentifiers/UndefinedMacroIdentifiers.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/undefinedmacroidentifiers/UndefinedMacroIdentifiers.qll
@@ -1,9 +1,9 @@
 import cpp
 import codingstandards.cpp.Exclusions
 
-abstract class UndefinedMacroIdentifiersQuery extends Query { }
+abstract class UndefinedMacroIdentifiersSharedQuery extends Query { }
 
-Query getQuery() { result instanceof UndefinedMacroIdentifiersQuery }
+Query getQuery() { result instanceof UndefinedMacroIdentifiersSharedQuery }
 
 pragma[noinline]
 predicate isMacroAccessFileAndLine(MacroAccess ma, string filepath, int startLine) {

--- a/cpp/common/test/Linkage/ExternalLinkage.expected
+++ b/cpp/common/test/Linkage/ExternalLinkage.expected
@@ -1,3 +1,4 @@
+| file://:0:0:0:0 | (global namespace) | Element has external linkage |
 | test.cpp:1:5:1:6 | g1 | Element has external linkage |
 | test.cpp:2:12:2:13 | g2 | Element has external linkage |
 | test.cpp:7:11:7:13 | ns1 | Element has external linkage |

--- a/cpp/common/test/Linkage/ExternalLinkage.expected
+++ b/cpp/common/test/Linkage/ExternalLinkage.expected
@@ -1,4 +1,3 @@
-| file://:0:0:0:0 | (global namespace) | Element has external linkage |
 | test.cpp:1:5:1:6 | g1 | Element has external linkage |
 | test.cpp:2:12:2:13 | g2 | Element has external linkage |
 | test.cpp:7:11:7:13 | ns1 | Element has external linkage |

--- a/cpp/common/test/rules/accessofnonexistingmemberthroughpointertomember/AccessOfNonExistingMemberThroughPointerToMember.ql
+++ b/cpp/common/test/rules/accessofnonexistingmemberthroughpointertomember/AccessOfNonExistingMemberThroughPointerToMember.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.accessofnonexistingmemberthroughpointertomember.AccessOfNonExistingMemberThroughPointerToMember
+
+class TestFileQuery extends AccessOfNonExistingMemberThroughPointerToMemberSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/accessofundefinedmemberthroughnullpointer/AccessOfUndefinedMemberThroughNullPointer.ql
+++ b/cpp/common/test/rules/accessofundefinedmemberthroughnullpointer/AccessOfUndefinedMemberThroughNullPointer.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.accessofundefinedmemberthroughnullpointer.AccessOfUndefinedMemberThroughNullPointer
+
+class TestFileQuery extends AccessOfUndefinedMemberThroughNullPointerSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/accessofundefinedmemberthroughuninitializedstaticpointer/AccessOfUndefinedMemberThroughUninitializedStaticPointer.ql
+++ b/cpp/common/test/rules/accessofundefinedmemberthroughuninitializedstaticpointer/AccessOfUndefinedMemberThroughUninitializedStaticPointer.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.accessofundefinedmemberthroughuninitializedstaticpointer.AccessOfUndefinedMemberThroughUninitializedStaticPointer
+
+class TestFileQuery extends AccessOfUndefinedMemberThroughUninitializedStaticPointerSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/basicstringmaynotbenullterminated/BasicStringMayNotBeNullTerminated.ql
+++ b/cpp/common/test/rules/basicstringmaynotbenullterminated/BasicStringMayNotBeNullTerminated.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.basicstringmaynotbenullterminated.BasicStringMayNotBeNullTerminated
+
+class TestFileQuery extends BasicStringMayNotBeNullTerminatedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/catchblockshadowing/CatchBlockShadowing.ql
+++ b/cpp/common/test/rules/catchblockshadowing/CatchBlockShadowing.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.catchblockshadowing.CatchBlockShadowing
+
+class TestFileQuery extends CatchBlockShadowingSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/catchexceptionsbylvaluereference/CatchExceptionsByLvalueReference.ql
+++ b/cpp/common/test/rules/catchexceptionsbylvaluereference/CatchExceptionsByLvalueReference.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.catchexceptionsbylvaluereference.CatchExceptionsByLvalueReference
+
+class TestFileQuery extends CatchExceptionsByLvalueReferenceSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/commaoperatorused/CommaOperatorUsed.ql
+++ b/cpp/common/test/rules/commaoperatorused/CommaOperatorUsed.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.commaoperatorused.CommaOperatorUsed
+
+class TestFileQuery extends CommaOperatorUsedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/conditionvariablepostconditionfailed/ConditionVariablePostConditionFailed.ql
+++ b/cpp/common/test/rules/conditionvariablepostconditionfailed/ConditionVariablePostConditionFailed.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.conditionvariablepostconditionfailed.ConditionVariablePostConditionFailed
+
+class TestFileQuery extends ConditionVariablePostConditionFailedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/constantunsignedintegerexpressionswraparound/ConstantUnsignedIntegerExpressionsWrapAround.ql
+++ b/cpp/common/test/rules/constantunsignedintegerexpressionswraparound/ConstantUnsignedIntegerExpressionsWrapAround.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.constantunsignedintegerexpressionswraparound.ConstantUnsignedIntegerExpressionsWrapAround
+
+class TestFileQuery extends ConstantUnsignedIntegerExpressionsWrapAroundSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/containeraccesswithoutrangecheck/ContainerAccessWithoutRangeCheck.ql
+++ b/cpp/common/test/rules/containeraccesswithoutrangecheck/ContainerAccessWithoutRangeCheck.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.containeraccesswithoutrangecheck.ContainerAccessWithoutRangeCheck
+
+class TestFileQuery extends ContainerAccessWithoutRangeCheckSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/danglingcapturewhenmovinglambdaobject/DanglingCaptureWhenMovingLambdaObject.ql
+++ b/cpp/common/test/rules/danglingcapturewhenmovinglambdaobject/DanglingCaptureWhenMovingLambdaObject.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.danglingcapturewhenmovinglambdaobject.DanglingCaptureWhenMovingLambdaObject
+
+class TestFileQuery extends DanglingCaptureWhenMovingLambdaObjectSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/danglingcapturewhenreturninglambdaobject/DanglingCaptureWhenReturningLambdaObject.ql
+++ b/cpp/common/test/rules/danglingcapturewhenreturninglambdaobject/DanglingCaptureWhenReturningLambdaObject.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.danglingcapturewhenreturninglambdaobject.DanglingCaptureWhenReturningLambdaObject
+
+class TestFileQuery extends DanglingCaptureWhenReturningLambdaObjectSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/deadcode/DeadCode.ql
+++ b/cpp/common/test/rules/deadcode/DeadCode.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.deadcode.DeadCode
+
+class TestFileQuery extends DeadCodeSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/deleteofpointertoincompleteclass/DeleteOfPointerToIncompleteClass.ql
+++ b/cpp/common/test/rules/deleteofpointertoincompleteclass/DeleteOfPointerToIncompleteClass.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.deleteofpointertoincompleteclass.DeleteOfPointerToIncompleteClass
+
+class TestFileQuery extends DeleteOfPointerToIncompleteClassSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/dereferenceofnullpointer/DereferenceOfNullPointer.ql
+++ b/cpp/common/test/rules/dereferenceofnullpointer/DereferenceOfNullPointer.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.dereferenceofnullpointer.DereferenceOfNullPointer
+
+class TestFileQuery extends DereferenceOfNullPointerSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/destroyedvaluereferencedindestructorcatchblock/DestroyedValueReferencedInDestructorCatchBlock.ql
+++ b/cpp/common/test/rules/destroyedvaluereferencedindestructorcatchblock/DestroyedValueReferencedInDestructorCatchBlock.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.destroyedvaluereferencedindestructorcatchblock.DestroyedValueReferencedInDestructorCatchBlock
+
+class TestFileQuery extends DestroyedValueReferencedInDestructorCatchBlockSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/differentidentifiersnottypographicallyunambiguous/DifferentIdentifiersNotTypographicallyUnambiguous.ql
+++ b/cpp/common/test/rules/differentidentifiersnottypographicallyunambiguous/DifferentIdentifiersNotTypographicallyUnambiguous.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.differentidentifiersnottypographicallyunambiguous.DifferentIdentifiersNotTypographicallyUnambiguous
+
+class TestFileQuery extends DifferentIdentifiersNotTypographicallyUnambiguousSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/donotallowamutextogooutofscopewhilelocked/DoNotAllowAMutexToGoOutOfScopeWhileLocked.ql
+++ b/cpp/common/test/rules/donotallowamutextogooutofscopewhilelocked/DoNotAllowAMutexToGoOutOfScopeWhileLocked.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotallowamutextogooutofscopewhilelocked.DoNotAllowAMutexToGoOutOfScopeWhileLocked
+
+class TestFileQuery extends DoNotAllowAMutexToGoOutOfScopeWhileLockedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/donotcopyaddressofautostorageobjecttootherobject/DoNotCopyAddressOfAutoStorageObjectToOtherObject.ql
+++ b/cpp/common/test/rules/donotcopyaddressofautostorageobjecttootherobject/DoNotCopyAddressOfAutoStorageObjectToOtherObject.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotcopyaddressofautostorageobjecttootherobject.DoNotCopyAddressOfAutoStorageObjectToOtherObject
+
+class TestFileQuery extends DoNotCopyAddressOfAutoStorageObjectToOtherObjectSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/donotdestroyamutexwhileitislocked/DoNotDestroyAMutexWhileItIsLocked.ql
+++ b/cpp/common/test/rules/donotdestroyamutexwhileitislocked/DoNotDestroyAMutexWhileItIsLocked.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotdestroyamutexwhileitislocked.DoNotDestroyAMutexWhileItIsLocked
+
+class TestFileQuery extends DoNotDestroyAMutexWhileItIsLockedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/donotsubtractpointersaddressingdifferentarrays/DoNotSubtractPointersAddressingDifferentArrays.ql
+++ b/cpp/common/test/rules/donotsubtractpointersaddressingdifferentarrays/DoNotSubtractPointersAddressingDifferentArrays.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotsubtractpointersaddressingdifferentarrays.DoNotSubtractPointersAddressingDifferentArrays
+
+class TestFileQuery extends DoNotSubtractPointersAddressingDifferentArraysSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/donotusemorethantwolevelsofpointerindirection/DoNotUseMoreThanTwoLevelsOfPointerIndirection.ql
+++ b/cpp/common/test/rules/donotusemorethantwolevelsofpointerindirection/DoNotUseMoreThanTwoLevelsOfPointerIndirection.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotusemorethantwolevelsofpointerindirection.DoNotUseMoreThanTwoLevelsOfPointerIndirection
+
+class TestFileQuery extends DoNotUseMoreThanTwoLevelsOfPointerIndirectionSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/donotusepointerarithmetictoaddressdifferentarrays/DoNotUsePointerArithmeticToAddressDifferentArrays.ql
+++ b/cpp/common/test/rules/donotusepointerarithmetictoaddressdifferentarrays/DoNotUsePointerArithmeticToAddressDifferentArrays.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotusepointerarithmetictoaddressdifferentarrays.DoNotUsePointerArithmeticToAddressDifferentArrays
+
+class TestFileQuery extends DoNotUsePointerArithmeticToAddressDifferentArraysSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/donotuserandforgeneratingpseudorandomnumbers/DoNotUseRandForGeneratingPseudorandomNumbers.ql
+++ b/cpp/common/test/rules/donotuserandforgeneratingpseudorandomnumbers/DoNotUseRandForGeneratingPseudorandomNumbers.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotuserandforgeneratingpseudorandomnumbers.DoNotUseRandForGeneratingPseudorandomNumbers
+
+class TestFileQuery extends DoNotUseRandForGeneratingPseudorandomNumbersSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/donotuserelationaloperatorswithdifferingarrays/DoNotUseRelationalOperatorsWithDifferingArrays.ql
+++ b/cpp/common/test/rules/donotuserelationaloperatorswithdifferingarrays/DoNotUseRelationalOperatorsWithDifferingArrays.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotuserelationaloperatorswithdifferingarrays.DoNotUseRelationalOperatorsWithDifferingArrays
+
+class TestFileQuery extends DoNotUseRelationalOperatorsWithDifferingArraysSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/exceptionsafetyguarantees/ExceptionSafetyGuarantees.ql
+++ b/cpp/common/test/rules/exceptionsafetyguarantees/ExceptionSafetyGuarantees.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.exceptionsafetyguarantees.ExceptionSafetyGuarantees
+
+class TestFileQuery extends ExceptionSafetyGuaranteesSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/exceptionsafetyvalidstate/ExceptionSafetyValidState.ql
+++ b/cpp/common/test/rules/exceptionsafetyvalidstate/ExceptionSafetyValidState.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.exceptionsafetyvalidstate.ExceptionSafetyValidState
+
+class TestFileQuery extends ExceptionSafetyValidStateSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/exithandlerthrowsexception/ExitHandlerThrowsException.ql
+++ b/cpp/common/test/rules/exithandlerthrowsexception/ExitHandlerThrowsException.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.exithandlerthrowsexception.ExitHandlerThrowsException
+
+class TestFileQuery extends ExitHandlerThrowsExceptionSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/explicitabrupttermination/ExplicitAbruptTermination.ql
+++ b/cpp/common/test/rules/explicitabrupttermination/ExplicitAbruptTermination.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.explicitabrupttermination.ExplicitAbruptTermination
+
+class TestFileQuery extends ExplicitAbruptTerminationSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/functionnoreturnattributecondition/FunctionNoReturnAttributeCondition.ql
+++ b/cpp/common/test/rules/functionnoreturnattributecondition/FunctionNoReturnAttributeCondition.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.functionnoreturnattributecondition.FunctionNoReturnAttributeCondition
+
+class TestFileQuery extends FunctionNoReturnAttributeConditionSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/gotostatementcondition/GotoStatementCondition.ql
+++ b/cpp/common/test/rules/gotostatementcondition/GotoStatementCondition.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.gotostatementcondition.GotoStatementCondition
+
+class TestFileQuery extends GotoStatementConditionSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/guardaccesstobitfields/GuardAccessToBitFields.ql
+++ b/cpp/common/test/rules/guardaccesstobitfields/GuardAccessToBitFields.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.guardaccesstobitfields.GuardAccessToBitFields
+
+class TestFileQuery extends GuardAccessToBitFieldsSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/handleallexceptionsduringstartup/HandleAllExceptionsDuringStartup.ql
+++ b/cpp/common/test/rules/handleallexceptionsduringstartup/HandleAllExceptionsDuringStartup.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.handleallexceptionsduringstartup.HandleAllExceptionsDuringStartup
+
+class TestFileQuery extends HandleAllExceptionsDuringStartupSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/hashoperatorsused/HashOperatorsUsed.ql
+++ b/cpp/common/test/rules/hashoperatorsused/HashOperatorsUsed.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.hashoperatorsused.HashOperatorsUsed
+
+class TestFileQuery extends HashOperatorsUsedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/identifierhidden/IdentifierHidden.ql
+++ b/cpp/common/test/rules/identifierhidden/IdentifierHidden.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.identifierhidden.IdentifierHidden
+
+class TestFileQuery extends IdentifierHiddenSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/identifierwithexternallinkageonedefinitionshared/IdentifierWithExternalLinkageOneDefinitionShared.ql
+++ b/cpp/common/test/rules/identifierwithexternallinkageonedefinitionshared/IdentifierWithExternalLinkageOneDefinitionShared.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.identifierwithexternallinkageonedefinitionshared.IdentifierWithExternalLinkageOneDefinitionShared
+
+class TestFileQuery extends IdentifierWithExternalLinkageOneDefinitionSharedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/ifelseterminationconstruct/IfElseTerminationConstruct.ql
+++ b/cpp/common/test/rules/ifelseterminationconstruct/IfElseTerminationConstruct.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.ifelseterminationconstruct.IfElseTerminationConstruct
+
+class TestFileQuery extends IfElseTerminationConstructSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/includeguardsnotused/IncludeGuardsNotUsed.ql
+++ b/cpp/common/test/rules/includeguardsnotused/IncludeGuardsNotUsed.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.includeguardsnotused.IncludeGuardsNotUsed
+
+class TestFileQuery extends IncludeGuardsNotUsedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/informationleakageacrossboundaries/InformationLeakageAcrossBoundaries.ql
+++ b/cpp/common/test/rules/informationleakageacrossboundaries/InformationLeakageAcrossBoundaries.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.informationleakageacrossboundaries.InformationLeakageAcrossBoundaries
+
+class TestFileQuery extends InformationLeakageAcrossBoundariesSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/iofstreammissingpositioning/IOFstreamMissingPositioning.ql
+++ b/cpp/common/test/rules/iofstreammissingpositioning/IOFstreamMissingPositioning.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.iofstreammissingpositioning.IOFstreamMissingPositioning
+
+class TestFileQuery extends IOFstreamMissingPositioningSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/joinablethreadcopiedordestroyed/JoinableThreadCopiedOrDestroyed.ql
+++ b/cpp/common/test/rules/joinablethreadcopiedordestroyed/JoinableThreadCopiedOrDestroyed.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.joinablethreadcopiedordestroyed.JoinableThreadCopiedOrDestroyed
+
+class TestFileQuery extends JoinableThreadCopiedOrDestroyedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/macroparameternotenclosedinparentheses/MacroParameterNotEnclosedInParentheses.ql
+++ b/cpp/common/test/rules/macroparameternotenclosedinparentheses/MacroParameterNotEnclosedInParentheses.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.macroparameternotenclosedinparentheses.MacroParameterNotEnclosedInParentheses
+
+class TestFileQuery extends MacroParameterNotEnclosedInParenthesesSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/memcmpusedtocomparepaddingdata/MemcmpUsedToComparePaddingData.ql
+++ b/cpp/common/test/rules/memcmpusedtocomparepaddingdata/MemcmpUsedToComparePaddingData.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.memcmpusedtocomparepaddingdata.MemcmpUsedToComparePaddingData
+
+class TestFileQuery extends MemcmpUsedToComparePaddingDataSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/missingstaticspecifierfunctionredeclarationshared/MissingStaticSpecifierFunctionRedeclarationShared.ql
+++ b/cpp/common/test/rules/missingstaticspecifierfunctionredeclarationshared/MissingStaticSpecifierFunctionRedeclarationShared.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.missingstaticspecifierfunctionredeclarationshared.MissingStaticSpecifierFunctionRedeclarationShared
+
+class TestFileQuery extends MissingStaticSpecifierFunctionRedeclarationSharedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/movedfromobjectsunspecifiedstate/MovedFromObjectsUnspecifiedState.ql
+++ b/cpp/common/test/rules/movedfromobjectsunspecifiedstate/MovedFromObjectsUnspecifiedState.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.movedfromobjectsunspecifiedstate.MovedFromObjectsUnspecifiedState
+
+class TestFileQuery extends MovedFromObjectsUnspecifiedStateSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/nestedlabelinswitch/NestedLabelInSwitch.ql
+++ b/cpp/common/test/rules/nestedlabelinswitch/NestedLabelInSwitch.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nestedlabelinswitch.NestedLabelInSwitch
+
+class TestFileQuery extends NestedLabelInSwitchSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/nonbooleanifstmt/NonBooleanIfStmt.ql
+++ b/cpp/common/test/rules/nonbooleanifstmt/NonBooleanIfStmt.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nonbooleanifstmt.NonBooleanIfStmt
+
+class TestFileQuery extends NonBooleanIfStmtSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/nonbooleaniterationstmt/NonBooleanIterationStmt.ql
+++ b/cpp/common/test/rules/nonbooleaniterationstmt/NonBooleanIterationStmt.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nonbooleaniterationstmt.NonBooleanIterationStmt
+
+class TestFileQuery extends NonBooleanIterationStmtSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/nonconstantformat/NonConstantFormat.ql
+++ b/cpp/common/test/rules/nonconstantformat/NonConstantFormat.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nonconstantformat.NonConstantFormat
+
+class TestFileQuery extends NonConstantFormatSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/nonstandardentitiesinstandardnamespaces/NonStandardEntitiesInStandardNamespaces.ql
+++ b/cpp/common/test/rules/nonstandardentitiesinstandardnamespaces/NonStandardEntitiesInStandardNamespaces.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nonstandardentitiesinstandardnamespaces.NonStandardEntitiesInStandardNamespaces
+
+class TestFileQuery extends NonStandardEntitiesInStandardNamespacesSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/nonvoidfunctiondoesnotreturn/NonVoidFunctionDoesNotReturn.ql
+++ b/cpp/common/test/rules/nonvoidfunctiondoesnotreturn/NonVoidFunctionDoesNotReturn.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nonvoidfunctiondoesnotreturn.NonVoidFunctionDoesNotReturn
+
+class TestFileQuery extends NonVoidFunctionDoesNotReturnSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/objectaccessedafterlifetime/ObjectAccessedAfterLifetime.ql
+++ b/cpp/common/test/rules/objectaccessedafterlifetime/ObjectAccessedAfterLifetime.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.objectaccessedafterlifetime.ObjectAccessedAfterLifetime
+
+class TestFileQuery extends ObjectAccessedAfterLifetimeSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/objectaccessedbeforelifetime/ObjectAccessedBeforeLifetime.ql
+++ b/cpp/common/test/rules/objectaccessedbeforelifetime/ObjectAccessedBeforeLifetime.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.objectaccessedbeforelifetime.ObjectAccessedBeforeLifetime
+
+class TestFileQuery extends ObjectAccessedBeforeLifetimeSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/onedefinitionruleviolation/OneDefinitionRuleViolation.ql
+++ b/cpp/common/test/rules/onedefinitionruleviolation/OneDefinitionRuleViolation.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.onedefinitionruleviolation.OneDefinitionRuleViolation
+
+class TestFileQuery extends OneDefinitionRuleViolationSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/operationmaynotnullterminatecstylestring/OperationMayNotNullTerminateCStyleString.ql
+++ b/cpp/common/test/rules/operationmaynotnullterminatecstylestring/OperationMayNotNullTerminateCStyleString.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.operationmaynotnullterminatecstylestring.OperationMayNotNullTerminateCStyleString
+
+class TestFileQuery extends OperationMayNotNullTerminateCStyleStringSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/operatordeletemissingpartner/OperatorDeleteMissingPartner.ql
+++ b/cpp/common/test/rules/operatordeletemissingpartner/OperatorDeleteMissingPartner.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.operatordeletemissingpartner.OperatorDeleteMissingPartner
+
+class TestFileQuery extends OperatorDeleteMissingPartnerSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/orderingpredicatemustbestrictlyweak/OrderingPredicateMustBeStrictlyWeak.ql
+++ b/cpp/common/test/rules/orderingpredicatemustbestrictlyweak/OrderingPredicateMustBeStrictlyWeak.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.orderingpredicatemustbestrictlyweak.OrderingPredicateMustBeStrictlyWeak
+
+class TestFileQuery extends OrderingPredicateMustBeStrictlyWeakSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/ownedpointervaluestoredinunrelatedsmartpointer/OwnedPointerValueStoredInUnrelatedSmartPointer.ql
+++ b/cpp/common/test/rules/ownedpointervaluestoredinunrelatedsmartpointer/OwnedPointerValueStoredInUnrelatedSmartPointer.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.ownedpointervaluestoredinunrelatedsmartpointer.OwnedPointerValueStoredInUnrelatedSmartPointer
+
+class TestFileQuery extends OwnedPointerValueStoredInUnrelatedSmartPointerSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/placementnewinsufficientstorage/PlacementNewInsufficientStorage.ql
+++ b/cpp/common/test/rules/placementnewinsufficientstorage/PlacementNewInsufficientStorage.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.placementnewinsufficientstorage.PlacementNewInsufficientStorage
+
+class TestFileQuery extends PlacementNewInsufficientStorageSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/placementnewnotproperlyaligned/PlacementNewNotProperlyAligned.ql
+++ b/cpp/common/test/rules/placementnewnotproperlyaligned/PlacementNewNotProperlyAligned.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.placementnewnotproperlyaligned.PlacementNewNotProperlyAligned
+
+class TestFileQuery extends PlacementNewNotProperlyAlignedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/predicatefunctionobjectsshouldnotbemutable/PredicateFunctionObjectsShouldNotBeMutable.ql
+++ b/cpp/common/test/rules/predicatefunctionobjectsshouldnotbemutable/PredicateFunctionObjectsShouldNotBeMutable.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.predicatefunctionobjectsshouldnotbemutable.PredicateFunctionObjectsShouldNotBeMutable
+
+class TestFileQuery extends PredicateFunctionObjectsShouldNotBeMutableSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/preprocessingdirectivewithinmacroargument/PreprocessingDirectiveWithinMacroArgument.ql
+++ b/cpp/common/test/rules/preprocessingdirectivewithinmacroargument/PreprocessingDirectiveWithinMacroArgument.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preprocessingdirectivewithinmacroargument.PreprocessingDirectiveWithinMacroArgument
+
+class TestFileQuery extends PreprocessingDirectiveWithinMacroArgumentSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/preprocessorincludesforbiddenheadernames/PreprocessorIncludesForbiddenHeaderNames.ql
+++ b/cpp/common/test/rules/preprocessorincludesforbiddenheadernames/PreprocessorIncludesForbiddenHeaderNames.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preprocessorincludesforbiddenheadernames.PreprocessorIncludesForbiddenHeaderNames
+
+class TestFileQuery extends PreprocessorIncludesForbiddenHeaderNamesSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/preprocessorincludespreceded/PreprocessorIncludesPreceded.ql
+++ b/cpp/common/test/rules/preprocessorincludespreceded/PreprocessorIncludesPreceded.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preprocessorincludespreceded.PreprocessorIncludesPreceded
+
+class TestFileQuery extends PreprocessorIncludesPrecededSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/preservesafetywhenusingconditionvariables/PreserveSafetyWhenUsingConditionVariables.ql
+++ b/cpp/common/test/rules/preservesafetywhenusingconditionvariables/PreserveSafetyWhenUsingConditionVariables.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preservesafetywhenusingconditionvariables.PreserveSafetyWhenUsingConditionVariables
+
+class TestFileQuery extends PreserveSafetyWhenUsingConditionVariablesSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/preventdeadlockbylockinginpredefinedorder/PreventDeadlockByLockingInPredefinedOrder.ql
+++ b/cpp/common/test/rules/preventdeadlockbylockinginpredefinedorder/PreventDeadlockByLockingInPredefinedOrder.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preventdeadlockbylockinginpredefinedorder.PreventDeadlockByLockingInPredefinedOrder
+
+class TestFileQuery extends PreventDeadlockByLockingInPredefinedOrderSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/readofuninitializedmemory/ReadOfUninitializedMemory.ql
+++ b/cpp/common/test/rules/readofuninitializedmemory/ReadOfUninitializedMemory.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.readofuninitializedmemory.ReadOfUninitializedMemory
+
+class TestFileQuery extends ReadOfUninitializedMemorySharedQuery, TestQuery { }

--- a/cpp/common/test/rules/removeconstorvolatilequalification/RemoveConstOrVolatileQualification.ql
+++ b/cpp/common/test/rules/removeconstorvolatilequalification/RemoveConstOrVolatileQualification.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.removeconstorvolatilequalification.RemoveConstOrVolatileQualification
+
+class TestFileQuery extends RemoveConstOrVolatileQualificationSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/rethrownestedwithoutcapture/RethrowNestedWithoutCapture.ql
+++ b/cpp/common/test/rules/rethrownestedwithoutcapture/RethrowNestedWithoutCapture.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.rethrownestedwithoutcapture.RethrowNestedWithoutCapture
+
+class TestFileQuery extends RethrowNestedWithoutCaptureSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/sectionsofcodeshallnotbecommentedout/SectionsOfCodeShallNotBeCommentedOut.ql
+++ b/cpp/common/test/rules/sectionsofcodeshallnotbecommentedout/SectionsOfCodeShallNotBeCommentedOut.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.sectionsofcodeshallnotbecommentedout.SectionsOfCodeShallNotBeCommentedOut
+
+class TestFileQuery extends SectionsOfCodeShallNotBeCommentedOutSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/stringnumberconversionmissingerrorcheck/StringNumberConversionMissingErrorCheck.ql
+++ b/cpp/common/test/rules/stringnumberconversionmissingerrorcheck/StringNumberConversionMissingErrorCheck.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.stringnumberconversionmissingerrorcheck.StringNumberConversionMissingErrorCheck
+
+class TestFileQuery extends StringNumberConversionMissingErrorCheckSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/switchcasepositioncondition/SwitchCasePositionCondition.ql
+++ b/cpp/common/test/rules/switchcasepositioncondition/SwitchCasePositionCondition.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.switchcasepositioncondition.SwitchCasePositionCondition
+
+class TestFileQuery extends SwitchCasePositionConditionSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/switchnotwellformed/SwitchNotWellFormed.ql
+++ b/cpp/common/test/rules/switchnotwellformed/SwitchNotWellFormed.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.switchnotwellformed.SwitchNotWellFormed
+
+class TestFileQuery extends SwitchNotWellFormedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/throwingnothrowoperatornewdelete/ThrowingNoThrowOperatorNewDelete.ql
+++ b/cpp/common/test/rules/throwingnothrowoperatornewdelete/ThrowingNoThrowOperatorNewDelete.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.throwingnothrowoperatornewdelete.ThrowingNoThrowOperatorNewDelete
+
+class TestFileQuery extends ThrowingNoThrowOperatorNewDeleteSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/throwingoperatornewreturnsnull/ThrowingOperatorNewReturnsNull.ql
+++ b/cpp/common/test/rules/throwingoperatornewreturnsnull/ThrowingOperatorNewReturnsNull.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.throwingoperatornewreturnsnull.ThrowingOperatorNewReturnsNull
+
+class TestFileQuery extends ThrowingOperatorNewReturnsNullSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/throwingoperatornewthrowsinvalidexception/ThrowingOperatorNewThrowsInvalidException.ql
+++ b/cpp/common/test/rules/throwingoperatornewthrowsinvalidexception/ThrowingOperatorNewThrowsInvalidException.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.throwingoperatornewthrowsinvalidexception.ThrowingOperatorNewThrowsInvalidException
+
+class TestFileQuery extends ThrowingOperatorNewThrowsInvalidExceptionSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/uncheckedrangedomainpoleerrors/UncheckedRangeDomainPoleErrors.ql
+++ b/cpp/common/test/rules/uncheckedrangedomainpoleerrors/UncheckedRangeDomainPoleErrors.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.uncheckedrangedomainpoleerrors.UncheckedRangeDomainPoleErrors
+
+class TestFileQuery extends UncheckedRangeDomainPoleErrorsSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/undefinedmacroidentifiers/UndefinedMacroIdentifiers.ql
+++ b/cpp/common/test/rules/undefinedmacroidentifiers/UndefinedMacroIdentifiers.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.undefinedmacroidentifiers.UndefinedMacroIdentifiers
+
+class TestFileQuery extends UndefinedMacroIdentifiersSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/unnecessaryexposedidentifierdeclarationshared/UnnecessaryExposedIdentifierDeclarationShared.ql
+++ b/cpp/common/test/rules/unnecessaryexposedidentifierdeclarationshared/UnnecessaryExposedIdentifierDeclarationShared.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.unnecessaryexposedidentifierdeclarationshared.UnnecessaryExposedIdentifierDeclarationShared
+
+class TestFileQuery extends UnnecessaryExposedIdentifierDeclarationSharedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/unreachablecode/UnreachableCode.ql
+++ b/cpp/common/test/rules/unreachablecode/UnreachableCode.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.unreachablecode.UnreachableCode
+
+class TestFileQuery extends UnreachableCodeSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/unusedparameter/UnusedParameter.ql
+++ b/cpp/common/test/rules/unusedparameter/UnusedParameter.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.unusedparameter.UnusedParameter
+
+class TestFileQuery extends UnusedParameterSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/unusedtypedeclarations/UnusedTypeDeclarations.expected
+++ b/cpp/common/test/rules/unusedtypedeclarations/UnusedTypeDeclarations.expected
@@ -1,4 +1,3 @@
-| file://:0:0:0:0 | __va_list_tag | Type declaration __va_list_tag is not used. |
 | test.cpp:4:7:4:7 | A | Type declaration A is not used. |
 | test.cpp:6:7:6:7 | B | Type declaration B is not used. |
 | test.cpp:13:11:13:11 | D | Type declaration D is not used. |

--- a/cpp/common/test/rules/unusedtypedeclarations/UnusedTypeDeclarations.ql
+++ b/cpp/common/test/rules/unusedtypedeclarations/UnusedTypeDeclarations.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.unusedtypedeclarations.UnusedTypeDeclarations
+
+class TestFileQuery extends UnusedTypeDeclarationsSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/usageofassemblernotdocumented/UsageOfAssemblerNotDocumented.ql
+++ b/cpp/common/test/rules/usageofassemblernotdocumented/UsageOfAssemblerNotDocumented.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.usageofassemblernotdocumented.UsageOfAssemblerNotDocumented
+
+class TestFileQuery extends UsageOfAssemblerNotDocumentedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/usecanonicalorderformemberinit/UseCanonicalOrderForMemberInit.ql
+++ b/cpp/common/test/rules/usecanonicalorderformemberinit/UseCanonicalOrderForMemberInit.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.usecanonicalorderformemberinit.UseCanonicalOrderForMemberInit
+
+class TestFileQuery extends UseCanonicalOrderForMemberInitSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/useinitializerbracestomatchaggregatetypestructure/UseInitializerBracesToMatchAggregateTypeStructure.ql
+++ b/cpp/common/test/rules/useinitializerbracestomatchaggregatetypestructure/UseInitializerBracesToMatchAggregateTypeStructure.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.useinitializerbracestomatchaggregatetypestructure.UseInitializerBracesToMatchAggregateTypeStructure
+
+class TestFileQuery extends UseInitializerBracesToMatchAggregateTypeStructureSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/useonlyarrayindexingforpointerarithmetic/UseOnlyArrayIndexingForPointerArithmetic.ql
+++ b/cpp/common/test/rules/useonlyarrayindexingforpointerarithmetic/UseOnlyArrayIndexingForPointerArithmetic.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.useonlyarrayindexingforpointerarithmetic.UseOnlyArrayIndexingForPointerArithmetic
+
+class TestFileQuery extends UseOnlyArrayIndexingForPointerArithmeticSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/validcontainerelementaccess/ValidContainerElementAccess.ql
+++ b/cpp/common/test/rules/validcontainerelementaccess/ValidContainerElementAccess.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.validcontainerelementaccess.ValidContainerElementAccess
+
+class TestFileQuery extends ValidContainerElementAccessSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/wrapspuriousfunctioninloop/WrapSpuriousFunctionInLoop.ql
+++ b/cpp/common/test/rules/wrapspuriousfunctioninloop/WrapSpuriousFunctionInLoop.ql
@@ -1,2 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.wrapspuriousfunctioninloop.WrapSpuriousFunctionInLoop
+
+class TestFileQuery extends WrapSpuriousFunctionInLoopSharedQuery, TestQuery { }

--- a/scripts/generate_rules/generate_package_files.py
+++ b/scripts/generate_rules/generate_package_files.py
@@ -181,6 +181,8 @@ def write_shared_implementation(package_name, rule_id, query, language_name, ql_
                 .replace("/", ".")
                 + "\n"
             )
+            f.write("\n");
+            f.write("class TestFileQuery extends " + str(query["shared_implementation_short_name"]) + "SharedQuery, TestQuery { }\n")
 
         # Create an empty test file, if one doesn't already exist
         shared_impl_test_dir.joinpath(


### PR DESCRIPTION
## Description

For shared queries we generate a test query, as the shared query library is not directly testable. This generated query simply imported the shared library. For example, for dead code we had the following:
```codeql
// GENERATED FILE - DO NOT MODIFY
import codingstandards.cpp.rules.deadcode.DeadCode
```
However, the query uses an abstract class mechanism to implement rule-specific exclusions. Again, for `DeadCode.qll` we have:
```codeql
abstract class DeadCodeSharedQuery extends Query { }

Query getQuery() { result instanceof DeadCodeSharedQuery }
...
query predicate problems(Stmt s, string message) {
  not isExcluded(s, getQuery()) and
```
In this way the queries for specific rules can provide the correct `Query` instance, so only deviations for that rule will apply for that query.

Our test framework did not opt into this, as it did not extend the `DeadCodeSharedQuery`. `getQuery()` is therefore empty, which means no exclusions are applied through the `isExcluded` predicate.

The fix is to update our code generator to create an extension of the `..SharedQuery` using a dummy test query. For example:
```
class TestFileQuery extends DeadCodeSharedQuery, TestQuery { }
```

This addresses compiler compatibility test failures marked "Results reported outside the source location" for the following queries:

 * `A15-5-3` (qcc, gcc, clang)
 * `A25-1-1` (qcc, gcc, clang)
 * `A25-4-1` (qcc)
 * `CON53-CPP` (qcc, gcc, clang)
 * `CTR57-CPP` (qcc)
 * `CTR58-CPP` (qcc, gcc, clang)
 * `ERR50-CPP` (qcc, gcc, clang))

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)