### PR TITLE
Include the names of the types that are different in the alert

### DIFF
--- a/cpp/autosar/src/rules/M5-0-20/BitwiseOperatorOperandsHaveDifferentUnderlyingType.ql
+++ b/cpp/autosar/src/rules/M5-0-20/BitwiseOperatorOperandsHaveDifferentUnderlyingType.ql
@@ -29,10 +29,14 @@ predicate isBinaryBitwiseOperation(Operation o, VariableAccess l, VariableAccess
   )
 }
 
-from Operation o, Variable left, Variable right
+from
+  Operation o, Variable left, Variable right, Type leftUnderlyingType, Type rightUnderlyingType
 where
   not isExcluded(o, ExpressionsPackage::bitwiseOperatorOperandsHaveDifferentUnderlyingTypeQuery()) and
   not o.isFromUninstantiatedTemplate(_) and
   isBinaryBitwiseOperation(o, left.getAnAccess(), right.getAnAccess()) and
-  left.getUnderlyingType() != right.getUnderlyingType()
-select o, "Operands of the '" + o.getOperator() + "' operation have different underlying types."
+  leftUnderlyingType = left.getUnderlyingType() and
+  rightUnderlyingType = right.getUnderlyingType() and
+  leftUnderlyingType != rightUnderlyingType
+select o,
+  "Operands of the '" + o.getOperator() + "' operation have different underlying types '" + leftUnderlyingType.getName() + "' and '" + rightUnderlyingType.getName() + "'."

--- a/cpp/autosar/test/rules/M5-0-20/BitwiseOperatorOperandsHaveDifferentUnderlyingType.expected
+++ b/cpp/autosar/test/rules/M5-0-20/BitwiseOperatorOperandsHaveDifferentUnderlyingType.expected
@@ -1,21 +1,21 @@
-| test.cpp:18:3:18:6 | ... & ... | Operands of the '&' operation have different underlying types. |
-| test.cpp:19:3:19:7 | ... \| ... | Operands of the '\|' operation have different underlying types. |
-| test.cpp:20:3:20:7 | ... ^ ... | Operands of the '^' operation have different underlying types. |
-| test.cpp:21:3:21:8 | ... << ... | Operands of the '<<' operation have different underlying types. |
-| test.cpp:22:3:22:8 | ... >> ... | Operands of the '>>' operation have different underlying types. |
-| test.cpp:23:3:23:8 | ... &= ... | Operands of the '&=' operation have different underlying types. |
-| test.cpp:24:3:24:8 | ... \|= ... | Operands of the '\|=' operation have different underlying types. |
-| test.cpp:25:3:25:8 | ... ^= ... | Operands of the '^=' operation have different underlying types. |
-| test.cpp:26:3:26:9 | ... <<= ... | Operands of the '<<=' operation have different underlying types. |
-| test.cpp:27:3:27:9 | ... >>= ... | Operands of the '>>=' operation have different underlying types. |
-| test.cpp:45:3:45:6 | ... & ... | Operands of the '&' operation have different underlying types. |
-| test.cpp:46:3:46:7 | ... \| ... | Operands of the '\|' operation have different underlying types. |
-| test.cpp:47:3:47:7 | ... ^ ... | Operands of the '^' operation have different underlying types. |
-| test.cpp:48:3:48:8 | ... << ... | Operands of the '<<' operation have different underlying types. |
-| test.cpp:49:3:49:8 | ... >> ... | Operands of the '>>' operation have different underlying types. |
-| test.cpp:50:3:50:8 | ... &= ... | Operands of the '&=' operation have different underlying types. |
-| test.cpp:51:3:51:8 | ... \|= ... | Operands of the '\|=' operation have different underlying types. |
-| test.cpp:52:3:52:8 | ... ^= ... | Operands of the '^=' operation have different underlying types. |
-| test.cpp:53:3:53:9 | ... <<= ... | Operands of the '<<=' operation have different underlying types. |
-| test.cpp:54:3:54:9 | ... >>= ... | Operands of the '>>=' operation have different underlying types. |
-| test.cpp:67:3:67:14 | ... << ... | Operands of the '<<' operation have different underlying types. |
+| test.cpp:18:3:18:6 | ... & ... | Operands of the '&' operation have different underlying types 'unsigned int' and 'unsigned short'. |
+| test.cpp:19:3:19:7 | ... \| ... | Operands of the '\|' operation have different underlying types 'unsigned int' and 'unsigned short'. |
+| test.cpp:20:3:20:7 | ... ^ ... | Operands of the '^' operation have different underlying types 'unsigned int' and 'unsigned short'. |
+| test.cpp:21:3:21:8 | ... << ... | Operands of the '<<' operation have different underlying types 'unsigned int' and 'unsigned short'. |
+| test.cpp:22:3:22:8 | ... >> ... | Operands of the '>>' operation have different underlying types 'unsigned int' and 'unsigned short'. |
+| test.cpp:23:3:23:8 | ... &= ... | Operands of the '&=' operation have different underlying types 'unsigned int' and 'unsigned short'. |
+| test.cpp:24:3:24:8 | ... \|= ... | Operands of the '\|=' operation have different underlying types 'unsigned int' and 'unsigned short'. |
+| test.cpp:25:3:25:8 | ... ^= ... | Operands of the '^=' operation have different underlying types 'unsigned int' and 'unsigned short'. |
+| test.cpp:26:3:26:9 | ... <<= ... | Operands of the '<<=' operation have different underlying types 'unsigned int' and 'unsigned short'. |
+| test.cpp:27:3:27:9 | ... >>= ... | Operands of the '>>=' operation have different underlying types 'unsigned int' and 'unsigned short'. |
+| test.cpp:45:3:45:6 | ... & ... | Operands of the '&' operation have different underlying types 'unsigned char' and 'unsigned short'. |
+| test.cpp:46:3:46:7 | ... \| ... | Operands of the '\|' operation have different underlying types 'unsigned char' and 'unsigned short'. |
+| test.cpp:47:3:47:7 | ... ^ ... | Operands of the '^' operation have different underlying types 'unsigned char' and 'unsigned short'. |
+| test.cpp:48:3:48:8 | ... << ... | Operands of the '<<' operation have different underlying types 'unsigned char' and 'unsigned short'. |
+| test.cpp:49:3:49:8 | ... >> ... | Operands of the '>>' operation have different underlying types 'unsigned char' and 'unsigned short'. |
+| test.cpp:50:3:50:8 | ... &= ... | Operands of the '&=' operation have different underlying types 'unsigned char' and 'unsigned short'. |
+| test.cpp:51:3:51:8 | ... \|= ... | Operands of the '\|=' operation have different underlying types 'unsigned char' and 'unsigned short'. |
+| test.cpp:52:3:52:8 | ... ^= ... | Operands of the '^=' operation have different underlying types 'unsigned char' and 'unsigned short'. |
+| test.cpp:53:3:53:9 | ... <<= ... | Operands of the '<<=' operation have different underlying types 'unsigned char' and 'unsigned short'. |
+| test.cpp:54:3:54:9 | ... >>= ... | Operands of the '>>=' operation have different underlying types 'unsigned char' and 'unsigned short'. |
+| test.cpp:67:3:67:14 | ... << ... | Operands of the '<<' operation have different underlying types 'int &' and 'char &'. |


### PR DESCRIPTION
## Description

Add the names of the underlying types that differ in the bit-wise operation to assist in diagnosing the contravention.

This PR is stacked on https://github.com/github/codeql-coding-standards/pull/390 so we need to merge this first.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)