### PR TITLE
Fix CodeQL formatting issues

### DIFF
--- a/.github/workflows/validate-coding-standards.yml
+++ b/.github/workflows/validate-coding-standards.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Validate CodeQL Format (CPP)
         run: |
-          find cpp -name \*.ql -or -name \*.qll -print0 | xargs -0 --max-procs "$XARGS_MAX_PROCS" codeql query format --in-place
+          find cpp \( -name \*.ql -or -name \*.qll \) -print0 | xargs -0 --max-procs "$XARGS_MAX_PROCS" codeql query format --in-place
 
           git diff
           git diff --compact-summary
@@ -97,7 +97,7 @@ jobs:
 
       - name: Validate CodeQL Format (C)
         run: |
-          find c -name \*.ql -or -name \*.qll -print0 | xargs -0 --max-procs "$XARGS_MAX_PROCS" codeql query format --in-place
+          find c \( -name \*.ql -or -name \*.qll \) -print0 | xargs -0 --max-procs "$XARGS_MAX_PROCS" codeql query format --in-place
 
           git diff
           git diff --compact-summary

--- a/c/common/test/rules/closefilehandlewhennolongerneededshared/CloseFileHandleWhenNoLongerNeededShared.ql
+++ b/c/common/test/rules/closefilehandlewhennolongerneededshared/CloseFileHandleWhenNoLongerNeededShared.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.closefilehandlewhennolongerneededshared.CloseFileHandleWhenNoLongerNeededShared
 
-class TestFileQuery extends CloseFileHandleWhenNoLongerNeededSharedSharedQuery, TestQuery {
-}
+class TestFileQuery extends CloseFileHandleWhenNoLongerNeededSharedSharedQuery, TestQuery { }

--- a/c/common/test/rules/commaoperatorused/CommaOperatorUsed.ql
+++ b/c/common/test/rules/commaoperatorused/CommaOperatorUsed.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.commaoperatorused.CommaOperatorUsed
 
-class TestFileQuery extends CommaOperatorUsedSharedQuery, TestQuery {
-}
+class TestFileQuery extends CommaOperatorUsedSharedQuery, TestQuery { }

--- a/c/common/test/rules/constantunsignedintegerexpressionswraparound/ConstantUnsignedIntegerExpressionsWrapAround.ql
+++ b/c/common/test/rules/constantunsignedintegerexpressionswraparound/ConstantUnsignedIntegerExpressionsWrapAround.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.constantunsignedintegerexpressionswraparound.ConstantUnsignedIntegerExpressionsWrapAround
 
-class TestFileQuery extends ConstantUnsignedIntegerExpressionsWrapAroundSharedQuery, TestQuery {
-}
+class TestFileQuery extends ConstantUnsignedIntegerExpressionsWrapAroundSharedQuery, TestQuery { }

--- a/c/common/test/rules/constlikereturnvalue/ConstLikeReturnValue.ql
+++ b/c/common/test/rules/constlikereturnvalue/ConstLikeReturnValue.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.constlikereturnvalue.ConstLikeReturnValue
 
-class TestFileQuery extends ConstLikeReturnValueSharedQuery, TestQuery {
-}
+class TestFileQuery extends ConstLikeReturnValueSharedQuery, TestQuery { }

--- a/c/common/test/rules/deadcode/DeadCode.ql
+++ b/c/common/test/rules/deadcode/DeadCode.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.deadcode.DeadCode
 
-class TestFileQuery extends DeadCodeSharedQuery, TestQuery {
-}
+class TestFileQuery extends DeadCodeSharedQuery, TestQuery { }

--- a/c/common/test/rules/declaredareservedidentifier/DeclaredAReservedIdentifier.ql
+++ b/c/common/test/rules/declaredareservedidentifier/DeclaredAReservedIdentifier.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.declaredareservedidentifier.DeclaredAReservedIdentifier
 
-class TestFileQuery extends DeclaredAReservedIdentifierSharedQuery, TestQuery {
-}
+class TestFileQuery extends DeclaredAReservedIdentifierSharedQuery, TestQuery { }

--- a/c/common/test/rules/dereferenceofnullpointer/DereferenceOfNullPointer.ql
+++ b/c/common/test/rules/dereferenceofnullpointer/DereferenceOfNullPointer.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.dereferenceofnullpointer.DereferenceOfNullPointer
 
-class TestFileQuery extends DereferenceOfNullPointerSharedQuery, TestQuery {
-}
+class TestFileQuery extends DereferenceOfNullPointerSharedQuery, TestQuery { }

--- a/c/common/test/rules/donotaccessaclosedfile/DoNotAccessAClosedFile.ql
+++ b/c/common/test/rules/donotaccessaclosedfile/DoNotAccessAClosedFile.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotaccessaclosedfile.DoNotAccessAClosedFile
 
-class TestFileQuery extends DoNotAccessAClosedFileSharedQuery, TestQuery {
-}
+class TestFileQuery extends DoNotAccessAClosedFileSharedQuery, TestQuery { }

--- a/c/common/test/rules/donotallowamutextogooutofscopewhilelocked/DoNotAllowAMutexToGoOutOfScopeWhileLocked.ql
+++ b/c/common/test/rules/donotallowamutextogooutofscopewhilelocked/DoNotAllowAMutexToGoOutOfScopeWhileLocked.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotallowamutextogooutofscopewhilelocked.DoNotAllowAMutexToGoOutOfScopeWhileLocked
 
-class TestFileQuery extends DoNotAllowAMutexToGoOutOfScopeWhileLockedSharedQuery, TestQuery {
-}
+class TestFileQuery extends DoNotAllowAMutexToGoOutOfScopeWhileLockedSharedQuery, TestQuery { }

--- a/c/common/test/rules/donotdestroyamutexwhileitislocked/DoNotDestroyAMutexWhileItIsLocked.ql
+++ b/c/common/test/rules/donotdestroyamutexwhileitislocked/DoNotDestroyAMutexWhileItIsLocked.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotdestroyamutexwhileitislocked.DoNotDestroyAMutexWhileItIsLocked
 
-class TestFileQuery extends DoNotDestroyAMutexWhileItIsLockedSharedQuery, TestQuery {
-}
+class TestFileQuery extends DoNotDestroyAMutexWhileItIsLockedSharedQuery, TestQuery { }

--- a/c/common/test/rules/donotsubtractpointersaddressingdifferentarrays/DoNotSubtractPointersAddressingDifferentArrays.ql
+++ b/c/common/test/rules/donotsubtractpointersaddressingdifferentarrays/DoNotSubtractPointersAddressingDifferentArrays.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotsubtractpointersaddressingdifferentarrays.DoNotSubtractPointersAddressingDifferentArrays
 
-class TestFileQuery extends DoNotSubtractPointersAddressingDifferentArraysSharedQuery, TestQuery {
-}
+class TestFileQuery extends DoNotSubtractPointersAddressingDifferentArraysSharedQuery, TestQuery { }

--- a/c/common/test/rules/donotusemorethantwolevelsofpointerindirection/DoNotUseMoreThanTwoLevelsOfPointerIndirection.ql
+++ b/c/common/test/rules/donotusemorethantwolevelsofpointerindirection/DoNotUseMoreThanTwoLevelsOfPointerIndirection.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotusemorethantwolevelsofpointerindirection.DoNotUseMoreThanTwoLevelsOfPointerIndirection
 
-class TestFileQuery extends DoNotUseMoreThanTwoLevelsOfPointerIndirectionSharedQuery, TestQuery {
-}
+class TestFileQuery extends DoNotUseMoreThanTwoLevelsOfPointerIndirectionSharedQuery, TestQuery { }

--- a/c/common/test/rules/donotuserandforgeneratingpseudorandomnumbers/DoNotUseRandForGeneratingPseudorandomNumbers.ql
+++ b/c/common/test/rules/donotuserandforgeneratingpseudorandomnumbers/DoNotUseRandForGeneratingPseudorandomNumbers.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotuserandforgeneratingpseudorandomnumbers.DoNotUseRandForGeneratingPseudorandomNumbers
 
-class TestFileQuery extends DoNotUseRandForGeneratingPseudorandomNumbersSharedQuery, TestQuery {
-}
+class TestFileQuery extends DoNotUseRandForGeneratingPseudorandomNumbersSharedQuery, TestQuery { }

--- a/c/common/test/rules/donotuserelationaloperatorswithdifferingarrays/DoNotUseRelationalOperatorsWithDifferingArrays.ql
+++ b/c/common/test/rules/donotuserelationaloperatorswithdifferingarrays/DoNotUseRelationalOperatorsWithDifferingArrays.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotuserelationaloperatorswithdifferingarrays.DoNotUseRelationalOperatorsWithDifferingArrays
 
