### PR TITLE
CON56-CPP QCC Fixes

### DIFF
--- a/cpp/cert/src/rules/CON56-CPP/DoNotSpeculativelyLockALockedNonRecursiveMutex.ql
+++ b/cpp/cert/src/rules/CON56-CPP/DoNotSpeculativelyLockALockedNonRecursiveMutex.ql
@@ -19,10 +19,8 @@ import codingstandards.cpp.Concurrency
 from LockProtectedControlFlowNode n
 where
   not isExcluded(n, ConcurrencyPackage::doNotSpeculativelyLockALockedNonRecursiveMutexQuery()) and
-  // problematic nodes are ones where a lock is active and there is an attempt to
-  // call a speculative locking function
-
-  
+  // problematic nodes are ones where a lock is active and there is an attempt
+  // to call a speculative locking function
   n.(MutexFunctionCall).isSpeculativeLock() and
   not n.(MutexFunctionCall).isRecursive() and
   n.getAProtectingLock() = n.(MutexFunctionCall).getLock()

--- a/cpp/cert/src/rules/CON56-CPP/DoNotSpeculativelyLockALockedNonRecursiveMutex.ql
+++ b/cpp/cert/src/rules/CON56-CPP/DoNotSpeculativelyLockALockedNonRecursiveMutex.ql
@@ -21,6 +21,8 @@ where
   not isExcluded(n, ConcurrencyPackage::doNotSpeculativelyLockALockedNonRecursiveMutexQuery()) and
   // problematic nodes are ones where a lock is active and there is an attempt to
   // call a speculative locking function
+
+  
   n.(MutexFunctionCall).isSpeculativeLock() and
   not n.(MutexFunctionCall).isRecursive() and
   n.getAProtectingLock() = n.(MutexFunctionCall).getLock()

--- a/cpp/cert/src/rules/CON56-CPP/LockedALockedNonRecursiveMutexAudit.ql
+++ b/cpp/cert/src/rules/CON56-CPP/LockedALockedNonRecursiveMutexAudit.ql
@@ -19,10 +19,8 @@ import codingstandards.cpp.Concurrency
 from LockProtectedControlFlowNode n
 where
   not isExcluded(n, ConcurrencyPackage::lockedALockedNonRecursiveMutexAuditQuery()) and
-  // problematic nodes are ones where a lock is active and there is an attempt to
-  // call a speculative locking function
-
-  
+  // problematic nodes are ones where a lock is active and there is an attempt
+  // to call a speculative locking function  
   n.(MutexFunctionCall).isSpeculativeLock() and
   not n.(MutexFunctionCall).isRecursive()
 select n, "(Audit) Attempt to speculatively lock a non-recursive mutex while it is $@.",

--- a/cpp/cert/src/rules/CON56-CPP/LockedALockedNonRecursiveMutexAudit.ql
+++ b/cpp/cert/src/rules/CON56-CPP/LockedALockedNonRecursiveMutexAudit.ql
@@ -21,6 +21,8 @@ where
   not isExcluded(n, ConcurrencyPackage::lockedALockedNonRecursiveMutexAuditQuery()) and
   // problematic nodes are ones where a lock is active and there is an attempt to
   // call a speculative locking function
+
+  
   n.(MutexFunctionCall).isSpeculativeLock() and
   not n.(MutexFunctionCall).isRecursive()
 select n, "(Audit) Attempt to speculatively lock a non-recursive mutex while it is $@.",

--- a/cpp/common/src/codingstandards/cpp/Concurrency.qll
+++ b/cpp/common/src/codingstandards/cpp/Concurrency.qll
@@ -404,9 +404,8 @@ class LockProtectedControlFlowNode extends ThreadedCFN {
         // to the caller to enforce this condition.
         // Because of the way that `getAThreadContextAwarePredecessor` works, it is possible
         // for operations PAST it to be technically part of the predecessors.
-        // Thus, we need to make sure that this lock (to be actually)
-        // an unlock along the same path it must be the case that when we
-        // supply it as the starting point of the search it hits the try lock
+        // Thus, we need to make sure that this node is a 
+        // successor of the unlock in the CFG
         getAThreadContextAwareSuccessor(unlock) = this
       ) and
       (lock instanceof MutexFunctionCall implies not this.(MutexFunctionCall).isUnlock())

--- a/cpp/common/src/codingstandards/cpp/Concurrency.qll
+++ b/cpp/common/src/codingstandards/cpp/Concurrency.qll
@@ -404,7 +404,7 @@ class LockProtectedControlFlowNode extends ThreadedCFN {
         // to the caller to enforce this condition.
         // Because of the way that `getAThreadContextAwarePredecessor` works, it is possible
         // for operations PAST it to be technically part of the predecessors.
-        // Thus, we need to make sure that this node is a 
+        // Thus, we need to make sure that this node is a
         // successor of the unlock in the CFG
         getAThreadContextAwareSuccessor(unlock) = this
       ) and

