### PR TITLE
Remove unused classes from queries

### DIFF
--- a/cpp/autosar/src/rules/A15-3-3/MissingCatchHandlerInMain.ql
+++ b/cpp/autosar/src/rules/A15-3-3/MissingCatchHandlerInMain.ql
@@ -22,24 +22,6 @@ import codingstandards.cpp.exceptions.ThirdPartyExceptions
 import codingstandards.cpp.standardlibrary.Exceptions
 import codingstandards.cpp.EncapsulatingFunctions
 
-/** A `TryStmt` which covers the full body of a function. */
-class FullFunctionBodyTryStmt extends TryStmt {
-  FullFunctionBodyTryStmt() {
-    this instanceof FunctionTryStmt
-    or
-    exists(Function f, BlockStmt functionBlock |
-      functionBlock = f.getBlock() and
-      this = functionBlock.getStmt(0) and
-      (
-        functionBlock.getNumStmt() = 1
-        or
-        functionBlock.getNumStmt() = 2 and
-        functionBlock.getStmt(1) instanceof ReturnStmt
-      )
-    )
-  }
-}
-
 /*
  * The strategy for this query is to find a Stmt in the root BlockStmt which can throw one of the
  * ExceptionTypes that should be handled.

--- a/cpp/autosar/src/rules/A7-1-5/AutoSpecifierNotUsedAppropriatelyInVariableDefinition.ql
+++ b/cpp/autosar/src/rules/A7-1-5/AutoSpecifierNotUsedAppropriatelyInVariableDefinition.ql
@@ -19,11 +19,6 @@
 import cpp
 import codingstandards.cpp.autosar
 
-// for readability we define a "fundamental" type
-class FundamentalType extends Type {
-  FundamentalType() { this instanceof BuiltInType }
-}
-
 from Variable v
 where
   not isExcluded(v,


### PR DESCRIPTION
## Description

Remove classes from queries that are reported by the latest CodeQL CLI as being unused.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)