-class TestFileQuery extends DoNotUseRelationalOperatorsWithDifferingArraysSharedQuery, TestQuery {
-}
+class TestFileQuery extends DoNotUseRelationalOperatorsWithDifferingArraysSharedQuery, TestQuery { }

--- a/c/common/test/rules/freememorywhennolongerneededshared/FreeMemoryWhenNoLongerNeededShared.ql
+++ b/c/common/test/rules/freememorywhennolongerneededshared/FreeMemoryWhenNoLongerNeededShared.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.freememorywhennolongerneededshared.FreeMemoryWhenNoLongerNeededShared
 
-class TestFileQuery extends FreeMemoryWhenNoLongerNeededSharedSharedQuery, TestQuery {
-}
+class TestFileQuery extends FreeMemoryWhenNoLongerNeededSharedSharedQuery, TestQuery { }

--- a/c/common/test/rules/gotostatementcondition/GotoStatementCondition.ql
+++ b/c/common/test/rules/gotostatementcondition/GotoStatementCondition.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.gotostatementcondition.GotoStatementCondition
 
-class TestFileQuery extends GotoStatementConditionSharedQuery, TestQuery {
-}
+class TestFileQuery extends GotoStatementConditionSharedQuery, TestQuery { }

--- a/c/common/test/rules/guardaccesstobitfields/GuardAccessToBitFields.ql
+++ b/c/common/test/rules/guardaccesstobitfields/GuardAccessToBitFields.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.guardaccesstobitfields.GuardAccessToBitFields
 
-class TestFileQuery extends GuardAccessToBitFieldsSharedQuery, TestQuery {
-}
+class TestFileQuery extends GuardAccessToBitFieldsSharedQuery, TestQuery { }

--- a/c/common/test/rules/hashoperatorsused/HashOperatorsUsed.ql
+++ b/c/common/test/rules/hashoperatorsused/HashOperatorsUsed.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.hashoperatorsused.HashOperatorsUsed
 
-class TestFileQuery extends HashOperatorsUsedSharedQuery, TestQuery {
-}
+class TestFileQuery extends HashOperatorsUsedSharedQuery, TestQuery { }

--- a/c/common/test/rules/identifierhidden/IdentifierHidden.ql
+++ b/c/common/test/rules/identifierhidden/IdentifierHidden.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.identifierhidden.IdentifierHidden
 
-class TestFileQuery extends IdentifierHiddenSharedQuery, TestQuery {
-}
+class TestFileQuery extends IdentifierHiddenSharedQuery, TestQuery { }

--- a/c/common/test/rules/ifelseterminationconstruct/IfElseTerminationConstruct.ql
+++ b/c/common/test/rules/ifelseterminationconstruct/IfElseTerminationConstruct.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.ifelseterminationconstruct.IfElseTerminationConstruct
 
-class TestFileQuery extends IfElseTerminationConstructSharedQuery, TestQuery {
-}
+class TestFileQuery extends IfElseTerminationConstructSharedQuery, TestQuery { }

--- a/c/common/test/rules/includeguardsnotused/IncludeGuardsNotUsed.ql
+++ b/c/common/test/rules/includeguardsnotused/IncludeGuardsNotUsed.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.includeguardsnotused.IncludeGuardsNotUsed
 
-class TestFileQuery extends IncludeGuardsNotUsedSharedQuery, TestQuery {
-}
+class TestFileQuery extends IncludeGuardsNotUsedSharedQuery, TestQuery { }

--- a/c/common/test/rules/informationleakageacrossboundaries/InformationLeakageAcrossBoundaries.ql
+++ b/c/common/test/rules/informationleakageacrossboundaries/InformationLeakageAcrossBoundaries.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.informationleakageacrossboundaries.InformationLeakageAcrossBoundaries
 
-class TestFileQuery extends InformationLeakageAcrossBoundariesSharedQuery, TestQuery {
-}
+class TestFileQuery extends InformationLeakageAcrossBoundariesSharedQuery, TestQuery { }

--- a/c/common/test/rules/invalidatedenvstringpointers/InvalidatedEnvStringPointers.ql
+++ b/c/common/test/rules/invalidatedenvstringpointers/InvalidatedEnvStringPointers.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.invalidatedenvstringpointers.InvalidatedEnvStringPointers
 
-class TestFileQuery extends InvalidatedEnvStringPointersSharedQuery, TestQuery {
-}
+class TestFileQuery extends InvalidatedEnvStringPointersSharedQuery, TestQuery { }

--- a/c/common/test/rules/invalidatedenvstringpointerswarn/InvalidatedEnvStringPointersWarn.ql
+++ b/c/common/test/rules/invalidatedenvstringpointerswarn/InvalidatedEnvStringPointersWarn.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.invalidatedenvstringpointerswarn.InvalidatedEnvStringPointersWarn
 
-class TestFileQuery extends InvalidatedEnvStringPointersWarnSharedQuery, TestQuery {
-}
+class TestFileQuery extends InvalidatedEnvStringPointersWarnSharedQuery, TestQuery { }

--- a/c/common/test/rules/iofstreammissingpositioning/IOFstreamMissingPositioning.ql
+++ b/c/common/test/rules/iofstreammissingpositioning/IOFstreamMissingPositioning.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.iofstreammissingpositioning.IOFstreamMissingPositioning
 
-class TestFileQuery extends IOFstreamMissingPositioningSharedQuery, TestQuery {
-}
+class TestFileQuery extends IOFstreamMissingPositioningSharedQuery, TestQuery { }

--- a/c/common/test/rules/macroparameternotenclosedinparentheses/MacroParameterNotEnclosedInParentheses.ql
+++ b/c/common/test/rules/macroparameternotenclosedinparentheses/MacroParameterNotEnclosedInParentheses.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.macroparameternotenclosedinparentheses.MacroParameterNotEnclosedInParentheses
 
-class TestFileQuery extends MacroParameterNotEnclosedInParenthesesSharedQuery, TestQuery {
-}
+class TestFileQuery extends MacroParameterNotEnclosedInParenthesesSharedQuery, TestQuery { }

--- a/c/common/test/rules/memcmpusedtocomparepaddingdata/MemcmpUsedToComparePaddingData.ql
+++ b/c/common/test/rules/memcmpusedtocomparepaddingdata/MemcmpUsedToComparePaddingData.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.memcmpusedtocomparepaddingdata.MemcmpUsedToComparePaddingData
 
-class TestFileQuery extends MemcmpUsedToComparePaddingDataSharedQuery, TestQuery {
-}
+class TestFileQuery extends MemcmpUsedToComparePaddingDataSharedQuery, TestQuery { }

--- a/c/common/test/rules/nestedlabelinswitch/NestedLabelInSwitch.ql
+++ b/c/common/test/rules/nestedlabelinswitch/NestedLabelInSwitch.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nestedlabelinswitch.NestedLabelInSwitch
 
-class TestFileQuery extends NestedLabelInSwitchSharedQuery, TestQuery {
-}
+class TestFileQuery extends NestedLabelInSwitchSharedQuery, TestQuery { }

--- a/c/common/test/rules/nonconstantformat/NonConstantFormat.ql
+++ b/c/common/test/rules/nonconstantformat/NonConstantFormat.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nonconstantformat.NonConstantFormat
 
-class TestFileQuery extends NonConstantFormatSharedQuery, TestQuery {
-}
+class TestFileQuery extends NonConstantFormatSharedQuery, TestQuery { }

--- a/c/common/test/rules/nonvoidfunctiondoesnotreturn/NonVoidFunctionDoesNotReturn.ql
+++ b/c/common/test/rules/nonvoidfunctiondoesnotreturn/NonVoidFunctionDoesNotReturn.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nonvoidfunctiondoesnotreturn.NonVoidFunctionDoesNotReturn
 
-class TestFileQuery extends NonVoidFunctionDoesNotReturnSharedQuery, TestQuery {
-}
+class TestFileQuery extends NonVoidFunctionDoesNotReturnSharedQuery, TestQuery { }

--- a/c/common/test/rules/notdistinctidentifier/NotDistinctIdentifier.ql
+++ b/c/common/test/rules/notdistinctidentifier/NotDistinctIdentifier.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.notdistinctidentifier.NotDistinctIdentifier
 
-class TestFileQuery extends NotDistinctIdentifierSharedQuery, TestQuery {
-}
+class TestFileQuery extends NotDistinctIdentifierSharedQuery, TestQuery { }

--- a/c/common/test/rules/onlyfreememoryallocateddynamicallyshared/OnlyFreeMemoryAllocatedDynamicallyShared.ql
+++ b/c/common/test/rules/onlyfreememoryallocateddynamicallyshared/OnlyFreeMemoryAllocatedDynamicallyShared.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.onlyfreememoryallocateddynamicallyshared.OnlyFreeMemoryAllocatedDynamicallyShared
 
