### PR TITLE
Remove unused `internal` imports or use proper non-internal import

### DIFF
--- a/c/cert/src/rules/INT34-C/ExprShiftedbyNegativeOrGreaterPrecisionOperand.ql
+++ b/c/cert/src/rules/INT34-C/ExprShiftedbyNegativeOrGreaterPrecisionOperand.ql
@@ -13,7 +13,7 @@
 import cpp
 import codingstandards.c.cert
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
-import semmle.code.cpp.ir.internal.ASTValueNumbering
+import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import semmle.code.cpp.controlflow.Guards
 
 /*

--- a/c/cert/src/rules/STR31-C/StringsHasSufficientSpaceForTheNullTerminator.ql
+++ b/c/cert/src/rules/STR31-C/StringsHasSufficientSpaceForTheNullTerminator.ql
@@ -16,7 +16,6 @@
 import cpp
 import codingstandards.c.cert
 import semmle.code.cpp.dataflow.TaintTracking
-import semmle.code.cpp.dataflow.internal.TaintTrackingUtil
 import codingstandards.cpp.PossiblyUnsafeStringOperation
 
 /**

--- a/c/cert/src/rules/STR32-C/NonNullTerminatedToFunctionThatExpectsAString.ql
+++ b/c/cert/src/rules/STR32-C/NonNullTerminatedToFunctionThatExpectsAString.ql
@@ -16,7 +16,6 @@ import cpp
 import codingstandards.c.cert
 import codingstandards.cpp.Naming
 import semmle.code.cpp.dataflow.TaintTracking
-import semmle.code.cpp.dataflow.internal.TaintTrackingUtil
 import codingstandards.cpp.PossiblyUnsafeStringOperation
 
 /**

--- a/cpp/common/src/codingstandards/cpp/Expr.qll
+++ b/cpp/common/src/codingstandards/cpp/Expr.qll
@@ -1,5 +1,5 @@
 import cpp
-private import semmle.code.cpp.ir.internal.ASTValueNumbering
+private import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import codingstandards.cpp.AccessPath
 
 /** A full expression as defined in [intro.execution] of N3797. */

--- a/cpp/common/src/codingstandards/cpp/lifetimes/lifetimeprofile/LifetimeProfile.qll
+++ b/cpp/common/src/codingstandards/cpp/lifetimes/lifetimeprofile/LifetimeProfile.qll
@@ -1,6 +1,5 @@
 import cpp
 private import semmle.code.cpp.dataflow.DataFlow
-private import semmle.code.cpp.dataflow.internal.FlowVar
 private import semmle.code.cpp.controlflow.Nullness
 private import codingstandards.cpp.Dereferenced
 private import codingstandards.cpp.Expr

--- a/cpp/common/src/codingstandards/cpp/rules/basicstringmaynotbenullterminated/BasicStringMayNotBeNullTerminated.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/basicstringmaynotbenullterminated/BasicStringMayNotBeNullTerminated.qll
@@ -10,7 +10,6 @@ import semmle.code.cpp.security.BufferWrite
 import semmle.code.cpp.commons.Buffer
 import semmle.code.cpp.dataflow.DataFlow
 import semmle.code.cpp.dataflow.TaintTracking
-import semmle.code.cpp.dataflow.internal.TaintTrackingUtil
 import codingstandards.cpp.PossiblyUnsafeStringOperation
 
 abstract class BasicStringMayNotBeNullTerminatedSharedQuery extends Query { }


### PR DESCRIPTION
## Description

Remove unused `internal` imports or use proper non-internal imports. The internal ones should really never be used.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)