--- a/cpp/common/src/codingstandards/cpp/Concurrency.qll
+++ b/cpp/common/src/codingstandards/cpp/Concurrency.qll
@@ -231,7 +231,7 @@ pragma[inline]
 ControlFlowNode getAThreadContextAwarePredecessor(ControlFlowNode start, ControlFlowNode end) {
   result = getAThreadContextAwareSuccessor(start) and
   not result = getAThreadContextAwareSuccessor(end) and
-  not result = end 
+  not result = end
 }
 
 /**
@@ -399,16 +399,15 @@ class LockProtectedControlFlowNode extends ThreadedCFN {
       not exists(ControlFlowNode unlock |
         // it's an unlock
         unlock = getAThreadContextAwarePredecessor(lock, this) and
-        unlock.(MutexFunctionCall).isUnlock()
+        unlock.(MutexFunctionCall).isUnlock() and
         // note that we don't check that it's the same lock -- this is left
         // to the caller to enforce this condition.
-
         // Because of the way that `getAThreadContextAwarePredecessor` works, it is possible
-        // for operations PAST it to be technically part of the predecessors. 
-        // Thus, we need to make sure that this lock (to be actually) 
-        // an unlock along the same path it must be the case that when we 
-        // supply it as the starting point of the search it hits the try lock     
-        and getAThreadContextAwareSuccessor(unlock) = this 
+        // for operations PAST it to be technically part of the predecessors.
+        // Thus, we need to make sure that this lock (to be actually)
+        // an unlock along the same path it must be the case that when we
+        // supply it as the starting point of the search it hits the try lock
+        getAThreadContextAwareSuccessor(unlock) = this
       ) and
       (lock instanceof MutexFunctionCall implies not this.(MutexFunctionCall).isUnlock())
     )

--- a/cpp/common/src/codingstandards/cpp/Concurrency.qll
+++ b/cpp/common/src/codingstandards/cpp/Concurrency.qll
@@ -231,7 +231,7 @@ pragma[inline]
 ControlFlowNode getAThreadContextAwarePredecessor(ControlFlowNode start, ControlFlowNode end) {
   result = getAThreadContextAwareSuccessor(start) and
   not result = getAThreadContextAwareSuccessor(end) and
-  not result = end
+  not result = end 
 }
 
 /**
@@ -402,6 +402,13 @@ class LockProtectedControlFlowNode extends ThreadedCFN {
         unlock.(MutexFunctionCall).isUnlock()
         // note that we don't check that it's the same lock -- this is left
         // to the caller to enforce this condition.
+
+        // Because of the way that `getAThreadContextAwarePredecessor` works, it is possible
+        // for operations PAST it to be technically part of the predecessors. 
+        // Thus, we need to make sure that this lock (to be actually) 
+        // an unlock along the same path it must be the case that when we 
+        // supply it as the starting point of the search it hits the try lock     
+        and getAThreadContextAwareSuccessor(unlock) = this 
       ) and
       (lock instanceof MutexFunctionCall implies not this.(MutexFunctionCall).isUnlock())
     )

--- a/cpp/common/test/rules/ownedpointervaluestoredinunrelatedsmartpointer/OwnedPointerValueStoredInUnrelatedSmartPointer.expected.qcc
+++ b/cpp/common/test/rules/ownedpointervaluestoredinunrelatedsmartpointer/OwnedPointerValueStoredInUnrelatedSmartPointer.expected.qcc
@@ -51,7 +51,7 @@ edges
 | test.cpp:17:27:17:28 | v1 | file:///opt/qcc/qnx-sdp/target/qnx7/usr/include/c++/v1/memory:3757:34:3757:36 | __p |
 | test.cpp:17:27:17:28 | v1 | test.cpp:17:27:17:28 | ref arg v1 |
 | test.cpp:19:6:19:7 | v1 | test.cpp:3:14:3:15 | v1 |
- nodes
+nodes
 | file:///opt/qcc/qnx-sdp/target/qnx7/usr/include/c++/v1/memory:2469:31:2469:33 | __p | semmle.label | __p |
 | file:///opt/qcc/qnx-sdp/target/qnx7/usr/include/c++/v1/memory:2469:31:2469:33 | __p | semmle.label | __p |
 | file:///opt/qcc/qnx-sdp/target/qnx7/usr/include/c++/v1/memory:3611:30:3611:32 | __p | semmle.label | __p |
@@ -92,7 +92,7 @@ edges
 | test.cpp:17:27:17:28 | v1 | semmle.label | v1 |
 | test.cpp:17:27:17:28 | v1 | semmle.label | v1 |
 | test.cpp:19:6:19:7 | v1 | semmle.label | v1 |
- subpaths
+subpaths
 | file:///opt/qcc/qnx-sdp/target/qnx7/usr/include/c++/v1/memory:4065:28:4065:30 | __p | file:///opt/qcc/qnx-sdp/target/qnx7/usr/include/c++/v1/memory:2469:31:2469:33 | __p | file:///opt/qcc/qnx-sdp/target/qnx7/usr/include/c++/v1/memory:2469:31:2469:33 | __p | file:///opt/qcc/qnx-sdp/target/qnx7/usr/include/c++/v1/memory:4065:28:4065:30 | ref arg __p |
 | file:///opt/qcc/qnx-sdp/target/qnx7/usr/include/c++/v1/memory:4068:30:4068:32 | __p | file:///opt/qcc/qnx-sdp/target/qnx7/usr/include/c++/v1/memory:3611:30:3611:32 | __p | file:///opt/qcc/qnx-sdp/target/qnx7/usr/include/c++/v1/memory:3611:30:3611:32 | __p | file:///opt/qcc/qnx-sdp/target/qnx7/usr/include/c++/v1/memory:4068:30:4068:32 | ref arg __p |
 | test.cpp:5:27:5:28 | v1 | file:///opt/qcc/qnx-sdp/target/qnx7/usr/include/c++/v1/memory:3757:34:3757:36 | __p | file:///opt/qcc/qnx-sdp/target/qnx7/usr/include/c++/v1/memory:4063:7:4063:17 | constructor init of field __ptr_ [post-this] [__ptr_] | test.cpp:5:27:5:29 | call to shared_ptr [__ptr_] |


### PR DESCRIPTION
## Description

`CON56-CPP`: Fixes issues with compiler compatibility with QCC. 
`MEM56-CPP` `A20-8-1`: Fix typo in expected file

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - CON56-CPP

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)