-class TestFileQuery extends OnlyFreeMemoryAllocatedDynamicallySharedSharedQuery, TestQuery {
-}
+class TestFileQuery extends OnlyFreeMemoryAllocatedDynamicallySharedSharedQuery, TestQuery { }

--- a/c/common/test/rules/preprocessingdirectivewithinmacroargument/PreprocessingDirectiveWithinMacroArgument.ql
+++ b/c/common/test/rules/preprocessingdirectivewithinmacroargument/PreprocessingDirectiveWithinMacroArgument.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preprocessingdirectivewithinmacroargument.PreprocessingDirectiveWithinMacroArgument
 
-class TestFileQuery extends PreprocessingDirectiveWithinMacroArgumentSharedQuery, TestQuery {
-}
+class TestFileQuery extends PreprocessingDirectiveWithinMacroArgumentSharedQuery, TestQuery { }

--- a/c/common/test/rules/preprocessorincludesforbiddenheadernames/PreprocessorIncludesForbiddenHeaderNames.ql
+++ b/c/common/test/rules/preprocessorincludesforbiddenheadernames/PreprocessorIncludesForbiddenHeaderNames.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preprocessorincludesforbiddenheadernames.PreprocessorIncludesForbiddenHeaderNames
 
-class TestFileQuery extends PreprocessorIncludesForbiddenHeaderNamesSharedQuery, TestQuery {
-}
+class TestFileQuery extends PreprocessorIncludesForbiddenHeaderNamesSharedQuery, TestQuery { }

--- a/c/common/test/rules/preprocessorincludespreceded/PreprocessorIncludesPreceded.ql
+++ b/c/common/test/rules/preprocessorincludespreceded/PreprocessorIncludesPreceded.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preprocessorincludespreceded.PreprocessorIncludesPreceded
 
-class TestFileQuery extends PreprocessorIncludesPrecededSharedQuery, TestQuery {
-}
+class TestFileQuery extends PreprocessorIncludesPrecededSharedQuery, TestQuery { }

--- a/c/common/test/rules/preservesafetywhenusingconditionvariables/PreserveSafetyWhenUsingConditionVariables.ql
+++ b/c/common/test/rules/preservesafetywhenusingconditionvariables/PreserveSafetyWhenUsingConditionVariables.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preservesafetywhenusingconditionvariables.PreserveSafetyWhenUsingConditionVariables
 
-class TestFileQuery extends PreserveSafetyWhenUsingConditionVariablesSharedQuery, TestQuery {
-}
+class TestFileQuery extends PreserveSafetyWhenUsingConditionVariablesSharedQuery, TestQuery { }

--- a/c/common/test/rules/preventdeadlockbylockinginpredefinedorder/PreventDeadlockByLockingInPredefinedOrder.ql
+++ b/c/common/test/rules/preventdeadlockbylockinginpredefinedorder/PreventDeadlockByLockingInPredefinedOrder.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preventdeadlockbylockinginpredefinedorder.PreventDeadlockByLockingInPredefinedOrder
 
-class TestFileQuery extends PreventDeadlockByLockingInPredefinedOrderSharedQuery, TestQuery {
-}
+class TestFileQuery extends PreventDeadlockByLockingInPredefinedOrderSharedQuery, TestQuery { }

--- a/c/common/test/rules/readofuninitializedmemory/ReadOfUninitializedMemory.ql
+++ b/c/common/test/rules/readofuninitializedmemory/ReadOfUninitializedMemory.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.readofuninitializedmemory.ReadOfUninitializedMemory
 
-class TestFileQuery extends ReadOfUninitializedMemorySharedQuery, TestQuery {
-}
+class TestFileQuery extends ReadOfUninitializedMemorySharedQuery, TestQuery { }

--- a/c/common/test/rules/sectionsofcodeshallnotbecommentedout/SectionsOfCodeShallNotBeCommentedOut.ql
+++ b/c/common/test/rules/sectionsofcodeshallnotbecommentedout/SectionsOfCodeShallNotBeCommentedOut.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.sectionsofcodeshallnotbecommentedout.SectionsOfCodeShallNotBeCommentedOut
 
-class TestFileQuery extends SectionsOfCodeShallNotBeCommentedOutSharedQuery, TestQuery {
-}
+class TestFileQuery extends SectionsOfCodeShallNotBeCommentedOutSharedQuery, TestQuery { }

--- a/c/common/test/rules/switchcasepositioncondition/SwitchCasePositionCondition.ql
+++ b/c/common/test/rules/switchcasepositioncondition/SwitchCasePositionCondition.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.switchcasepositioncondition.SwitchCasePositionCondition
 
-class TestFileQuery extends SwitchCasePositionConditionSharedQuery, TestQuery {
-}
+class TestFileQuery extends SwitchCasePositionConditionSharedQuery, TestQuery { }

--- a/c/common/test/rules/switchnotwellformed/SwitchNotWellFormed.ql
+++ b/c/common/test/rules/switchnotwellformed/SwitchNotWellFormed.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.switchnotwellformed.SwitchNotWellFormed
 
-class TestFileQuery extends SwitchNotWellFormedSharedQuery, TestQuery {
-}
+class TestFileQuery extends SwitchNotWellFormedSharedQuery, TestQuery { }

--- a/c/common/test/rules/typeomitted/TypeOmitted.ql
+++ b/c/common/test/rules/typeomitted/TypeOmitted.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.typeomitted.TypeOmitted
 
-class TestFileQuery extends TypeOmittedSharedQuery, TestQuery {
-}
+class TestFileQuery extends TypeOmittedSharedQuery, TestQuery { }

--- a/c/common/test/rules/uncheckedrangedomainpoleerrors/UncheckedRangeDomainPoleErrors.ql
+++ b/c/common/test/rules/uncheckedrangedomainpoleerrors/UncheckedRangeDomainPoleErrors.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.uncheckedrangedomainpoleerrors.UncheckedRangeDomainPoleErrors
 
-class TestFileQuery extends UncheckedRangeDomainPoleErrorsSharedQuery, TestQuery {
-}
+class TestFileQuery extends UncheckedRangeDomainPoleErrorsSharedQuery, TestQuery { }

--- a/c/common/test/rules/undefinedmacroidentifiers/UndefinedMacroIdentifiers.ql
+++ b/c/common/test/rules/undefinedmacroidentifiers/UndefinedMacroIdentifiers.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.undefinedmacroidentifiers.UndefinedMacroIdentifiers
 
-class TestFileQuery extends UndefinedMacroIdentifiersSharedQuery, TestQuery {
-}
+class TestFileQuery extends UndefinedMacroIdentifiersSharedQuery, TestQuery { }

--- a/c/common/test/rules/unnecessaryexposedidentifierdeclarationshared/UnnecessaryExposedIdentifierDeclarationShared.ql
+++ b/c/common/test/rules/unnecessaryexposedidentifierdeclarationshared/UnnecessaryExposedIdentifierDeclarationShared.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.unnecessaryexposedidentifierdeclarationshared.UnnecessaryExposedIdentifierDeclarationShared
 
-class TestFileQuery extends UnnecessaryExposedIdentifierDeclarationSharedSharedQuery, TestQuery {
-}
+class TestFileQuery extends UnnecessaryExposedIdentifierDeclarationSharedSharedQuery, TestQuery { }

--- a/c/common/test/rules/unreachablecode/UnreachableCode.ql
+++ b/c/common/test/rules/unreachablecode/UnreachableCode.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.unreachablecode.UnreachableCode
 
-class TestFileQuery extends UnreachableCodeSharedQuery, TestQuery {
-}
+class TestFileQuery extends UnreachableCodeSharedQuery, TestQuery { }

--- a/c/common/test/rules/unusedparameter/UnusedParameter.ql
+++ b/c/common/test/rules/unusedparameter/UnusedParameter.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.unusedparameter.UnusedParameter
 
-class TestFileQuery extends UnusedParameterSharedQuery, TestQuery {
-}
+class TestFileQuery extends UnusedParameterSharedQuery, TestQuery { }

--- a/c/common/test/rules/unusedtypedeclarations/UnusedTypeDeclarations.ql
+++ b/c/common/test/rules/unusedtypedeclarations/UnusedTypeDeclarations.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.unusedtypedeclarations.UnusedTypeDeclarations
 
-class TestFileQuery extends UnusedTypeDeclarationsSharedQuery, TestQuery {
-}
+class TestFileQuery extends UnusedTypeDeclarationsSharedQuery, TestQuery { }

--- a/c/common/test/rules/usageofassemblernotdocumented/UsageOfAssemblerNotDocumented.ql
+++ b/c/common/test/rules/usageofassemblernotdocumented/UsageOfAssemblerNotDocumented.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.usageofassemblernotdocumented.UsageOfAssemblerNotDocumented
 
