### PR TITLE
Fixes false positives for M0-1-3.

### DIFF
--- a/change_notes/2023-07-26-unused-local-variable.md
+++ b/change_notes/2023-07-26-unused-local-variable.md
@@ -1,0 +1,1 @@
+ - Consider constexpr variables used in template instantiations as "used".

--- a/change_notes/2023-07-26-unused-local-variable.md
+++ b/change_notes/2023-07-26-unused-local-variable.md
@@ -1,1 +1,1 @@
- - Consider constexpr variables used in template instantiations as "used".
+ - `M0-1-3` - Consider constexpr variables used in template instantiations as "used".

--- a/cpp/autosar/src/rules/M0-1-3/UnusedLocalVariable.ql
+++ b/cpp/autosar/src/rules/M0-1-3/UnusedLocalVariable.ql
@@ -18,9 +18,37 @@ import cpp
 import codingstandards.cpp.autosar
 import codingstandards.cpp.deadcode.UnusedVariables
 
+/** Gets the constant value of a constexpr variable. */
+private string getConstExprValue(Variable v) {
+  result = v.getInitializer().getExpr().getValue() and
+  v.isConstexpr()
+}
+
+// This predicate is similar to getUseCount for M0-1-4 except that it also
+// considers static_asserts. This was created to cater for M0-1-3 specifically
+// and hence, doesn't attempt to reuse the M0-1-4 specific predicate
+// - getUseCount()
+int getUseCountConservatively(Variable v) {
+  result =
+        count(VariableAccess access | access = v.getAnAccess() and not access.isCompilerGenerated())
+        + count(UserProvidedConstructorFieldInit cfi | cfi.getTarget() = v) +
+        // For constexpr variables used as template arguments, we don't see accesses (just the
+        // appropriate literals). We therefore take a conservative approach and count the number of
+        // template instantiations that use the given constant, and consider each one to be a use
+        // of the variable
+        count(ClassTemplateInstantiation cti |
+          cti.getTemplateArgument(_).(Expr).getValue() = getConstExprValue(v)
+        )
+        // For static asserts too, check if there is a child which has the same value
+        // as the constexpr variable.
+        + count(StaticAssert s |
+         s.getCondition().getAChild*().getValue() = getConstExprValue(v))
+}
+
 from PotentiallyUnusedLocalVariable v
 where
   not isExcluded(v, DeadCodePackage::unusedLocalVariableQuery()) and
   // Local variable is never accessed
   not exists(v.getAnAccess())
+  and getUseCountConservatively(v) = 0
 select v, "Local variable " + v.getName() + " in " + v.getFunction().getName() + " is not used."

