### PR TITLE
Update release workflows to use GitHub App instead of PATs

### DIFF
--- a/.github/workflows/update-release-status.yml
+++ b/.github/workflows/update-release-status.yml
@@ -135,22 +135,22 @@ jobs:
           echo "check-run-head-sha=$CHECK_RUN_HEAD_SHA" >> "$GITHUB_OUTPUT"
 
   generate-token:
-      runs-on: ubuntu-latest
-      outputs:
-        token: ${{ steps.generate-token.outputs.token }}
-      steps:
-        - name: Generate token
-          id: generate-token
-          uses: actions/create-github-app-token@eaddb9eb7e4226c68cf4b39f167c83e5bd132b3e
-          with:
-            app_id: ${{ vars.AUTOMATION_APP_ID }}
-            private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.generate-token.outputs.token }}
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@eaddb9eb7e4226c68cf4b39f167c83e5bd132b3e
+        with:
+          app_id: ${{ vars.AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
 
   update-release:
     needs: [validate-check-runs, generate-token]
     if: needs.validate-check-runs.outputs.status == 'completed'
     uses: ./.github/workflows/update-release.yml
     with:
-        head-sha: ${{ needs.validate-check-runs.outputs.check-run-head-sha }}
+      head-sha: ${{ needs.validate-check-runs.outputs.check-run-head-sha }}
     secrets:
       RELEASE_ENGINEERING_TOKEN: ${{ generate-token.outputs.token }}

--- a/.github/workflows/update-release.yml
+++ b/.github/workflows/update-release.yml
@@ -23,18 +23,17 @@ env:
   HEAD_SHA: ${{ inputs.head-sha }}
 
 jobs:
-
   generate-token:
-      runs-on: ubuntu-latest
-      outputs:
-        token: ${{ steps.generate-token.outputs.token }}
-      steps:
-        - name: Generate token
-          id: generate-token
-          uses: actions/create-github-app-token@eaddb9eb7e4226c68cf4b39f167c83e5bd132b3e
-          with:
-            app_id: ${{ vars.AUTOMATION_APP_ID }}
-            private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.generate-token.outputs.token }}
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@eaddb9eb7e4226c68cf4b39f167c83e5bd132b3e
+        with:
+          app_id: ${{ vars.AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
 
   update-release:
     name: "Update release"

--- a/.github/workflows/validate-release.yml
+++ b/.github/workflows/validate-release.yml
@@ -15,16 +15,16 @@ env:
 
 jobs:
   generate-token:
-      runs-on: ubuntu-latest
-      outputs:
-        token: ${{ steps.generate-token.outputs.token }}
-      steps:
-        - name: Generate token
-          id: generate-token
-          uses: actions/create-github-app-token@eaddb9eb7e4226c68cf4b39f167c83e5bd132b3e
-          with:
-            app_id: ${{ vars.AUTOMATION_APP_ID }}
-            private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.generate-token.outputs.token }}
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@eaddb9eb7e4226c68cf4b39f167c83e5bd132b3e
+        with:
+          app_id: ${{ vars.AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.AUTOMATION_PRIVATE_KEY }}
 
   pre-validate-performance:
     outputs:
@@ -72,8 +72,8 @@ jobs:
     steps:
       - name: Fail check run status
         env:
-           CHECK_RUN_ID: ${{ needs.pre-validate-performance.outputs.check-run-id }}
-           GITHUB_TOKEN: ${{ github.token }}
+          CHECK_RUN_ID: ${{ needs.pre-validate-performance.outputs.check-run-id }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           jq -n \
           --arg status "completed" \
@@ -127,14 +127,15 @@ jobs:
           --ref rvermeulen/release-process
 
   on-failure-validate-compiler-compatibility-dispatch:
-    needs: [pre-validate-compiler-compatibility, validate-compiler-compatibility]
+    needs:
+      [pre-validate-compiler-compatibility, validate-compiler-compatibility]
     if: failure()
     runs-on: ubuntu-22.04
     steps:
       - name: Fail check run status
         env:
-           CHECK_RUN_ID: ${{ needs.pre-validate-compiler-compatibility.outputs.check-run-id }}
-           GITHUB_TOKEN: ${{ github.token }}
+          CHECK_RUN_ID: ${{ needs.pre-validate-compiler-compatibility.outputs.check-run-id }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           jq -n \
           --arg status "completed" \


### PR DESCRIPTION
## Description

This change replaces the use of PATs in the release process workflows with tokens generated by the `CodeQL Coding Standards Automation` GitHub App to ensure we are following best practices.

Other instances of PAT usage needs to be addressed in a separate PR.

## Change request type

 - [x] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [ ] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)