-class TestFileQuery extends UsageOfAssemblerNotDocumentedSharedQuery, TestQuery {
-}
+class TestFileQuery extends UsageOfAssemblerNotDocumentedSharedQuery, TestQuery { }

--- a/c/common/test/rules/useonlyarrayindexingforpointerarithmetic/UseOnlyArrayIndexingForPointerArithmetic.ql
+++ b/c/common/test/rules/useonlyarrayindexingforpointerarithmetic/UseOnlyArrayIndexingForPointerArithmetic.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.useonlyarrayindexingforpointerarithmetic.UseOnlyArrayIndexingForPointerArithmetic
 
-class TestFileQuery extends UseOnlyArrayIndexingForPointerArithmeticSharedQuery, TestQuery {
-}
+class TestFileQuery extends UseOnlyArrayIndexingForPointerArithmeticSharedQuery, TestQuery { }

--- a/c/common/test/rules/wrapspuriousfunctioninloop/WrapSpuriousFunctionInLoop.ql
+++ b/c/common/test/rules/wrapspuriousfunctioninloop/WrapSpuriousFunctionInLoop.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.wrapspuriousfunctioninloop.WrapSpuriousFunctionInLoop
 
-class TestFileQuery extends WrapSpuriousFunctionInLoopSharedQuery, TestQuery {
-}
+class TestFileQuery extends WrapSpuriousFunctionInLoopSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/accessofundefinedmemberthroughnullpointer/AccessOfUndefinedMemberThroughNullPointer.ql
+++ b/cpp/common/test/rules/accessofundefinedmemberthroughnullpointer/AccessOfUndefinedMemberThroughNullPointer.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.accessofundefinedmemberthroughnullpointer.AccessOfUndefinedMemberThroughNullPointer
 
-class TestFileQuery extends AccessOfUndefinedMemberThroughNullPointerSharedQuery, TestQuery {
-}
+class TestFileQuery extends AccessOfUndefinedMemberThroughNullPointerSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/accessofundefinedmemberthroughuninitializedstaticpointer/AccessOfUndefinedMemberThroughUninitializedStaticPointer.ql
+++ b/cpp/common/test/rules/accessofundefinedmemberthroughuninitializedstaticpointer/AccessOfUndefinedMemberThroughUninitializedStaticPointer.ql
@@ -1,5 +1,6 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.accessofundefinedmemberthroughuninitializedstaticpointer.AccessOfUndefinedMemberThroughUninitializedStaticPointer
 
-class TestFileQuery extends AccessOfUndefinedMemberThroughUninitializedStaticPointerSharedQuery, TestQuery {
-}
+class TestFileQuery extends AccessOfUndefinedMemberThroughUninitializedStaticPointerSharedQuery,
+  TestQuery
+{ }

--- a/cpp/common/test/rules/basicstringmaynotbenullterminated/BasicStringMayNotBeNullTerminated.ql
+++ b/cpp/common/test/rules/basicstringmaynotbenullterminated/BasicStringMayNotBeNullTerminated.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.basicstringmaynotbenullterminated.BasicStringMayNotBeNullTerminated
 
-class TestFileQuery extends BasicStringMayNotBeNullTerminatedSharedQuery, TestQuery {
-}
+class TestFileQuery extends BasicStringMayNotBeNullTerminatedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/catchblockshadowing/CatchBlockShadowing.ql
+++ b/cpp/common/test/rules/catchblockshadowing/CatchBlockShadowing.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.catchblockshadowing.CatchBlockShadowing
 
-class TestFileQuery extends CatchBlockShadowingSharedQuery, TestQuery {
-}
+class TestFileQuery extends CatchBlockShadowingSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/catchexceptionsbylvaluereference/CatchExceptionsByLvalueReference.ql
+++ b/cpp/common/test/rules/catchexceptionsbylvaluereference/CatchExceptionsByLvalueReference.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.catchexceptionsbylvaluereference.CatchExceptionsByLvalueReference
 
-class TestFileQuery extends CatchExceptionsByLvalueReferenceSharedQuery, TestQuery {
-}
+class TestFileQuery extends CatchExceptionsByLvalueReferenceSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/commaoperatorused/CommaOperatorUsed.ql
+++ b/cpp/common/test/rules/commaoperatorused/CommaOperatorUsed.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.commaoperatorused.CommaOperatorUsed
 
-class TestFileQuery extends CommaOperatorUsedSharedQuery, TestQuery {
-}
+class TestFileQuery extends CommaOperatorUsedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/conditionvariablepostconditionfailed/ConditionVariablePostConditionFailed.ql
+++ b/cpp/common/test/rules/conditionvariablepostconditionfailed/ConditionVariablePostConditionFailed.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.conditionvariablepostconditionfailed.ConditionVariablePostConditionFailed
 
-class TestFileQuery extends ConditionVariablePostConditionFailedSharedQuery, TestQuery {
-}
+class TestFileQuery extends ConditionVariablePostConditionFailedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/constantunsignedintegerexpressionswraparound/ConstantUnsignedIntegerExpressionsWrapAround.ql
+++ b/cpp/common/test/rules/constantunsignedintegerexpressionswraparound/ConstantUnsignedIntegerExpressionsWrapAround.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.constantunsignedintegerexpressionswraparound.ConstantUnsignedIntegerExpressionsWrapAround
 
-class TestFileQuery extends ConstantUnsignedIntegerExpressionsWrapAroundSharedQuery, TestQuery {
-}
+class TestFileQuery extends ConstantUnsignedIntegerExpressionsWrapAroundSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/containeraccesswithoutrangecheck/ContainerAccessWithoutRangeCheck.ql
+++ b/cpp/common/test/rules/containeraccesswithoutrangecheck/ContainerAccessWithoutRangeCheck.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.containeraccesswithoutrangecheck.ContainerAccessWithoutRangeCheck
 
-class TestFileQuery extends ContainerAccessWithoutRangeCheckSharedQuery, TestQuery {
-}
+class TestFileQuery extends ContainerAccessWithoutRangeCheckSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/danglingcapturewhenmovinglambdaobject/DanglingCaptureWhenMovingLambdaObject.ql
+++ b/cpp/common/test/rules/danglingcapturewhenmovinglambdaobject/DanglingCaptureWhenMovingLambdaObject.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.danglingcapturewhenmovinglambdaobject.DanglingCaptureWhenMovingLambdaObject
 
-class TestFileQuery extends DanglingCaptureWhenMovingLambdaObjectSharedQuery, TestQuery {
-}
+class TestFileQuery extends DanglingCaptureWhenMovingLambdaObjectSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/danglingcapturewhenreturninglambdaobject/DanglingCaptureWhenReturningLambdaObject.ql
+++ b/cpp/common/test/rules/danglingcapturewhenreturninglambdaobject/DanglingCaptureWhenReturningLambdaObject.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.danglingcapturewhenreturninglambdaobject.DanglingCaptureWhenReturningLambdaObject
 
-class TestFileQuery extends DanglingCaptureWhenReturningLambdaObjectSharedQuery, TestQuery {
-}
+class TestFileQuery extends DanglingCaptureWhenReturningLambdaObjectSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/deadcode/DeadCode.ql
+++ b/cpp/common/test/rules/deadcode/DeadCode.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.deadcode.DeadCode
 
-class TestFileQuery extends DeadCodeSharedQuery, TestQuery {
-}
+class TestFileQuery extends DeadCodeSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/deleteofpointertoincompleteclass/DeleteOfPointerToIncompleteClass.ql
+++ b/cpp/common/test/rules/deleteofpointertoincompleteclass/DeleteOfPointerToIncompleteClass.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.deleteofpointertoincompleteclass.DeleteOfPointerToIncompleteClass
 
-class TestFileQuery extends DeleteOfPointerToIncompleteClassSharedQuery, TestQuery {
-}
+class TestFileQuery extends DeleteOfPointerToIncompleteClassSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/dereferenceofnullpointer/DereferenceOfNullPointer.ql
+++ b/cpp/common/test/rules/dereferenceofnullpointer/DereferenceOfNullPointer.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.dereferenceofnullpointer.DereferenceOfNullPointer
 
-class TestFileQuery extends DereferenceOfNullPointerSharedQuery, TestQuery {
-}
+class TestFileQuery extends DereferenceOfNullPointerSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/destroyedvaluereferencedindestructorcatchblock/DestroyedValueReferencedInDestructorCatchBlock.ql
+++ b/cpp/common/test/rules/destroyedvaluereferencedindestructorcatchblock/DestroyedValueReferencedInDestructorCatchBlock.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.destroyedvaluereferencedindestructorcatchblock.DestroyedValueReferencedInDestructorCatchBlock
 
