### PR TITLE
C++: Accept test changes after github/codeql/pull/14637

### DIFF
--- a/cpp/cert/test/rules/MEM53-CPP/MissingConstructorCallForManuallyManagedObject.expected
+++ b/cpp/cert/test/rules/MEM53-CPP/MissingConstructorCallForManuallyManagedObject.expected
@@ -2,6 +2,7 @@ WARNING: Module DataFlow has been deprecated and may be removed in future (/home
 WARNING: Module DataFlow has been deprecated and may be removed in future (/home/runner/work/semmle-code/semmle-code/codeql-coding-standards/cpp/cert/src/rules/MEM53-CPP/MissingConstructorCallForManuallyManagedObject.ql:25,38-46)
 WARNING: Module DataFlow has been deprecated and may be removed in future (/home/runner/work/semmle-code/semmle-code/codeql-coding-standards/cpp/cert/src/rules/MEM53-CPP/MissingConstructorCallForManuallyManagedObject.ql:25,65-73)
 edges
+| test.cpp:65:21:65:34 | call to operator new | test.cpp:67:26:67:32 | call to realloc |
 nodes
 | test.cpp:16:26:16:31 | call to malloc | semmle.label | call to malloc |
 | test.cpp:17:38:17:43 | call to malloc | semmle.label | call to malloc |
@@ -12,6 +13,8 @@ nodes
 | test.cpp:47:26:47:39 | call to operator new | semmle.label | call to operator new |
 | test.cpp:49:29:49:42 | call to operator new | semmle.label | call to operator new |
 | test.cpp:51:29:51:42 | call to operator new | semmle.label | call to operator new |
+| test.cpp:65:21:65:34 | call to operator new | semmle.label | call to operator new |
+| test.cpp:67:26:67:32 | call to realloc | semmle.label | call to realloc |
 subpaths
 #select
 | test.cpp:16:26:16:31 | call to malloc | test.cpp:16:26:16:31 | call to malloc | test.cpp:16:26:16:31 | call to malloc | Allocation to cast without constructor call |
@@ -23,3 +26,4 @@ subpaths
 | test.cpp:47:26:47:39 | call to operator new | test.cpp:47:26:47:39 | call to operator new | test.cpp:47:26:47:39 | call to operator new | Allocation to cast without constructor call |
 | test.cpp:49:29:49:42 | call to operator new | test.cpp:49:29:49:42 | call to operator new | test.cpp:49:29:49:42 | call to operator new | Allocation to cast without constructor call |
 | test.cpp:51:29:51:42 | call to operator new | test.cpp:51:29:51:42 | call to operator new | test.cpp:51:29:51:42 | call to operator new | Allocation to cast without constructor call |
+| test.cpp:67:26:67:32 | call to realloc | test.cpp:65:21:65:34 | call to operator new | test.cpp:67:26:67:32 | call to realloc | Allocation to cast without constructor call |

--- a/cpp/cert/test/rules/MEM53-CPP/test.cpp
+++ b/cpp/cert/test/rules/MEM53-CPP/test.cpp
@@ -63,6 +63,7 @@ void test_no_constructor_but_has_destructor() {
 
 void test_realloc() {
   void *goodAlloc = ::operator new(sizeof(ClassA));
-  ClassA *a1 = new (goodAlloc) ClassA{1};                        // COMPLIANT
-  ClassA *a2 = (ClassA *)realloc(goodAlloc, sizeof(ClassA) * 2); // COMPLIANT
+  ClassA *a1 = new (goodAlloc) ClassA{1}; // COMPLIANT
+  ClassA *a2 = (ClassA *)realloc(
+      goodAlloc, sizeof(ClassA) * 2); // COMPLIANT [FALSE_POSITIVE]
 }


### PR DESCRIPTION
## Description

In https://github.com/github/codeql/pull/14637 we added taint-flow through `realloc` functions, and this is causing a FP because Coding Standards is using the old AST-based dataflow library.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)