### PR TITLE
Fix exclusion ids for a number of rules

### DIFF
--- a/c/misra/src/rules/DIR-4-12/StdLibDynamicMemoryAllocationUsed.ql
+++ b/c/misra/src/rules/DIR-4-12/StdLibDynamicMemoryAllocationUsed.ql
@@ -23,7 +23,7 @@ import semmle.code.cpp.models.interfaces.Deallocation
 
 from Expr e, string type
 where
-  not isExcluded(e, BannedPackage::memoryAllocDeallocFunctionsOfStdlibhUsedQuery()) and
+  not isExcluded(e, BannedPackage::stdLibDynamicMemoryAllocationUsedQuery()) and
   (
     e.(FunctionCall).getTarget().(AllocationFunction).requiresDealloc() and
     type = "allocation"

--- a/c/misra/src/rules/RULE-11-4/ConversionBetweenPointerToObjectAndIntegerType.ql
+++ b/c/misra/src/rules/RULE-11-4/ConversionBetweenPointerToObjectAndIntegerType.ql
@@ -17,11 +17,10 @@ import codingstandards.c.Pointers
 
 from CStyleCast cast, Type typeFrom, Type typeTo
 where
-  not isExcluded(cast, Pointers1Package::castBetweenObjectPointerAndDifferentObjectTypeQuery()) and
+  not isExcluded(cast, Pointers1Package::conversionBetweenPointerToObjectAndIntegerTypeQuery()) and
   typeFrom = cast.getExpr().getUnderlyingType() and
   typeTo = cast.getUnderlyingType() and
   [typeFrom, typeTo] instanceof IntegralType and
   [typeFrom, typeTo] instanceof PointerToObjectType and
   not isNullPointerConstant(cast.getExpr())
-select cast,
-  "Cast performed between a pointer to object type and a pointer to an integer type."
+select cast, "Cast performed between a pointer to object type and a pointer to an integer type."

--- a/c/misra/src/rules/RULE-21-6/StandardLibraryInputoutputFunctionsUsed.ql
+++ b/c/misra/src/rules/RULE-21-6/StandardLibraryInputoutputFunctionsUsed.ql
@@ -40,7 +40,7 @@ private string wcharInputOutput() {
 
 from FunctionCall fc, Function f
 where
-  not isExcluded(fc, BannedPackage::standardHeaderFileUsedSignalhQuery()) and
+  not isExcluded(fc, BannedPackage::standardLibraryInputoutputFunctionsUsedQuery()) and
   fc.getTarget() = f and
   (
     f.getName() = stdInputOutput() and

--- a/c/misra/src/rules/RULE-21-9/BsearchAndQsortOfStdlibhUsed.ql
+++ b/c/misra/src/rules/RULE-21-9/BsearchAndQsortOfStdlibhUsed.ql
@@ -17,7 +17,7 @@ import codingstandards.c.misra
 
 from FunctionCall fc, Function f
 where
-  not isExcluded(fc, BannedPackage::terminationFunctionsOfStdlibhUsedQuery()) and
+  not isExcluded(fc, BannedPackage::bsearchAndQsortOfStdlibhUsedQuery()) and
   f = fc.getTarget() and
   f.getName() = ["qsort", "bsearch"] and
   f.getFile().getBaseName() = "stdlib.h"

--- a/change_notes/2023-07-5-fix-suppression-ids.md
+++ b/change_notes/2023-07-5-fix-suppression-ids.md
@@ -1,0 +1,6 @@
+ * A number of rules had the wrong query ids attached for deviation purposes. This means they could not be deviated against using the correct ID, but could be incidentally suppressed when deviating a different rule. We have fixed this behavior for the following rules:
+    - `RULE-11-4`
+    - `DIR-4-12`
+    - `RULE-21-6`
+    - `RULE-21-9`
+    - `MEM51-CPP`

--- a/cpp/cert/src/rules/MEM51-CPP/ProperlyDeallocateDynamicallyAllocatedResources.ql
+++ b/cpp/cert/src/rules/MEM51-CPP/ProperlyDeallocateDynamicallyAllocatedResources.ql
@@ -26,7 +26,7 @@ predicate matching(string allocKind, string deleteKind) {
 
 from Expr alloc, Expr free, Expr freed, string allocKind, string deleteKind
 where
-  not isExcluded(freed, FreedPackage::newDeleteArrayMismatchQuery()) and
+  not isExcluded(freed, AllocationsPackage::properlyDeallocateDynamicallyAllocatedResourcesQuery()) and
   allocReaches(freed, alloc, allocKind) and
   freeExprOrIndirect(free, freed, deleteKind) and
   not matching(allocKind, deleteKind)


### PR DESCRIPTION
## Description

Fixes https://github.com/github/codeql-coding-standards/issues/323.

These ids had been copy-pasted incorrectly.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `RULE-11-4`
     - `DIR-4-12`
     - `RULE-21-6`
     - `RULE-21-9`
     - `MEM51-CPP`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)