-class TestFileQuery extends DestroyedValueReferencedInDestructorCatchBlockSharedQuery, TestQuery {
-}
+class TestFileQuery extends DestroyedValueReferencedInDestructorCatchBlockSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/donotallowamutextogooutofscopewhilelocked/DoNotAllowAMutexToGoOutOfScopeWhileLocked.ql
+++ b/cpp/common/test/rules/donotallowamutextogooutofscopewhilelocked/DoNotAllowAMutexToGoOutOfScopeWhileLocked.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotallowamutextogooutofscopewhilelocked.DoNotAllowAMutexToGoOutOfScopeWhileLocked
 
-class TestFileQuery extends DoNotAllowAMutexToGoOutOfScopeWhileLockedSharedQuery, TestQuery {
-}
+class TestFileQuery extends DoNotAllowAMutexToGoOutOfScopeWhileLockedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/donotdestroyamutexwhileitislocked/DoNotDestroyAMutexWhileItIsLocked.ql
+++ b/cpp/common/test/rules/donotdestroyamutexwhileitislocked/DoNotDestroyAMutexWhileItIsLocked.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotdestroyamutexwhileitislocked.DoNotDestroyAMutexWhileItIsLocked
 
-class TestFileQuery extends DoNotDestroyAMutexWhileItIsLockedSharedQuery, TestQuery {
-}
+class TestFileQuery extends DoNotDestroyAMutexWhileItIsLockedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/donotsubtractpointersaddressingdifferentarrays/DoNotSubtractPointersAddressingDifferentArrays.ql
+++ b/cpp/common/test/rules/donotsubtractpointersaddressingdifferentarrays/DoNotSubtractPointersAddressingDifferentArrays.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotsubtractpointersaddressingdifferentarrays.DoNotSubtractPointersAddressingDifferentArrays
 
-class TestFileQuery extends DoNotSubtractPointersAddressingDifferentArraysSharedQuery, TestQuery {
-}
+class TestFileQuery extends DoNotSubtractPointersAddressingDifferentArraysSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/donotusemorethantwolevelsofpointerindirection/DoNotUseMoreThanTwoLevelsOfPointerIndirection.ql
+++ b/cpp/common/test/rules/donotusemorethantwolevelsofpointerindirection/DoNotUseMoreThanTwoLevelsOfPointerIndirection.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotusemorethantwolevelsofpointerindirection.DoNotUseMoreThanTwoLevelsOfPointerIndirection
 
-class TestFileQuery extends DoNotUseMoreThanTwoLevelsOfPointerIndirectionSharedQuery, TestQuery {
-}
+class TestFileQuery extends DoNotUseMoreThanTwoLevelsOfPointerIndirectionSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/donotuserandforgeneratingpseudorandomnumbers/DoNotUseRandForGeneratingPseudorandomNumbers.ql
+++ b/cpp/common/test/rules/donotuserandforgeneratingpseudorandomnumbers/DoNotUseRandForGeneratingPseudorandomNumbers.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotuserandforgeneratingpseudorandomnumbers.DoNotUseRandForGeneratingPseudorandomNumbers
 
-class TestFileQuery extends DoNotUseRandForGeneratingPseudorandomNumbersSharedQuery, TestQuery {
-}
+class TestFileQuery extends DoNotUseRandForGeneratingPseudorandomNumbersSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/donotuserelationaloperatorswithdifferingarrays/DoNotUseRelationalOperatorsWithDifferingArrays.ql
+++ b/cpp/common/test/rules/donotuserelationaloperatorswithdifferingarrays/DoNotUseRelationalOperatorsWithDifferingArrays.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotuserelationaloperatorswithdifferingarrays.DoNotUseRelationalOperatorsWithDifferingArrays
 
-class TestFileQuery extends DoNotUseRelationalOperatorsWithDifferingArraysSharedQuery, TestQuery {
-}
+class TestFileQuery extends DoNotUseRelationalOperatorsWithDifferingArraysSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/donotusesetjmporlongjmpshared/DoNotUseSetjmpOrLongjmpShared.ql
+++ b/cpp/common/test/rules/donotusesetjmporlongjmpshared/DoNotUseSetjmpOrLongjmpShared.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.donotusesetjmporlongjmpshared.DoNotUseSetjmpOrLongjmpShared
 
-class TestFileQuery extends DoNotUseSetjmpOrLongjmpSharedSharedQuery, TestQuery {
-}
+class TestFileQuery extends DoNotUseSetjmpOrLongjmpSharedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/exceptionsafetyguarantees/ExceptionSafetyGuarantees.ql
+++ b/cpp/common/test/rules/exceptionsafetyguarantees/ExceptionSafetyGuarantees.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.exceptionsafetyguarantees.ExceptionSafetyGuarantees
 
-class TestFileQuery extends ExceptionSafetyGuaranteesSharedQuery, TestQuery {
-}
+class TestFileQuery extends ExceptionSafetyGuaranteesSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/exceptionsafetyvalidstate/ExceptionSafetyValidState.ql
+++ b/cpp/common/test/rules/exceptionsafetyvalidstate/ExceptionSafetyValidState.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.exceptionsafetyvalidstate.ExceptionSafetyValidState
 
-class TestFileQuery extends ExceptionSafetyValidStateSharedQuery, TestQuery {
-}
+class TestFileQuery extends ExceptionSafetyValidStateSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/exithandlerthrowsexception/ExitHandlerThrowsException.ql
+++ b/cpp/common/test/rules/exithandlerthrowsexception/ExitHandlerThrowsException.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.exithandlerthrowsexception.ExitHandlerThrowsException
 
-class TestFileQuery extends ExitHandlerThrowsExceptionSharedQuery, TestQuery {
-}
+class TestFileQuery extends ExitHandlerThrowsExceptionSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/explicitabrupttermination/ExplicitAbruptTermination.ql
+++ b/cpp/common/test/rules/explicitabrupttermination/ExplicitAbruptTermination.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.explicitabrupttermination.ExplicitAbruptTermination
 
-class TestFileQuery extends ExplicitAbruptTerminationSharedQuery, TestQuery {
-}
+class TestFileQuery extends ExplicitAbruptTerminationSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/functionnoreturnattributecondition/FunctionNoReturnAttributeCondition.ql
+++ b/cpp/common/test/rules/functionnoreturnattributecondition/FunctionNoReturnAttributeCondition.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.functionnoreturnattributecondition.FunctionNoReturnAttributeCondition
 
-class TestFileQuery extends FunctionNoReturnAttributeConditionSharedQuery, TestQuery {
-}
+class TestFileQuery extends FunctionNoReturnAttributeConditionSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/gotostatementcondition/GotoStatementCondition.ql
+++ b/cpp/common/test/rules/gotostatementcondition/GotoStatementCondition.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.gotostatementcondition.GotoStatementCondition
 
-class TestFileQuery extends GotoStatementConditionSharedQuery, TestQuery {
-}
+class TestFileQuery extends GotoStatementConditionSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/guardaccesstobitfields/GuardAccessToBitFields.ql
+++ b/cpp/common/test/rules/guardaccesstobitfields/GuardAccessToBitFields.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.guardaccesstobitfields.GuardAccessToBitFields
 
-class TestFileQuery extends GuardAccessToBitFieldsSharedQuery, TestQuery {
-}
+class TestFileQuery extends GuardAccessToBitFieldsSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/handleallexceptionsduringstartup/HandleAllExceptionsDuringStartup.ql
+++ b/cpp/common/test/rules/handleallexceptionsduringstartup/HandleAllExceptionsDuringStartup.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.handleallexceptionsduringstartup.HandleAllExceptionsDuringStartup
 
-class TestFileQuery extends HandleAllExceptionsDuringStartupSharedQuery, TestQuery {
-}
+class TestFileQuery extends HandleAllExceptionsDuringStartupSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/hashoperatorsused/HashOperatorsUsed.ql
+++ b/cpp/common/test/rules/hashoperatorsused/HashOperatorsUsed.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.hashoperatorsused.HashOperatorsUsed
 
-class TestFileQuery extends HashOperatorsUsedSharedQuery, TestQuery {
-}
+class TestFileQuery extends HashOperatorsUsedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/identifierhidden/IdentifierHidden.ql
+++ b/cpp/common/test/rules/identifierhidden/IdentifierHidden.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.identifierhidden.IdentifierHidden
 
-class TestFileQuery extends IdentifierHiddenSharedQuery, TestQuery {
-}
+class TestFileQuery extends IdentifierHiddenSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/ifelseterminationconstruct/IfElseTerminationConstruct.ql
+++ b/cpp/common/test/rules/ifelseterminationconstruct/IfElseTerminationConstruct.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.ifelseterminationconstruct.IfElseTerminationConstruct
 