--- a/cpp/autosar/src/rules/M0-1-3/UnusedLocalVariable.ql
+++ b/cpp/autosar/src/rules/M0-1-3/UnusedLocalVariable.ql
@@ -30,7 +30,7 @@ private string getConstExprValue(Variable v) {
 // - getUseCount()
 int getUseCountConservatively(Variable v) {
   result =
-        count(VariableAccess access | access = v.getAnAccess() and not access.isCompilerGenerated())
+        count(VariableAccess access | access = v.getAnAccess())
         + count(UserProvidedConstructorFieldInit cfi | cfi.getTarget() = v) +
         // For constexpr variables used as template arguments, we don't see accesses (just the
         // appropriate literals). We therefore take a conservative approach and count the number of

--- a/cpp/autosar/test/rules/M0-1-3/test.cpp
+++ b/cpp/autosar/test/rules/M0-1-3/test.cpp
@@ -47,6 +47,7 @@ void test_side_effect_init() {
 }
 
 #include <cstdio>
+#include <array>
 template <int t>
 class CharBuffer
 {
@@ -55,13 +56,31 @@ class CharBuffer
   CharBuffer():member{0}{}
 };
 
-int foo()
+int test_constexpr_in_template_inst()
 {
-  constexpr int line_length = 1024U;
+  constexpr int line_length = 1024U; // COMPLIANT - used in template inst.
+                                     // of buffer.
   CharBuffer<line_length> buffer{};
-  constexpr std::size_t max_stack_size_usage = 64 * 1024;
-  static_assert(
-      (sizeof(buffer) + sizeof(line_length)) <= max_stack_size_usage,
-        "assert");
   return buffer.member[0];
+}
+
+enum DataType : unsigned char {
+    int8,
+    int16,
+};
+
+template <typename... Types>
+int test_constexpr_in_static_assert()
+{
+  const std::array <DataType, sizeof...(Types)> lldts {int8};
+  const std::array <DataType, sizeof...(Types)> llams {int16};
+  constexpr std::size_t mssu = 64 * 1024; // COMPLIANT - used in static assert.
+  static_assert((sizeof(lldts) + sizeof(llams)) <= mssu, "assert");
+  return 0;
+}
+
+int baz()
+{
+  test_constexpr_in_static_assert<int>();
+  return 0;
 }

--- a/cpp/autosar/test/rules/M0-1-3/test.cpp
+++ b/cpp/autosar/test/rules/M0-1-3/test.cpp
@@ -46,18 +46,15 @@ void test_side_effect_init() {
         // have side effects
 }
 
-#include <cstdio>
 #include <array>
-template <int t>
-class CharBuffer
-{
-  public:
+#include <cstdio>
+template <int t> class CharBuffer {
+public:
   int member[t];
-  CharBuffer():member{0}{}
+  CharBuffer() : member{0} {}
 };
 
-int test_constexpr_in_template_inst()
-{
+int test_constexpr_in_template_inst() {
   constexpr int line_length = 1024U; // COMPLIANT - used in template inst.
                                      // of buffer.
   CharBuffer<line_length> buffer{};
@@ -65,22 +62,19 @@ int test_constexpr_in_template_inst()
 }
 
 enum DataType : unsigned char {
-    int8,
-    int16,
+  int8,
+  int16,
 };
 
-template <typename... Types>
-int test_constexpr_in_static_assert()
-{
-  const std::array <DataType, sizeof...(Types)> lldts {int8};
-  const std::array <DataType, sizeof...(Types)> llams {int16};
+template <typename... Types> int test_constexpr_in_static_assert() {
+  const std::array<DataType, sizeof...(Types)> lldts{int8};
+  const std::array<DataType, sizeof...(Types)> llams{int16};
   constexpr std::size_t mssu = 64 * 1024; // COMPLIANT - used in static assert.
   static_assert((sizeof(lldts) + sizeof(llams)) <= mssu, "assert");
   return 0;
 }
 
-int baz()
-{
+int baz() {
   test_constexpr_in_static_assert<int>();
   return 0;
 }

--- a/cpp/autosar/test/rules/M0-1-3/test.cpp
+++ b/cpp/autosar/test/rules/M0-1-3/test.cpp
@@ -45,3 +45,23 @@ void test_side_effect_init() {
   LC c; // COMPLIANT - constructor called which is considered to potentially
         // have side effects
 }
+
+#include <cstdio>
+template <int t>
+class CharBuffer
+{
+  public:
+  int member[t];
+  CharBuffer():member{0}{}
+};
+
+int foo()
+{
+  constexpr int line_length = 1024U;
+  CharBuffer<line_length> buffer{};
+  constexpr std::size_t max_stack_size_usage = 64 * 1024;
+  static_assert(
+      (sizeof(buffer) + sizeof(line_length)) <= max_stack_size_usage,
+        "assert");
+  return buffer.member[0];
+}

--- a/rule_packages/cpp/DeadCode.json
+++ b/rule_packages/cpp/DeadCode.json
@@ -238,7 +238,10 @@
           "tags": [
             "readability",
             "maintainability"
-          ]
+          ],
+          "implementation_scope": {
+            "description": "In limited cases, this query can raise false-positives for variables that are defined as constexpr and used in an expression to instantiate a template."
+          }
         },
         {
           "description": "Unused variables complicate the program and can indicate a possible mistake on the part of the programmer.",

--- a/rule_packages/cpp/Templates.json
+++ b/rule_packages/cpp/Templates.json
@@ -190,33 +190,6 @@
           }
       ],
       "title": "In a class template with a dependent base, any name that may be found in that dependent base shall be referred to using a qualified-id or this->."
-    },
-    "M0-1-3": {
-      "properties": {
-        "allocated-target": [
-          "implementation"
-        ],
-        "enforcement": "automated",
-        "obligation": "required"
-      },
-      "queries": [
-        {
-          "description": "Unused variables complicate the program and can indicate a possible mistake on the part of the programmer.",
-          "kind": "problem",
-          "name": "A project shall not contain unused local variables",
-          "precision": "very-high",
-          "severity": "warning",
-          "short_name": "UnusedLocalVariable",
-          "tags": [
-            "maintainability",
-            "readability"
-          ],
-          "implementation_scope": {
-            "description": "In limited cases, this query can raise false-positives for variables that are defined as constexpr and used in an expression to instantiate a template."
-          }
-        }
-      ],
-      "title": "A project shall not contain unused local variables."
     }
   }
 }

--- a/rule_packages/cpp/Templates.json
+++ b/rule_packages/cpp/Templates.json
@@ -190,6 +190,33 @@
           }
       ],
       "title": "In a class template with a dependent base, any name that may be found in that dependent base shall be referred to using a qualified-id or this->."
+    },
+    "M0-1-3": {
+      "properties": {
+        "allocated-target": [
+          "implementation"
+        ],
+        "enforcement": "automated",
+        "obligation": "required"
+      },
+      "queries": [
+        {
+          "description": "Unused variables complicate the program and can indicate a possible mistake on the part of the programmer.",
+          "kind": "problem",
+          "name": "A project shall not contain unused local variables",
+          "precision": "very-high",
+          "severity": "warning",
+          "short_name": "UnusedLocalVariable",
+          "tags": [
+            "maintainability",
+            "readability"
+          ],
+          "implementation_scope": {
+            "description": "In limited cases, this query can raise false-positives for variables that are defined as constexpr and used in an expression to instantiate a template."
+          }
+        }
+      ],
+      "title": "A project shall not contain unused local variables."
     }
   }
 }


### PR DESCRIPTION
## Description

This PR fixes issue [349](https://github.com/github/codeql-coding-standards/issues/349)
Constexpr variables which are used in template instantiations are not considered "used".

### Example

```cpp

template <int t>
class CharBuffer
{
  public:
  int member[t];
  CharBuffer():member{0}{}
};

int foo()
{
  constexpr int line_length = 1024U;
  CharBuffer<line_length> buffer{}; // line_length is used here but reported as a violation for M0-1-3
  return buffer.member[0];
}
```

The fix is to conservatively check that if a template instantiation or a static assert has a constant which is equal to a local variable marked as a constexpr, then the said variable is considered as used.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - M0-1-3

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)