### PR TITLE
Fix for A5-1-3 false positives

### DIFF
--- a/change_notes/2023-07-11-lambda-expr-without-param-list.md
+++ b/change_notes/2023-07-11-lambda-expr-without-param-list.md
@@ -1,1 +1,1 @@
- - Only consider lambdas that have zero arguments, since any lambda with non-zero arguments will have an explicit argument list. 
+ - `A5-1-3` - Only consider lambdas that have zero arguments, since any lambda with non-zero arguments will have an explicit argument list. 

--- a/change_notes/2023-07-11-lambda-expr-without-param-list.md
+++ b/change_notes/2023-07-11-lambda-expr-without-param-list.md
@@ -1,0 +1,1 @@
+ - Only consider lambdas that have zero arguments, since any lambda with non-zero arguments will have an explicit argument list. 

--- a/cpp/autosar/src/rules/A5-1-3/LambdaExpressionWithoutParameterList.ql
+++ b/cpp/autosar/src/rules/A5-1-3/LambdaExpressionWithoutParameterList.ql
@@ -21,6 +21,10 @@ where
   not isExcluded(lambda, LambdasPackage::lambdaExpressionWithoutParameterListQuery()) and
   lambdaFunction = lambda.getLambdaFunction() and
   not lambdaFunction.isAffectedByMacro() and
+  // If it has a parameter, then it will have an
+  // explicit parameter list. Therefore, proceed to check only if the lambda
+  // does not have any parameters.
+  not exists (lambdaFunction.getAParameter()) and
   // The extractor doesn't store the syntactic information whether the parameter list
   // is enclosed in parenthesis. Therefore we cannot determine if the parameter list is
   // explicitly specified when the parameter list is empty.

--- a/cpp/autosar/test/rules/A5-1-3/test.cpp
+++ b/cpp/autosar/test/rules/A5-1-3/test.cpp
@@ -29,3 +29,11 @@ void test() {
   };
   // clang-format on
 }
+
+#define PARAM_MACRO [](int i) { i; };
+
+int test_lambda_in_macro()
+{
+  PARAM_MACRO // COMPLIANT
+  return 0;
+}

--- a/cpp/autosar/test/rules/A5-1-3/test.cpp
+++ b/cpp/autosar/test/rules/A5-1-3/test.cpp
@@ -32,8 +32,7 @@ void test() {
 
 #define PARAM_MACRO [](int i) { i; };
 
-int test_lambda_in_macro()
-{
+int test_lambda_in_macro() {
   PARAM_MACRO // COMPLIANT
-  return 0;
+      return 0;
 }


### PR DESCRIPTION
## Description

A5-1-3's original implementation raised alerts for cases where lambdas had an explicit argument list. However, it raised a false positive in case the lambda had an argument list but was defined inside a macro.

```cpp
#define PARAM_MACRO [](int i) { i; };

int test_lambda_in_macro()
{
  PARAM_MACRO // False positive here.
  return 0;
}
```
As a fix, A5-1-3 is modified to consider only those lambdas which have zero arguments, as non-zero arguments in a lambda function would require the user to specify an explicit argument list. Adding this check, removed all of the false positives that were seen in the project for this rule.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - A5-1-3

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)