-class TestFileQuery extends IfElseTerminationConstructSharedQuery, TestQuery {
-}
+class TestFileQuery extends IfElseTerminationConstructSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/includeguardsnotused/IncludeGuardsNotUsed.ql
+++ b/cpp/common/test/rules/includeguardsnotused/IncludeGuardsNotUsed.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.includeguardsnotused.IncludeGuardsNotUsed
 
-class TestFileQuery extends IncludeGuardsNotUsedSharedQuery, TestQuery {
-}
+class TestFileQuery extends IncludeGuardsNotUsedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/informationleakageacrossboundaries/InformationLeakageAcrossBoundaries.ql
+++ b/cpp/common/test/rules/informationleakageacrossboundaries/InformationLeakageAcrossBoundaries.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.informationleakageacrossboundaries.InformationLeakageAcrossBoundaries
 
-class TestFileQuery extends InformationLeakageAcrossBoundariesSharedQuery, TestQuery {
-}
+class TestFileQuery extends InformationLeakageAcrossBoundariesSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/iofstreammissingpositioning/IOFstreamMissingPositioning.ql
+++ b/cpp/common/test/rules/iofstreammissingpositioning/IOFstreamMissingPositioning.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.iofstreammissingpositioning.IOFstreamMissingPositioning
 
-class TestFileQuery extends IOFstreamMissingPositioningSharedQuery, TestQuery {
-}
+class TestFileQuery extends IOFstreamMissingPositioningSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/joinablethreadcopiedordestroyed/JoinableThreadCopiedOrDestroyed.ql
+++ b/cpp/common/test/rules/joinablethreadcopiedordestroyed/JoinableThreadCopiedOrDestroyed.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.joinablethreadcopiedordestroyed.JoinableThreadCopiedOrDestroyed
 
-class TestFileQuery extends JoinableThreadCopiedOrDestroyedSharedQuery, TestQuery {
-}
+class TestFileQuery extends JoinableThreadCopiedOrDestroyedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/macroparameternotenclosedinparentheses/MacroParameterNotEnclosedInParentheses.ql
+++ b/cpp/common/test/rules/macroparameternotenclosedinparentheses/MacroParameterNotEnclosedInParentheses.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.macroparameternotenclosedinparentheses.MacroParameterNotEnclosedInParentheses
 
-class TestFileQuery extends MacroParameterNotEnclosedInParenthesesSharedQuery, TestQuery {
-}
+class TestFileQuery extends MacroParameterNotEnclosedInParenthesesSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/memcmpusedtocomparepaddingdata/MemcmpUsedToComparePaddingData.ql
+++ b/cpp/common/test/rules/memcmpusedtocomparepaddingdata/MemcmpUsedToComparePaddingData.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.memcmpusedtocomparepaddingdata.MemcmpUsedToComparePaddingData
 
-class TestFileQuery extends MemcmpUsedToComparePaddingDataSharedQuery, TestQuery {
-}
+class TestFileQuery extends MemcmpUsedToComparePaddingDataSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/movedfromobjectsunspecifiedstate/MovedFromObjectsUnspecifiedState.ql
+++ b/cpp/common/test/rules/movedfromobjectsunspecifiedstate/MovedFromObjectsUnspecifiedState.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.movedfromobjectsunspecifiedstate.MovedFromObjectsUnspecifiedState
 
-class TestFileQuery extends MovedFromObjectsUnspecifiedStateSharedQuery, TestQuery {
-}
+class TestFileQuery extends MovedFromObjectsUnspecifiedStateSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/nestedlabelinswitch/NestedLabelInSwitch.ql
+++ b/cpp/common/test/rules/nestedlabelinswitch/NestedLabelInSwitch.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nestedlabelinswitch.NestedLabelInSwitch
 
-class TestFileQuery extends NestedLabelInSwitchSharedQuery, TestQuery {
-}
+class TestFileQuery extends NestedLabelInSwitchSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/nonbooleanifstmt/NonBooleanIfStmt.ql
+++ b/cpp/common/test/rules/nonbooleanifstmt/NonBooleanIfStmt.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nonbooleanifstmt.NonBooleanIfStmt
 
-class TestFileQuery extends NonBooleanIfStmtSharedQuery, TestQuery {
-}
+class TestFileQuery extends NonBooleanIfStmtSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/nonbooleaniterationstmt/NonBooleanIterationStmt.ql
+++ b/cpp/common/test/rules/nonbooleaniterationstmt/NonBooleanIterationStmt.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nonbooleaniterationstmt.NonBooleanIterationStmt
 
-class TestFileQuery extends NonBooleanIterationStmtSharedQuery, TestQuery {
-}
+class TestFileQuery extends NonBooleanIterationStmtSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/nonconstantformat/NonConstantFormat.ql
+++ b/cpp/common/test/rules/nonconstantformat/NonConstantFormat.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nonconstantformat.NonConstantFormat
 
-class TestFileQuery extends NonConstantFormatSharedQuery, TestQuery {
-}
+class TestFileQuery extends NonConstantFormatSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/nonstandardentitiesinstandardnamespaces/NonStandardEntitiesInStandardNamespaces.ql
+++ b/cpp/common/test/rules/nonstandardentitiesinstandardnamespaces/NonStandardEntitiesInStandardNamespaces.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nonstandardentitiesinstandardnamespaces.NonStandardEntitiesInStandardNamespaces
 
-class TestFileQuery extends NonStandardEntitiesInStandardNamespacesSharedQuery, TestQuery {
-}
+class TestFileQuery extends NonStandardEntitiesInStandardNamespacesSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/nonvoidfunctiondoesnotreturn/NonVoidFunctionDoesNotReturn.ql
+++ b/cpp/common/test/rules/nonvoidfunctiondoesnotreturn/NonVoidFunctionDoesNotReturn.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.nonvoidfunctiondoesnotreturn.NonVoidFunctionDoesNotReturn
 
-class TestFileQuery extends NonVoidFunctionDoesNotReturnSharedQuery, TestQuery {
-}
+class TestFileQuery extends NonVoidFunctionDoesNotReturnSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/objectaccessedafterlifetime/ObjectAccessedAfterLifetime.ql
+++ b/cpp/common/test/rules/objectaccessedafterlifetime/ObjectAccessedAfterLifetime.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.objectaccessedafterlifetime.ObjectAccessedAfterLifetime
 
-class TestFileQuery extends ObjectAccessedAfterLifetimeSharedQuery, TestQuery {
-}
+class TestFileQuery extends ObjectAccessedAfterLifetimeSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/objectaccessedbeforelifetime/ObjectAccessedBeforeLifetime.ql
+++ b/cpp/common/test/rules/objectaccessedbeforelifetime/ObjectAccessedBeforeLifetime.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.objectaccessedbeforelifetime.ObjectAccessedBeforeLifetime
 
-class TestFileQuery extends ObjectAccessedBeforeLifetimeSharedQuery, TestQuery {
-}
+class TestFileQuery extends ObjectAccessedBeforeLifetimeSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/onedefinitionruleviolation/OneDefinitionRuleViolation.ql
+++ b/cpp/common/test/rules/onedefinitionruleviolation/OneDefinitionRuleViolation.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.onedefinitionruleviolation.OneDefinitionRuleViolation
 
-class TestFileQuery extends OneDefinitionRuleViolationSharedQuery, TestQuery {
-}
+class TestFileQuery extends OneDefinitionRuleViolationSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/operationmaynotnullterminatecstylestring/OperationMayNotNullTerminateCStyleString.ql
+++ b/cpp/common/test/rules/operationmaynotnullterminatecstylestring/OperationMayNotNullTerminateCStyleString.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.operationmaynotnullterminatecstylestring.OperationMayNotNullTerminateCStyleString
 
-class TestFileQuery extends OperationMayNotNullTerminateCStyleStringSharedQuery, TestQuery {
-}
+class TestFileQuery extends OperationMayNotNullTerminateCStyleStringSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/operatordeletemissingpartner/OperatorDeleteMissingPartner.ql
+++ b/cpp/common/test/rules/operatordeletemissingpartner/OperatorDeleteMissingPartner.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.operatordeletemissingpartner.OperatorDeleteMissingPartner
 
-class TestFileQuery extends OperatorDeleteMissingPartnerSharedQuery, TestQuery {
-}
+class TestFileQuery extends OperatorDeleteMissingPartnerSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/orderingpredicatemustbestrictlyweak/OrderingPredicateMustBeStrictlyWeak.ql
+++ b/cpp/common/test/rules/orderingpredicatemustbestrictlyweak/OrderingPredicateMustBeStrictlyWeak.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.orderingpredicatemustbestrictlyweak.OrderingPredicateMustBeStrictlyWeak
 
-class TestFileQuery extends OrderingPredicateMustBeStrictlyWeakSharedQuery, TestQuery {
-}
+class TestFileQuery extends OrderingPredicateMustBeStrictlyWeakSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/ownedpointervaluestoredinunrelatedsmartpointer/OwnedPointerValueStoredInUnrelatedSmartPointer.ql
+++ b/cpp/common/test/rules/ownedpointervaluestoredinunrelatedsmartpointer/OwnedPointerValueStoredInUnrelatedSmartPointer.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.ownedpointervaluestoredinunrelatedsmartpointer.OwnedPointerValueStoredInUnrelatedSmartPointer
 
-class TestFileQuery extends OwnedPointerValueStoredInUnrelatedSmartPointerSharedQuery, TestQuery {
-}
+class TestFileQuery extends OwnedPointerValueStoredInUnrelatedSmartPointerSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/placementnewinsufficientstorage/PlacementNewInsufficientStorage.ql
+++ b/cpp/common/test/rules/placementnewinsufficientstorage/PlacementNewInsufficientStorage.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.placementnewinsufficientstorage.PlacementNewInsufficientStorage
 
-class TestFileQuery extends PlacementNewInsufficientStorageSharedQuery, TestQuery {
-}
+class TestFileQuery extends PlacementNewInsufficientStorageSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/placementnewnotproperlyaligned/PlacementNewNotProperlyAligned.ql
+++ b/cpp/common/test/rules/placementnewnotproperlyaligned/PlacementNewNotProperlyAligned.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.placementnewnotproperlyaligned.PlacementNewNotProperlyAligned
 
-class TestFileQuery extends PlacementNewNotProperlyAlignedSharedQuery, TestQuery {
-}
+class TestFileQuery extends PlacementNewNotProperlyAlignedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/predicatefunctionobjectsshouldnotbemutable/PredicateFunctionObjectsShouldNotBeMutable.ql
+++ b/cpp/common/test/rules/predicatefunctionobjectsshouldnotbemutable/PredicateFunctionObjectsShouldNotBeMutable.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.predicatefunctionobjectsshouldnotbemutable.PredicateFunctionObjectsShouldNotBeMutable
 
-class TestFileQuery extends PredicateFunctionObjectsShouldNotBeMutableSharedQuery, TestQuery {
-}
+class TestFileQuery extends PredicateFunctionObjectsShouldNotBeMutableSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/preprocessingdirectivewithinmacroargument/PreprocessingDirectiveWithinMacroArgument.ql
+++ b/cpp/common/test/rules/preprocessingdirectivewithinmacroargument/PreprocessingDirectiveWithinMacroArgument.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preprocessingdirectivewithinmacroargument.PreprocessingDirectiveWithinMacroArgument
 
-class TestFileQuery extends PreprocessingDirectiveWithinMacroArgumentSharedQuery, TestQuery {
-}
+class TestFileQuery extends PreprocessingDirectiveWithinMacroArgumentSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/preprocessorincludesforbiddenheadernames/PreprocessorIncludesForbiddenHeaderNames.ql
+++ b/cpp/common/test/rules/preprocessorincludesforbiddenheadernames/PreprocessorIncludesForbiddenHeaderNames.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preprocessorincludesforbiddenheadernames.PreprocessorIncludesForbiddenHeaderNames
 
-class TestFileQuery extends PreprocessorIncludesForbiddenHeaderNamesSharedQuery, TestQuery {
-}
+class TestFileQuery extends PreprocessorIncludesForbiddenHeaderNamesSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/preprocessorincludespreceded/PreprocessorIncludesPreceded.ql
+++ b/cpp/common/test/rules/preprocessorincludespreceded/PreprocessorIncludesPreceded.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preprocessorincludespreceded.PreprocessorIncludesPreceded
 
-class TestFileQuery extends PreprocessorIncludesPrecededSharedQuery, TestQuery {
-}
+class TestFileQuery extends PreprocessorIncludesPrecededSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/preservesafetywhenusingconditionvariables/PreserveSafetyWhenUsingConditionVariables.ql
+++ b/cpp/common/test/rules/preservesafetywhenusingconditionvariables/PreserveSafetyWhenUsingConditionVariables.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preservesafetywhenusingconditionvariables.PreserveSafetyWhenUsingConditionVariables
 
-class TestFileQuery extends PreserveSafetyWhenUsingConditionVariablesSharedQuery, TestQuery {
-}
+class TestFileQuery extends PreserveSafetyWhenUsingConditionVariablesSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/preventdeadlockbylockinginpredefinedorder/PreventDeadlockByLockingInPredefinedOrder.ql
+++ b/cpp/common/test/rules/preventdeadlockbylockinginpredefinedorder/PreventDeadlockByLockingInPredefinedOrder.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.preventdeadlockbylockinginpredefinedorder.PreventDeadlockByLockingInPredefinedOrder
 
-class TestFileQuery extends PreventDeadlockByLockingInPredefinedOrderSharedQuery, TestQuery {
-}
+class TestFileQuery extends PreventDeadlockByLockingInPredefinedOrderSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/readofuninitializedmemory/ReadOfUninitializedMemory.ql
+++ b/cpp/common/test/rules/readofuninitializedmemory/ReadOfUninitializedMemory.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.readofuninitializedmemory.ReadOfUninitializedMemory
 
-class TestFileQuery extends ReadOfUninitializedMemorySharedQuery, TestQuery {
-}
+class TestFileQuery extends ReadOfUninitializedMemorySharedQuery, TestQuery { }

--- a/cpp/common/test/rules/removeconstorvolatilequalification/RemoveConstOrVolatileQualification.ql
+++ b/cpp/common/test/rules/removeconstorvolatilequalification/RemoveConstOrVolatileQualification.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.removeconstorvolatilequalification.RemoveConstOrVolatileQualification
 
-class TestFileQuery extends RemoveConstOrVolatileQualificationSharedQuery, TestQuery {
-}
+class TestFileQuery extends RemoveConstOrVolatileQualificationSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/rethrownestedwithoutcapture/RethrowNestedWithoutCapture.ql
+++ b/cpp/common/test/rules/rethrownestedwithoutcapture/RethrowNestedWithoutCapture.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.rethrownestedwithoutcapture.RethrowNestedWithoutCapture
 
-class TestFileQuery extends RethrowNestedWithoutCaptureSharedQuery, TestQuery {
-}
+class TestFileQuery extends RethrowNestedWithoutCaptureSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/sectionsofcodeshallnotbecommentedout/SectionsOfCodeShallNotBeCommentedOut.ql
+++ b/cpp/common/test/rules/sectionsofcodeshallnotbecommentedout/SectionsOfCodeShallNotBeCommentedOut.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.sectionsofcodeshallnotbecommentedout.SectionsOfCodeShallNotBeCommentedOut
 
-class TestFileQuery extends SectionsOfCodeShallNotBeCommentedOutSharedQuery, TestQuery {
-}
+class TestFileQuery extends SectionsOfCodeShallNotBeCommentedOutSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/stringnumberconversionmissingerrorcheck/StringNumberConversionMissingErrorCheck.ql
+++ b/cpp/common/test/rules/stringnumberconversionmissingerrorcheck/StringNumberConversionMissingErrorCheck.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.stringnumberconversionmissingerrorcheck.StringNumberConversionMissingErrorCheck
 
-class TestFileQuery extends StringNumberConversionMissingErrorCheckSharedQuery, TestQuery {
-}
+class TestFileQuery extends StringNumberConversionMissingErrorCheckSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/switchcasepositioncondition/SwitchCasePositionCondition.ql
+++ b/cpp/common/test/rules/switchcasepositioncondition/SwitchCasePositionCondition.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.switchcasepositioncondition.SwitchCasePositionCondition
 
-class TestFileQuery extends SwitchCasePositionConditionSharedQuery, TestQuery {
-}
+class TestFileQuery extends SwitchCasePositionConditionSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/switchnotwellformed/SwitchNotWellFormed.ql
+++ b/cpp/common/test/rules/switchnotwellformed/SwitchNotWellFormed.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.switchnotwellformed.SwitchNotWellFormed
 
-class TestFileQuery extends SwitchNotWellFormedSharedQuery, TestQuery {
-}
+class TestFileQuery extends SwitchNotWellFormedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/throwingnothrowoperatornewdelete/ThrowingNoThrowOperatorNewDelete.ql
+++ b/cpp/common/test/rules/throwingnothrowoperatornewdelete/ThrowingNoThrowOperatorNewDelete.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.throwingnothrowoperatornewdelete.ThrowingNoThrowOperatorNewDelete
 
-class TestFileQuery extends ThrowingNoThrowOperatorNewDeleteSharedQuery, TestQuery {
-}
+class TestFileQuery extends ThrowingNoThrowOperatorNewDeleteSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/throwingoperatornewreturnsnull/ThrowingOperatorNewReturnsNull.ql
+++ b/cpp/common/test/rules/throwingoperatornewreturnsnull/ThrowingOperatorNewReturnsNull.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.throwingoperatornewreturnsnull.ThrowingOperatorNewReturnsNull
 
-class TestFileQuery extends ThrowingOperatorNewReturnsNullSharedQuery, TestQuery {
-}
+class TestFileQuery extends ThrowingOperatorNewReturnsNullSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/throwingoperatornewthrowsinvalidexception/ThrowingOperatorNewThrowsInvalidException.ql
+++ b/cpp/common/test/rules/throwingoperatornewthrowsinvalidexception/ThrowingOperatorNewThrowsInvalidException.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.throwingoperatornewthrowsinvalidexception.ThrowingOperatorNewThrowsInvalidException
 
-class TestFileQuery extends ThrowingOperatorNewThrowsInvalidExceptionSharedQuery, TestQuery {
-}
+class TestFileQuery extends ThrowingOperatorNewThrowsInvalidExceptionSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/uncheckedrangedomainpoleerrors/UncheckedRangeDomainPoleErrors.ql
+++ b/cpp/common/test/rules/uncheckedrangedomainpoleerrors/UncheckedRangeDomainPoleErrors.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.uncheckedrangedomainpoleerrors.UncheckedRangeDomainPoleErrors
 
-class TestFileQuery extends UncheckedRangeDomainPoleErrorsSharedQuery, TestQuery {
-}
+class TestFileQuery extends UncheckedRangeDomainPoleErrorsSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/undefinedmacroidentifiers/UndefinedMacroIdentifiers.ql
+++ b/cpp/common/test/rules/undefinedmacroidentifiers/UndefinedMacroIdentifiers.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.undefinedmacroidentifiers.UndefinedMacroIdentifiers
 
-class TestFileQuery extends UndefinedMacroIdentifiersSharedQuery, TestQuery {
-}
+class TestFileQuery extends UndefinedMacroIdentifiersSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/unnecessaryexposedidentifierdeclarationshared/UnnecessaryExposedIdentifierDeclarationShared.ql
+++ b/cpp/common/test/rules/unnecessaryexposedidentifierdeclarationshared/UnnecessaryExposedIdentifierDeclarationShared.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.unnecessaryexposedidentifierdeclarationshared.UnnecessaryExposedIdentifierDeclarationShared
 
-class TestFileQuery extends UnnecessaryExposedIdentifierDeclarationSharedSharedQuery, TestQuery {
-}
+class TestFileQuery extends UnnecessaryExposedIdentifierDeclarationSharedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/unreachablecode/UnreachableCode.ql
+++ b/cpp/common/test/rules/unreachablecode/UnreachableCode.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.unreachablecode.UnreachableCode
 
-class TestFileQuery extends UnreachableCodeSharedQuery, TestQuery {
-}
+class TestFileQuery extends UnreachableCodeSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/unusedparameter/UnusedParameter.ql
+++ b/cpp/common/test/rules/unusedparameter/UnusedParameter.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.unusedparameter.UnusedParameter
 
-class TestFileQuery extends UnusedParameterSharedQuery, TestQuery {
-}
+class TestFileQuery extends UnusedParameterSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/unusedtypedeclarations/UnusedTypeDeclarations.ql
+++ b/cpp/common/test/rules/unusedtypedeclarations/UnusedTypeDeclarations.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.unusedtypedeclarations.UnusedTypeDeclarations
 
-class TestFileQuery extends UnusedTypeDeclarationsSharedQuery, TestQuery {
-}
+class TestFileQuery extends UnusedTypeDeclarationsSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/usageofassemblernotdocumented/UsageOfAssemblerNotDocumented.ql
+++ b/cpp/common/test/rules/usageofassemblernotdocumented/UsageOfAssemblerNotDocumented.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.usageofassemblernotdocumented.UsageOfAssemblerNotDocumented
 
-class TestFileQuery extends UsageOfAssemblerNotDocumentedSharedQuery, TestQuery {
-}
+class TestFileQuery extends UsageOfAssemblerNotDocumentedSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/usecanonicalorderformemberinit/UseCanonicalOrderForMemberInit.ql
+++ b/cpp/common/test/rules/usecanonicalorderformemberinit/UseCanonicalOrderForMemberInit.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.usecanonicalorderformemberinit.UseCanonicalOrderForMemberInit
 
-class TestFileQuery extends UseCanonicalOrderForMemberInitSharedQuery, TestQuery {
-}
+class TestFileQuery extends UseCanonicalOrderForMemberInitSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/useonlyarrayindexingforpointerarithmetic/UseOnlyArrayIndexingForPointerArithmetic.ql
+++ b/cpp/common/test/rules/useonlyarrayindexingforpointerarithmetic/UseOnlyArrayIndexingForPointerArithmetic.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.useonlyarrayindexingforpointerarithmetic.UseOnlyArrayIndexingForPointerArithmetic
 
-class TestFileQuery extends UseOnlyArrayIndexingForPointerArithmeticSharedQuery, TestQuery {
-}
+class TestFileQuery extends UseOnlyArrayIndexingForPointerArithmeticSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/validcontainerelementaccess/ValidContainerElementAccess.ql
+++ b/cpp/common/test/rules/validcontainerelementaccess/ValidContainerElementAccess.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.validcontainerelementaccess.ValidContainerElementAccess
 
-class TestFileQuery extends ValidContainerElementAccessSharedQuery, TestQuery {
-}
+class TestFileQuery extends ValidContainerElementAccessSharedQuery, TestQuery { }

--- a/cpp/common/test/rules/wrapspuriousfunctioninloop/WrapSpuriousFunctionInLoop.ql
+++ b/cpp/common/test/rules/wrapspuriousfunctioninloop/WrapSpuriousFunctionInLoop.ql
@@ -1,5 +1,4 @@
 // GENERATED FILE - DO NOT MODIFY
 import codingstandards.cpp.rules.wrapspuriousfunctioninloop.WrapSpuriousFunctionInLoop
 
-class TestFileQuery extends WrapSpuriousFunctionInLoopSharedQuery, TestQuery {
-}
+class TestFileQuery extends WrapSpuriousFunctionInLoopSharedQuery, TestQuery { }

--- a/scripts/generate_rules/generate_package_files.py
+++ b/scripts/generate_rules/generate_package_files.py
@@ -182,8 +182,7 @@ def write_shared_implementation(package_name, rule_id, query, language_name, ql_
                 + "\n"
             )
             f.write("\n");
-            f.write("class TestFileQuery extends " + str(query["shared_implementation_short_name"]) + "SharedQuery, TestQuery {\n")
-            f.write("}\n")
+            f.write("class TestFileQuery extends " + str(query["shared_implementation_short_name"]) + "SharedQuery, TestQuery { }\n")
 
         # Create an empty test file, if one doesn't already exist
         shared_impl_test_dir.joinpath(

--- a/scripts/generate_rules/generate_package_files.py
+++ b/scripts/generate_rules/generate_package_files.py
@@ -181,8 +181,19 @@ def write_shared_implementation(package_name, rule_id, query, language_name, ql_
                 .replace("/", ".")
                 + "\n"
             )
-            f.write("\n");
-            f.write("class TestFileQuery extends " + str(query["shared_implementation_short_name"]) + "SharedQuery, TestQuery { }\n")
+            f.write("\n")
+            class_name = str(query["shared_implementation_short_name"]) + "SharedQuery"
+            f.write("class TestFileQuery extends " + class_name + ",")
+            # ql formatting of this line depends on the line length
+            if len(class_name) > 61:
+                # Line break required after comma
+                f.write("\n  TestQuery\n{ }\n")
+            elif len(class_name) > 57:
+                # Line break required after `{`
+                f.write(" TestQuery {\n}\n")
+            else:
+                # Under 100 characters, can be formatted on the same line
+                f.write(" TestQuery { }\n")
 
         # Create an empty test file, if one doesn't already exist
         shared_impl_test_dir.joinpath(


### PR DESCRIPTION
## Description

The upgrade to CodeQL CLI 2.13.5 changed the formatting rules for CodeQL classes with empty bodies - the format is now dependent on the length of the first line of the class itself.

This PR fixes some issues introduced during the upgrade by:
 * Reverting commit https://github.com/github/codeql-coding-standards/commit/1193b8d721b7ca8c05231b768f4394a544d864f8, which inappropriately reformatted the shared query tests and the code generator, under a misunderstanding of how these files are expected to be formatted.
 * Updating the package file generator to reflect the conditional formatting of classes with empty bodies (so we generate qlformat compliant code).
 * Fixes the PR check for qlformatting, which prevented us from identifying this discrepancy during the upgrade itself.

## Change request type

 - [x] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [ ] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)