### PR TITLE
Modernize dataflow configurations

### DIFF
--- a/c/cert/src/rules/ARR39-C/DoNotAddOrSubtractAScaledIntegerToAPointer.ql
+++ b/c/cert/src/rules/ARR39-C/DoNotAddOrSubtractAScaledIntegerToAPointer.ql
@@ -15,7 +15,7 @@ import cpp
 import codingstandards.c.cert
 import codingstandards.c.Pointers
 import codingstandards.cpp.dataflow.TaintTracking
-import DataFlow::PathGraph
+import ScaledIntegerPointerArithmeticFlow::PathGraph
 
 /**
  * An expression which invokes the `offsetof` macro or `__builtin_offsetof` operation.
@@ -69,12 +69,10 @@ class ScaledIntegerExpr extends Expr {
  * A data-flow configuration modeling data-flow from a `ScaledIntegerExpr` to a
  * `PointerArithmeticExpr` where the pointer does not point to a 1-byte type.
  */
-class ScaledIntegerPointerArithmeticConfig extends DataFlow::Configuration {
-  ScaledIntegerPointerArithmeticConfig() { this = "ScaledIntegerPointerArithmeticConfig" }
+module ScaledIntegerPointerArithmeticConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) { src.asExpr() instanceof ScaledIntegerExpr }
 
-  override predicate isSource(DataFlow::Node src) { src.asExpr() instanceof ScaledIntegerExpr }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(PointerArithmeticExpr pa |
       // exclude pointers to 1-byte types as they do not scale
       pa.getPointer().getFullyConverted().getType().(DerivedType).getBaseType().getSize() != 1 and
@@ -83,9 +81,13 @@ class ScaledIntegerPointerArithmeticConfig extends DataFlow::Configuration {
   }
 }
 
-from ScaledIntegerPointerArithmeticConfig config, DataFlow::PathNode src, DataFlow::PathNode sink
+module ScaledIntegerPointerArithmeticFlow = DataFlow::Global<ScaledIntegerPointerArithmeticConfig>;
+
+from
+  ScaledIntegerPointerArithmeticFlow::PathNode src,
+  ScaledIntegerPointerArithmeticFlow::PathNode sink
 where
   not isExcluded(sink.getNode().asExpr(),
     Pointers2Package::doNotAddOrSubtractAScaledIntegerToAPointerQuery()) and
-  config.hasFlowPath(src, sink)
+  ScaledIntegerPointerArithmeticFlow::flowPath(src, sink)
 select sink, src, sink, "Scaled integer used in pointer arithmetic."

--- a/c/cert/src/rules/EXP36-C/DoNotCastPointerToMoreStrictlyAlignedPointerType.ql
+++ b/c/cert/src/rules/EXP36-C/DoNotCastPointerToMoreStrictlyAlignedPointerType.ql
@@ -17,7 +17,7 @@ import codingstandards.cpp.Alignment
 import codingstandards.cpp.dataflow.DataFlow
 import codingstandards.cpp.dataflow.DataFlow2
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
-import DataFlow::PathGraph
+import ExprWithAlignmentToCStyleCastFlow::PathGraph
 
 /**
  * An expression with a type that has defined alignment requirements
@@ -96,8 +96,7 @@ class UnconvertedCastFromNonVoidPointerExpr extends Expr {
  */
 class DefaultAlignedPointerExpr extends UnconvertedCastFromNonVoidPointerExpr, ExprWithAlignment {
   DefaultAlignedPointerExpr() {
-    not any(AllocationOrAddressOfExprToUnconvertedCastFromNonVoidPointerExprConfig config)
-        .hasFlowTo(DataFlow::exprNode(this))
+    not AllocationOrAddressOfExprToUnconvertedCastFromNonVoidPointerExprFlow::flowTo(DataFlow::exprNode(this))
   }
 
   override int getAlignment() { result = this.getType().(PointerType).getBaseType().getAlignment() }
@@ -118,43 +117,37 @@ class DefaultAlignedPointerExpr extends UnconvertedCastFromNonVoidPointerExpr, E
  * to exclude an `DefaultAlignedPointerAccessExpr` as a source if a preceding source
  * defined by this configuration provides more accurate alignment information.
  */
-class AllocationOrAddressOfExprToUnconvertedCastFromNonVoidPointerExprConfig extends DataFlow2::Configuration
+module AllocationOrAddressOfExprToUnconvertedCastFromNonVoidPointerExprConfig implements
+  DataFlow::ConfigSig
 {
-  AllocationOrAddressOfExprToUnconvertedCastFromNonVoidPointerExprConfig() {
-    this = "AllocationOrAddressOfExprToUnconvertedCastFromNonVoidPointerExprConfig"
-  }
-
-  override predicate isSource(DataFlow::Node source) {
+  predicate isSource(DataFlow::Node source) {
     source.asExpr() instanceof AddressOfAlignedVariableExpr or
     source.asExpr() instanceof DefinedAlignmentAllocationExpr
   }
 
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     sink.asExpr() instanceof UnconvertedCastFromNonVoidPointerExpr
   }
 }
+
+module AllocationOrAddressOfExprToUnconvertedCastFromNonVoidPointerExprFlow =
+  DataFlow::Global<AllocationOrAddressOfExprToUnconvertedCastFromNonVoidPointerExprConfig>;
 
 /**
  * A data-flow configuration for analysing the flow of `ExprWithAlignment` pointer expressions
  * to casts which perform pointer type conversions and potentially create pointer alignment issues.
  */
-class ExprWithAlignmentToCStyleCastConfiguration extends DataFlow::Configuration {
-  ExprWithAlignmentToCStyleCastConfiguration() {
-    this = "ExprWithAlignmentToCStyleCastConfiguration"
-  }
+module ExprWithAlignmentToCStyleCastConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source.asExpr() instanceof ExprWithAlignment }
 
-  override predicate isSource(DataFlow::Node source) {
-    source.asExpr() instanceof ExprWithAlignment
-  }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(CStyleCast cast |
       cast.getUnderlyingType() instanceof PointerType and
       cast.getUnconverted() = sink.asExpr()
     )
   }
 
-  override predicate isBarrierOut(DataFlow::Node node) {
+  predicate isBarrierOut(DataFlow::Node node) {
     // the default interprocedural data-flow model flows through any array assignment expressions
     // to the qualifier (array base or pointer dereferenced) instead of the individual element
     // that the assignment modifies. this default behaviour causes false positives for any future
@@ -169,12 +162,15 @@ class ExprWithAlignmentToCStyleCastConfiguration extends DataFlow::Configuration
   }
 }
 
+module ExprWithAlignmentToCStyleCastFlow = DataFlow::Global<ExprWithAlignmentToCStyleCastConfig>;
+
 from
-  DataFlow::PathNode source, DataFlow::PathNode sink, ExprWithAlignment expr, CStyleCast cast,
+  ExprWithAlignmentToCStyleCastFlow::PathNode source,
+  ExprWithAlignmentToCStyleCastFlow::PathNode sink, ExprWithAlignment expr, CStyleCast cast,
   Type toBaseType, int alignmentFrom, int alignmentTo
 where
   not isExcluded(cast, Pointers3Package::doNotCastPointerToMoreStrictlyAlignedPointerTypeQuery()) and
-  any(ExprWithAlignmentToCStyleCastConfiguration config).hasFlowPath(source, sink) and
+  ExprWithAlignmentToCStyleCastFlow::flowPath(source, sink) and
   source.getNode().asExpr() = expr and
   sink.getNode().asExpr() = cast.getUnconverted() and
   toBaseType = cast.getActualType().(PointerType).getBaseType() and

--- a/c/cert/src/rules/EXP36-C/DoNotCastPointerToMoreStrictlyAlignedPointerType.ql
+++ b/c/cert/src/rules/EXP36-C/DoNotCastPointerToMoreStrictlyAlignedPointerType.ql
@@ -15,7 +15,6 @@ import cpp
 import codingstandards.c.cert
 import codingstandards.cpp.Alignment
 import codingstandards.cpp.dataflow.DataFlow
-import codingstandards.cpp.dataflow.DataFlow2
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 import ExprWithAlignmentToCStyleCastFlow::PathGraph
 

--- a/c/cert/src/rules/EXP37-C/DoNotCallFunctionPointerWithIncompatibleType.ql
+++ b/c/cert/src/rules/EXP37-C/DoNotCallFunctionPointerWithIncompatibleType.ql
@@ -14,7 +14,7 @@
 import cpp
 import codingstandards.c.cert
 import codingstandards.cpp.dataflow.DataFlow
-import DataFlow::PathGraph
+import SuspectFunctionPointerToCallFlow::PathGraph
 
 /**
  * An expression of type `FunctionPointer` which is the unconverted expression of a cast
@@ -37,26 +37,26 @@ class SuspiciousFunctionPointerCastExpr extends Expr {
  * Data-flow configuration for flow from a `SuspiciousFunctionPointerCastExpr`
  * to a call of the function pointer resulting from the function pointer cast
  */
-class SuspectFunctionPointerToCallConfig extends DataFlow::Configuration {
-  SuspectFunctionPointerToCallConfig() { this = "SuspectFunctionPointerToCallConfig" }
-
-  override predicate isSource(DataFlow::Node src) {
+module SuspectFunctionPointerToCallConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) {
     src.asExpr() instanceof SuspiciousFunctionPointerCastExpr
   }
 
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(VariableCall call | sink.asExpr() = call.getExpr().(VariableAccess))
   }
 }
 
+module SuspectFunctionPointerToCallFlow = DataFlow::Global<SuspectFunctionPointerToCallConfig>;
+
 from
-  SuspectFunctionPointerToCallConfig config, DataFlow::PathNode src, DataFlow::PathNode sink,
+  SuspectFunctionPointerToCallFlow::PathNode src, SuspectFunctionPointerToCallFlow::PathNode sink,
   Access access
 where
   not isExcluded(src.getNode().asExpr(),
     ExpressionsPackage::doNotCallFunctionPointerWithIncompatibleTypeQuery()) and
   access = src.getNode().asExpr() and
-  config.hasFlowPath(src, sink)
+  SuspectFunctionPointerToCallFlow::flowPath(src, sink)
 select src, src, sink,
   "Incompatible function $@ assigned to function pointer is eventually called through the pointer.",
   access.getTarget(), access.getTarget().getName()

--- a/c/cert/src/rules/FIO44-C/OnlyUseValuesForFsetposThatAreReturnedFromFgetpos.ql
+++ b/c/cert/src/rules/FIO44-C/OnlyUseValuesForFsetposThatAreReturnedFromFgetpos.ql
@@ -22,24 +22,24 @@ class FsetposCall extends FunctionCall {
   FsetposCall() { this.getTarget().hasGlobalOrStdName("fsetpos") }
 }
 
-class FposDFConf extends DataFlow::Configuration {
-  FposDFConf() { this = "FposDFConf" }
-
-  override predicate isSource(DataFlow::Node source) {
+module FposDFConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
     // source must be the second parameter of a FgetposCall call
     source = DataFlow::definitionByReferenceNodeFromArgument(any(FgetposCall c).getArgument(1))
   }
 
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     // sink must be the second parameter of a FsetposCall call
     sink.asExpr() = any(FsetposCall c).getArgument(1)
   }
 }
 
+module FposDFFlow = DataFlow::Global<FposDFConfig>;
+
 from FsetposCall fsetpos
 where
   not isExcluded(fsetpos.getArgument(1),
     IO2Package::onlyUseValuesForFsetposThatAreReturnedFromFgetposQuery()) and
-  not any(FposDFConf dfConf).hasFlowToExpr(fsetpos.getArgument(1))
+  not FposDFFlow::flowToExpr(fsetpos.getArgument(1))
 select fsetpos.getArgument(1),
   "The position argument of a call to `fsetpos()` should be obtained from a call to `fgetpos()`."

--- a/c/cert/src/rules/MEM36-C/DoNotModifyAlignmentOfMemoryWithRealloc.ql
+++ b/c/cert/src/rules/MEM36-C/DoNotModifyAlignmentOfMemoryWithRealloc.ql
@@ -16,7 +16,7 @@ import cpp
 import codingstandards.c.cert
 import codingstandards.cpp.Alignment
 import codingstandards.cpp.dataflow.DataFlow
-import DataFlow::PathGraph
+import AlignedAllocToReallocFlow::PathGraph
 
 int getStatedValue(Expr e) {
   // `upperBound(e)` defaults to `exprMaxVal(e)` when `e` isn't analyzable. So to get a meaningful
@@ -37,22 +37,22 @@ class ReallocCall extends FunctionCall {
   ReallocCall() { this.getTarget().hasName("realloc") }
 }
 
-class AlignedAllocToReallocConfig extends DataFlow::Configuration {
-  AlignedAllocToReallocConfig() { this = "AlignedAllocToReallocConfig" }
-
-  override predicate isSource(DataFlow::Node source) {
+module AlignedAllocToReallocConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
     source.asExpr() instanceof NonDefaultAlignedAllocCall
   }
 
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(ReallocCall realloc | sink.asExpr() = realloc.getArgument(0))
   }
 }
 
-from AlignedAllocToReallocConfig cfg, DataFlow::PathNode source, DataFlow::PathNode sink
+module AlignedAllocToReallocFlow = DataFlow::Global<AlignedAllocToReallocConfig>;
+
+from AlignedAllocToReallocFlow::PathNode source, AlignedAllocToReallocFlow::PathNode sink
 where
   not isExcluded(sink.getNode().asExpr(),
     Memory2Package::doNotModifyAlignmentOfMemoryWithReallocQuery()) and
-  cfg.hasFlowPath(source, sink)
+  AlignedAllocToReallocFlow::flowPath(source, sink)
 select sink, source, sink, "Memory allocated with $@ but reallocated with realloc.",
   source.getNode().asExpr(), "aligned_alloc"

--- a/c/cert/src/rules/MSC33-C/DoNotPassInvalidDataToTheAsctimeFunction.ql
+++ b/c/cert/src/rules/MSC33-C/DoNotPassInvalidDataToTheAsctimeFunction.ql
@@ -30,22 +30,22 @@ class AsctimeArg extends Expr {
  * Dataflow configuration for flow from a library function
  * to a call of function `asctime`
  */
-class TmStructSafeConfig extends DataFlow::Configuration {
-  TmStructSafeConfig() { this = "TmStructSafeConfig" }
-
-  override predicate isSource(DataFlow::Node src) {
+module TmStructSafeConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) {
     src.asExpr()
         .(FunctionCall)
         .getTarget()
         .hasGlobalName(["localtime", "localtime_r", "localtime_s", "gmtime", "gmtime_r", "gmtime_s"])
   }
 
-  override predicate isSink(DataFlow::Node sink) { sink.asExpr() instanceof AsctimeArg }
+  predicate isSink(DataFlow::Node sink) { sink.asExpr() instanceof AsctimeArg }
 }
 
-from AsctimeArg fc, TmStructSafeConfig config
+module TmStructSafeFlow = DataFlow::Global<TmStructSafeConfig>;
+
+from AsctimeArg fc
 where
   not isExcluded(fc, Contracts7Package::doNotPassInvalidDataToTheAsctimeFunctionQuery()) and
-  not config.hasFlowToExpr(fc)
+  not TmStructSafeFlow::flowToExpr(fc)
 select fc,
   "The function `asctime` and `asctime_r` should be discouraged. Unsanitized input can overflow the output buffer."

--- a/c/cert/src/rules/MSC39-C/DoNotCallVaArgOnAVaListThatHasAnIndeterminateValue.ql
+++ b/c/cert/src/rules/MSC39-C/DoNotCallVaArgOnAVaListThatHasAnIndeterminateValue.ql
@@ -35,16 +35,16 @@ class VaEndArg extends VaAccess {
  * Dataflow configuration for flow from a library function
  * to a call of function `asctime`
  */
-class VaArgConfig extends DataFlow::Configuration {
-  VaArgConfig() { this = "VaArgConfig" }
-
-  override predicate isSource(DataFlow::Node src) {
+module VaArgConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) {
     src.asUninitialized() =
       any(VariableDeclarationEntry m | m.getType().hasName("va_list")).getVariable()
   }
 
-  override predicate isSink(DataFlow::Node sink) { sink.asExpr() instanceof VaAccess }
+  predicate isSink(DataFlow::Node sink) { sink.asExpr() instanceof VaAccess }
 }
+
+module VaArgFlow = DataFlow::Global<VaArgConfig>;
 
 /**
  * Controlflow nodes preceeding a call to `va_arg`
@@ -65,9 +65,9 @@ ControlFlowNode preceedsFC(VaAccess va_arg) {
 }
 
 predicate sameSource(VaAccess e1, VaAccess e2) {
-  exists(VaArgConfig config, DataFlow::Node source |
-    config.hasFlow(source, DataFlow::exprNode(e1)) and
-    config.hasFlow(source, DataFlow::exprNode(e2))
+  exists(DataFlow::Node source |
+    VaArgFlow::flow(source, DataFlow::exprNode(e1)) and
+    VaArgFlow::flow(source, DataFlow::exprNode(e2))
   )
 }
 

--- a/c/common/test/rules/donotsubtractpointersaddressingdifferentarrays/DoNotSubtractPointersAddressingDifferentArrays.expected
+++ b/c/common/test/rules/donotsubtractpointersaddressingdifferentarrays/DoNotSubtractPointersAddressingDifferentArrays.expected
@@ -4,15 +4,19 @@ problems
 | test.c:13:10:13:11 | p4 | test.c:5:14:5:15 | l2 | test.c:13:10:13:11 | p4 | Subtraction between left operand pointing to array $@ and other operand pointing to array $@. | test.c:3:7:3:8 | l2 | l2 | test.c:2:7:2:8 | l1 | l1 |
 | test.c:13:15:13:16 | l1 | test.c:13:15:13:16 | l1 | test.c:13:15:13:16 | l1 | Subtraction between right operand pointing to array $@ and other operand pointing to array $@. | test.c:2:7:2:8 | l1 | l1 | test.c:3:7:3:8 | l2 | l2 |
 edges
-| test.c:4:14:4:15 | l1 | test.c:10:10:10:11 | p1 |
-| test.c:4:14:4:15 | l1 | test.c:12:10:12:11 | p1 |
-| test.c:5:14:5:15 | l2 | test.c:11:10:11:11 | p2 |
-| test.c:5:14:5:15 | l2 | test.c:12:15:12:16 | p2 |
-| test.c:5:14:5:15 | l2 | test.c:13:10:13:11 | p4 |
-| test.c:5:14:5:15 | l2 | test.c:14:10:14:11 | p4 |
+| test.c:4:14:4:15 | l1 | test.c:4:14:4:18 | access to array |
+| test.c:4:14:4:18 | access to array | test.c:10:10:10:11 | p1 |
+| test.c:4:14:4:18 | access to array | test.c:12:10:12:11 | p1 |
+| test.c:5:14:5:15 | l2 | test.c:5:14:5:19 | access to array |
+| test.c:5:14:5:19 | access to array | test.c:11:10:11:11 | p2 |
+| test.c:5:14:5:19 | access to array | test.c:12:15:12:16 | p2 |
+| test.c:5:14:5:19 | access to array | test.c:13:10:13:11 | p4 |
+| test.c:5:14:5:19 | access to array | test.c:14:10:14:11 | p4 |
 nodes
 | test.c:4:14:4:15 | l1 | semmle.label | l1 |
+| test.c:4:14:4:18 | access to array | semmle.label | access to array |
 | test.c:5:14:5:15 | l2 | semmle.label | l2 |
+| test.c:5:14:5:19 | access to array | semmle.label | access to array |
 | test.c:10:10:10:11 | p1 | semmle.label | p1 |
 | test.c:10:15:10:16 | l1 | semmle.label | l1 |
 | test.c:11:10:11:11 | p2 | semmle.label | p2 |

--- a/c/common/test/rules/donotuserelationaloperatorswithdifferingarrays/DoNotUseRelationalOperatorsWithDifferingArrays.expected
+++ b/c/common/test/rules/donotuserelationaloperatorswithdifferingarrays/DoNotUseRelationalOperatorsWithDifferingArrays.expected
@@ -11,20 +11,26 @@ problems
 | test.c:25:7:25:14 | ... >= ... | test.c:25:13:25:14 | l3 | test.c:25:13:25:14 | l3 | Compare operation >= comparing right operand pointing to array $@ and other operand pointing to array $@. | test.c:4:7:4:8 | l3 | l3 | test.c:2:7:2:8 | l1 | l1 |
 edges
 | test.c:6:13:6:14 | l1 | test.c:13:12:13:13 | p0 |
-| test.c:7:14:7:15 | l1 | test.c:11:7:11:8 | p1 |
-| test.c:7:14:7:15 | l1 | test.c:13:7:13:8 | p1 |
-| test.c:7:14:7:15 | l1 | test.c:15:13:15:14 | p1 |
-| test.c:7:14:7:15 | l1 | test.c:17:7:17:8 | p1 |
-| test.c:7:14:7:15 | l1 | test.c:23:13:23:14 | p1 |
-| test.c:7:14:7:15 | l1 | test.c:25:7:25:8 | p1 |
-| test.c:8:14:8:15 | l1 | test.c:11:12:11:13 | p2 |
-| test.c:8:14:8:15 | l1 | test.c:21:7:21:8 | p2 |
-| test.c:9:14:9:15 | l2 | test.c:21:12:21:13 | p3 |
+| test.c:7:14:7:15 | l1 | test.c:7:14:7:18 | access to array |
+| test.c:7:14:7:18 | access to array | test.c:11:7:11:8 | p1 |
+| test.c:7:14:7:18 | access to array | test.c:13:7:13:8 | p1 |
+| test.c:7:14:7:18 | access to array | test.c:15:13:15:14 | p1 |
+| test.c:7:14:7:18 | access to array | test.c:17:7:17:8 | p1 |
+| test.c:7:14:7:18 | access to array | test.c:23:13:23:14 | p1 |
+| test.c:7:14:7:18 | access to array | test.c:25:7:25:8 | p1 |
+| test.c:8:14:8:15 | l1 | test.c:8:14:8:18 | access to array |
+| test.c:8:14:8:18 | access to array | test.c:11:12:11:13 | p2 |
+| test.c:8:14:8:18 | access to array | test.c:21:7:21:8 | p2 |
+| test.c:9:14:9:15 | l2 | test.c:9:14:9:18 | access to array |
+| test.c:9:14:9:18 | access to array | test.c:21:12:21:13 | p3 |
 nodes
 | test.c:6:13:6:14 | l1 | semmle.label | l1 |
 | test.c:7:14:7:15 | l1 | semmle.label | l1 |
+| test.c:7:14:7:18 | access to array | semmle.label | access to array |
 | test.c:8:14:8:15 | l1 | semmle.label | l1 |
+| test.c:8:14:8:18 | access to array | semmle.label | access to array |
 | test.c:9:14:9:15 | l2 | semmle.label | l2 |
+| test.c:9:14:9:18 | access to array | semmle.label | access to array |
 | test.c:11:7:11:8 | p1 | semmle.label | p1 |
 | test.c:11:12:11:13 | p2 | semmle.label | p2 |
 | test.c:13:7:13:8 | p1 | semmle.label | p1 |

--- a/c/misra/src/rules/RULE-17-5/ArrayFunctionArgumentNumberOfElements.ql
+++ b/c/misra/src/rules/RULE-17-5/ArrayFunctionArgumentNumberOfElements.ql
@@ -44,21 +44,22 @@ class ArrayParameter extends Parameter {
  */
 int countElements(ArrayAggregateLiteral l) { result = count(l.getAnElementExpr(_)) }
 
-class SmallArrayConfig extends DataFlow::Configuration {
-  SmallArrayConfig() { this = "SmallArrayConfig" }
+module SmallArrayConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node src) { src.asExpr() instanceof ArrayAggregateLiteral }
 
-  override predicate isSource(DataFlow::Node src) { src.asExpr() instanceof ArrayAggregateLiteral }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     sink.asExpr() = any(ArrayParameter p).getAMatchingArgument()
   }
 }
 
+module SmallArrayFlow = DataFlow::Global<SmallArrayConfig>;
+
 from Expr arg, ArrayParameter p
 where
   not isExcluded(arg, Contracts6Package::arrayFunctionArgumentNumberOfElementsQuery()) and
-  exists(SmallArrayConfig config | arg = p.getAMatchingArgument() |
-    // the argument is a value and not an arrey
+  arg = p.getAMatchingArgument() and
+  (
+    // the argument is a value and not an array
     not arg.getType() instanceof DerivedType
     or
     // the argument is an array too small
@@ -67,7 +68,7 @@ where
     // the argument is a pointer and its value does not come from a literal of the correct
     arg.getType() instanceof PointerType and
     not exists(ArrayAggregateLiteral l |
-      config.hasFlow(DataFlow::exprNode(l), DataFlow::exprNode(arg)) and
+      SmallArrayFlow::flow(DataFlow::exprNode(l), DataFlow::exprNode(arg)) and
       countElements(l) >= p.getArraySize()
     )
   )

--- a/cpp/autosar/src/rules/A5-1-7/LambdaPassedToDecltype.ql
+++ b/cpp/autosar/src/rules/A5-1-7/LambdaPassedToDecltype.ql
@@ -17,15 +17,15 @@ import cpp
 import codingstandards.cpp.autosar
 import codingstandards.cpp.dataflow.DataFlow
 
-class LambdaExpressionToInitializer extends DataFlow::Configuration {
-  LambdaExpressionToInitializer() { this = "LambdaExpressionToInitializer" }
+module LambdaExpressionToInitializerConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source.asExpr() instanceof LambdaExpression }
 
-  override predicate isSource(DataFlow::Node source) { source.asExpr() instanceof LambdaExpression }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(Variable v | v.getInitializer().getExpr() = sink.asExpr())
   }
 }
+
+module LambdaExpressionToInitializerFlow = DataFlow::Global<LambdaExpressionToInitializerConfig>;
 
 from Decltype dt, LambdaExpression lambda
 where
@@ -33,10 +33,11 @@ where
   (
     dt.getExpr() = lambda
     or
-    exists(LambdaExpressionToInitializer config, VariableAccess va, Variable v |
+    exists(VariableAccess va, Variable v |
       dt.getExpr() = va and
       v = va.getTarget() and
-      config.hasFlow(DataFlow::exprNode(lambda), DataFlow::exprNode(v.getInitializer().getExpr()))
+      LambdaExpressionToInitializerFlow::flow(DataFlow::exprNode(lambda),
+        DataFlow::exprNode(v.getInitializer().getExpr()))
     )
   )
 select dt, "Lambda $@ passed as operand to decltype.", lambda, "expression"

--- a/cpp/autosar/src/rules/A5-1-7/LambdaPassedToTypeid.ql
+++ b/cpp/autosar/src/rules/A5-1-7/LambdaPassedToTypeid.ql
@@ -16,21 +16,19 @@
 import cpp
 import codingstandards.cpp.dataflow.DataFlow
 import codingstandards.cpp.autosar
-import DataFlow::PathGraph
+import LambdaExpressionToTypeidFlow::PathGraph
 
-class LambdaExpressionToTypeid extends DataFlow::Configuration {
-  LambdaExpressionToTypeid() { this = "LambdaExpressionToTypeid" }
+module LambdaExpressionToTypeidConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source.asExpr() instanceof LambdaExpression }
 
-  override predicate isSource(DataFlow::Node source) { source.asExpr() instanceof LambdaExpression }
-
-  override predicate isSink(DataFlow::Node sink) {
-    exists(TypeidOperator op | op.getExpr() = sink.asExpr())
-  }
+  predicate isSink(DataFlow::Node sink) { exists(TypeidOperator op | op.getExpr() = sink.asExpr()) }
 }
 
-from DataFlow::PathNode source, DataFlow::PathNode sink
+module LambdaExpressionToTypeidFlow = DataFlow::Global<LambdaExpressionToTypeidConfig>;
+
+from LambdaExpressionToTypeidFlow::PathNode source, LambdaExpressionToTypeidFlow::PathNode sink
 where
   not isExcluded(source.getNode().asExpr(), LambdasPackage::lambdaPassedToTypeidQuery()) and
-  any(LambdaExpressionToTypeid config).hasFlowPath(source, sink)
+  LambdaExpressionToTypeidFlow::flowPath(source, sink)
 select sink.getNode(), source, sink, "Lambda $@ passed as operand to typeid operator.",
   source.getNode(), "expression"

--- a/cpp/autosar/src/rules/M5-0-17/PointerSubtractionOnDifferentArrays.ql
+++ b/cpp/autosar/src/rules/M5-0-17/PointerSubtractionOnDifferentArrays.ql
@@ -16,40 +16,41 @@
 import cpp
 import codingstandards.cpp.autosar
 import codingstandards.cpp.dataflow.DataFlow
-import DataFlow::PathGraph
+import ArrayToPointerDiffOperandFlow::PathGraph
 
-class ArrayToPointerDiffOperandConfig extends DataFlow::Configuration {
-  ArrayToPointerDiffOperandConfig() { this = "ArrayToPointerDiffOperandConfig" }
-
-  override predicate isSource(DataFlow::Node source) {
+module ArrayToPointerDiffOperandConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
     source.asExpr().(VariableAccess).getType() instanceof ArrayType
     or
     // Consider array to pointer decay for parameters.
     source.asExpr().(VariableAccess).getTarget().(Parameter).getType() instanceof ArrayType
   }
 
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(PointerDiffExpr e | e.getAnOperand() = sink.asExpr())
   }
 
-  override predicate isAdditionalFlowStep(DataFlow::Node pred, DataFlow::Node succ) {
+  predicate isAdditionalFlowStep(DataFlow::Node pred, DataFlow::Node succ) {
     // Add a flow step from the base to the array expression to track pointers to elements of the array.
     exists(ArrayExpr e | e.getArrayBase() = pred.asExpr() and e = succ.asExpr())
   }
 }
 
+module ArrayToPointerDiffOperandFlow = DataFlow::Global<ArrayToPointerDiffOperandConfig>;
+
 from
   PointerDiffExpr pointerSubstraction, Variable currentOperandPointee, Variable otherOperandPointee,
-  DataFlow::PathNode source, DataFlow::PathNode sink, string side
+  ArrayToPointerDiffOperandFlow::PathNode source, ArrayToPointerDiffOperandFlow::PathNode sink,
+  string side
 where
   not isExcluded(pointerSubstraction, PointersPackage::pointerSubtractionOnDifferentArraysQuery()) and
-  exists(ArrayToPointerDiffOperandConfig c, Variable sourceLeft, Variable sourceRight |
-    c.hasFlow(DataFlow::exprNode(sourceLeft.getAnAccess()),
+  exists(Variable sourceLeft, Variable sourceRight |
+    ArrayToPointerDiffOperandFlow::flow(DataFlow::exprNode(sourceLeft.getAnAccess()),
       DataFlow::exprNode(pointerSubstraction.getLeftOperand())) and
-    c.hasFlow(DataFlow::exprNode(sourceRight.getAnAccess()),
+    ArrayToPointerDiffOperandFlow::flow(DataFlow::exprNode(sourceRight.getAnAccess()),
       DataFlow::exprNode(pointerSubstraction.getRightOperand())) and
     not sourceLeft = sourceRight and
-    c.hasFlowPath(source, sink) and
+    ArrayToPointerDiffOperandFlow::flowPath(source, sink) and
     (
       source.getNode().asExpr() = sourceLeft.getAnAccess() and
       sink.getNode().asExpr() = pointerSubstraction.getLeftOperand() and

--- a/cpp/autosar/test/rules/A18-1-4/PointerToAnElementOfAnArrayPassedToASmartPointer.expected
+++ b/cpp/autosar/test/rules/A18-1-4/PointerToAnElementOfAnArrayPassedToASmartPointer.expected
@@ -2,11 +2,13 @@ edges
 | test.cpp:3:36:3:45 | new[] | test.cpp:19:27:19:44 | call to allocate_int_array |
 | test.cpp:3:36:3:45 | new[] | test.cpp:23:12:23:29 | call to allocate_int_array |
 | test.cpp:3:36:3:45 | new[] | test.cpp:27:20:27:37 | call to allocate_int_array |
-| test.cpp:11:29:11:41 | call to unique_ptr | test.cpp:12:30:12:36 | call to release |
+| test.cpp:11:29:11:41 | call to unique_ptr | test.cpp:12:27:12:28 | v2 |
+| test.cpp:12:27:12:28 | v2 | test.cpp:12:30:12:36 | call to release |
 | test.cpp:27:20:27:37 | call to allocate_int_array | test.cpp:32:12:32:20 | int_array |
 nodes
 | test.cpp:3:36:3:45 | new[] | semmle.label | new[] |
 | test.cpp:11:29:11:41 | call to unique_ptr | semmle.label | call to unique_ptr |
+| test.cpp:12:27:12:28 | v2 | semmle.label | v2 |
 | test.cpp:12:30:12:36 | call to release | semmle.label | call to release |
 | test.cpp:19:27:19:44 | call to allocate_int_array | semmle.label | call to allocate_int_array |
 | test.cpp:23:12:23:29 | call to allocate_int_array | semmle.label | call to allocate_int_array |

--- a/cpp/cert/src/rules/CTR56-CPP/DoNotUsePointerArithmeticOnPolymorphicObjects.ql
+++ b/cpp/cert/src/rules/CTR56-CPP/DoNotUsePointerArithmeticOnPolymorphicObjects.ql
@@ -14,7 +14,7 @@
 import cpp
 import codingstandards.cpp.cert
 import codingstandards.cpp.dataflow.DataFlow
-import DataFlow::PathGraph
+import NonFinalClassToPointerArithmeticExprFlow::PathGraph
 
 class ArrayAccessOrPointerArith extends Expr {
   ArrayAccessOrPointerArith() {
@@ -38,12 +38,8 @@ class AddressOfPointerCreation extends ClassPointerCreation, AddressOfExpr {
   AddressOfPointerCreation() { this.getAnOperand().getUnderlyingType() instanceof Class }
 }
 
-class NonFinalClassToPointerArithmeticExprConfig extends DataFlow::Configuration {
-  NonFinalClassToPointerArithmeticExprConfig() {
-    this = "NonFinalClassToPointerArithmeticExprConfig"
-  }
-
-  override predicate isSource(DataFlow::Node source) {
+module NonFinalClassToPointerArithmeticExprConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
     exists(Class c |
       source.asExpr() instanceof ClassPointerCreation and
       source.asExpr().getUnderlyingType().(PointerType).getBaseType() = c
@@ -52,17 +48,21 @@ class NonFinalClassToPointerArithmeticExprConfig extends DataFlow::Configuration
     )
   }
 
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(ArrayAccessOrPointerArith e | e.getAnOperand() = sink.asExpr())
   }
 }
 
+module NonFinalClassToPointerArithmeticExprFlow =
+  DataFlow::Global<NonFinalClassToPointerArithmeticExprConfig>;
+
 from
-  ArrayAccessOrPointerArith e, Class clz, Variable v, DataFlow::PathNode source,
-  DataFlow::PathNode sink
+  ArrayAccessOrPointerArith e, Class clz, Variable v,
+  NonFinalClassToPointerArithmeticExprFlow::PathNode source,
+  NonFinalClassToPointerArithmeticExprFlow::PathNode sink
 where
   not isExcluded(e, PointersPackage::doNotUsePointerArithmeticOnPolymorphicObjectsQuery()) and
-  any(NonFinalClassToPointerArithmeticExprConfig c).hasFlowPath(source, sink) and
+  NonFinalClassToPointerArithmeticExprFlow::flowPath(source, sink) and
   v.getAnAssignedValue() = source.getNode().asExpr() and
   (
     e.(PointerArithmeticOperation).getAnOperand() = sink.getNode().asExpr()

--- a/cpp/cert/src/rules/EXP51-CPP/DoNotDeleteAnArrayThroughAPointerOfTheIncorrectType.ql
+++ b/cpp/cert/src/rules/EXP51-CPP/DoNotDeleteAnArrayThroughAPointerOfTheIncorrectType.ql
@@ -14,25 +14,25 @@
 import cpp
 import codingstandards.cpp.cert
 import codingstandards.cpp.dataflow.DataFlow
-import DataFlow::PathGraph
+import AllocationToDeleteFlow::PathGraph
 
-class AllocationToDeleteConfig extends DataFlow::Configuration {
-  AllocationToDeleteConfig() { this = "AllocationToDelete" }
+module AllocationToDeleteConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source.asExpr() instanceof NewArrayExpr }
 
-  override predicate isSource(DataFlow::Node source) { source.asExpr() instanceof NewArrayExpr }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(DeleteArrayExpr dae | dae.getExpr() = sink.asExpr())
   }
 }
 
+module AllocationToDeleteFlow = DataFlow::Global<AllocationToDeleteConfig>;
+
 from
-  AllocationToDeleteConfig config, DataFlow::PathNode source, DataFlow::PathNode sink,
+  AllocationToDeleteFlow::PathNode source, AllocationToDeleteFlow::PathNode sink,
   NewArrayExpr newArray, DeleteArrayExpr deleteArray
 where
   not isExcluded(deleteArray.getExpr(),
     FreedPackage::doNotDeleteAnArrayThroughAPointerOfTheIncorrectTypeQuery()) and
-  config.hasFlowPath(source, sink) and
+  AllocationToDeleteFlow::flowPath(source, sink) and
   newArray = source.getNode().asExpr() and
   deleteArray.getExpr() = sink.getNode().asExpr() and
   not newArray.getType().getUnspecifiedType() = deleteArray.getExpr().getType().getUnspecifiedType()

--- a/cpp/cert/src/rules/MEM52-CPP/DetectAndHandleMemoryAllocationErrors.ql
+++ b/cpp/cert/src/rules/MEM52-CPP/DetectAndHandleMemoryAllocationErrors.ql
@@ -74,22 +74,20 @@ class NotWrappedNoThrowAllocExpr extends NoThrowAllocExpr {
 /**
  * A data flow configuration for finding nothrow allocation calls which are checked in some kind of guard.
  */
-class NoThrowNewErrorCheckConfig extends DataFlow::Configuration {
-  NoThrowNewErrorCheckConfig() { this = "NoThrowNewErrorCheckConfig" }
-
-  override predicate isSource(DataFlow::Node source) {
+module NoThrowNewErrorCheckConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
     source.asExpr() instanceof NotWrappedNoThrowAllocExpr
   }
 
-  override predicate isSink(DataFlow::Node sink) {
-    sink.asExpr() = any(GuardCondition gc).getAChild*()
-  }
+  predicate isSink(DataFlow::Node sink) { sink.asExpr() = any(GuardCondition gc).getAChild*() }
 }
+
+module NoThrowNewErrorCheckFlow = DataFlow::Global<NoThrowNewErrorCheckConfig>;
 
 from NotWrappedNoThrowAllocExpr ae
 where
   not isExcluded(ae, AllocationsPackage::detectAndHandleMemoryAllocationErrorsQuery()) and
-  not any(NoThrowNewErrorCheckConfig nt).hasFlow(DataFlow::exprNode(ae), _)
+  not NoThrowNewErrorCheckFlow::flow(DataFlow::exprNode(ae), _)
 select ae,
   "nothrow new allocation of $@ returns here without a subsequent check to see whether the pointer is valid.",
   ae.getUnderlyingAlloc() as underlying, underlying.getType().getName()

--- a/cpp/cert/src/rules/MEM53-CPP/ManuallyManagedLifetime.qll
+++ b/cpp/cert/src/rules/MEM53-CPP/ManuallyManagedLifetime.qll
@@ -3,7 +3,6 @@ import codingstandards.cpp.Conversion
 import codingstandards.cpp.TrivialType
 import ManuallyManagedLifetime
 import semmle.code.cpp.controlflow.Dominance
-import codingstandards.cpp.dataflow.DataFlow2
 import codingstandards.cpp.dataflow.TaintTracking
 
 /**
@@ -11,10 +10,8 @@ import codingstandards.cpp.dataflow.TaintTracking
  *
  * We use a taint-tracking configuration because we also want to track sub-sections
  */
-class AllocToStaticCastConfig extends TaintTracking::Configuration {
-  AllocToStaticCastConfig() { this = "AllocToStaticCastConfig" }
-
-  override predicate isSource(DataFlow::Node source) {
+module AllocToStaticCastConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
     exists(AllocationExpr ae |
       ae.getType().getUnspecifiedType() instanceof VoidPointerType and
       source.asExpr() = ae and
@@ -23,7 +20,7 @@ class AllocToStaticCastConfig extends TaintTracking::Configuration {
     )
   }
 
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(StaticOrCStyleCast sc, Class nonTrivialClass |
       sc.getExpr() = sink.asExpr() and
       nonTrivialClass = sc.getType().getUnspecifiedType().(PointerType).getBaseType() and
@@ -32,12 +29,14 @@ class AllocToStaticCastConfig extends TaintTracking::Configuration {
   }
 }
 
+module AllocToStaticCastFlow = TaintTracking::Global<AllocToStaticCastConfig>;
+
 /**
  * A cast of some existing memory, where we believe the resulting pointer has not been properly
  * constructed.
  */
 class CastWithoutConstruction extends StaticOrCStyleCast {
-  CastWithoutConstruction() { any(AllocToStaticCastConfig c).hasFlowToExpr(getExpr()) }
+  CastWithoutConstruction() { AllocToStaticCastFlow::flowToExpr(getExpr()) }
 }
 
 /*
@@ -96,18 +95,16 @@ class NonDestructingDeallocationCall extends Expr {
  * A data flow configuration from a `CastWithoutConstruction` to a free call on the memory without
  * an intervening destructor invocation.
  */
-class FreeWithoutDestructorConfig extends DataFlow2::Configuration {
-  FreeWithoutDestructorConfig() { this = "FreeWithoutDestructorConfig" }
-
-  override predicate isSource(DataFlow::Node source) {
+module FreeWithoutDestructorConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
     source.asExpr() = any(CastWithoutConstruction c).getExpr()
   }
 
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     sink.asExpr() = any(NonDestructingDeallocationCall de).getFreedExpr()
   }
 
-  override predicate isBarrier(DataFlow::Node barrier) {
+  predicate isBarrier(DataFlow::Node barrier) {
     // Consider any expression which later has a destructor called upon it to be safe.
     exists(DirectOrIndirectDestructorCall dc |
       DataFlow::localFlow(barrier, DataFlow::exprNode(dc.getDestructedArgument()))
@@ -122,7 +119,9 @@ class FreeWithoutDestructorConfig extends DataFlow2::Configuration {
     )
   }
 
-  override predicate isAdditionalFlowStep(DataFlow::Node stepFrom, DataFlow::Node stepTo) {
+  predicate isAdditionalFlowStep(DataFlow::Node stepFrom, DataFlow::Node stepTo) {
     stepTo.asExpr().(StaticOrCStyleCast).getExpr() = stepFrom.asExpr()
   }
 }
+
+module FreeWithoutDestructorFlow = DataFlow::Global<FreeWithoutDestructorConfig>;

--- a/cpp/cert/src/rules/MEM53-CPP/MissingConstructorCallForManuallyManagedObject.ql
+++ b/cpp/cert/src/rules/MEM53-CPP/MissingConstructorCallForManuallyManagedObject.ql
@@ -15,16 +15,16 @@ import codingstandards.cpp.cert
 import codingstandards.cpp.TrivialType
 import ManuallyManagedLifetime
 import codingstandards.cpp.dataflow.TaintTracking
-import DataFlow::PathGraph
+import AllocToStaticCastFlow::PathGraph
 
 /*
  * Find flow from a manual allocation returning void* to a static_cast (or c-style cast)
  * to a specific type.
  */
 
-from AllocToStaticCastConfig config, DataFlow::PathNode source, DataFlow::PathNode sink
+from AllocToStaticCastFlow::PathNode source, AllocToStaticCastFlow::PathNode sink
 where
   not isExcluded(sink.getNode().asExpr(),
     AllocationsPackage::missingConstructorCallForManuallyManagedObjectQuery()) and
-  config.hasFlowPath(source, sink)
+  AllocToStaticCastFlow::flowPath(source, sink)
 select sink.getNode(), source, sink, "Allocation to cast without constructor call"

--- a/cpp/cert/src/rules/MEM53-CPP/MissingDestructorCallForManuallyManagedObject.ql
+++ b/cpp/cert/src/rules/MEM53-CPP/MissingDestructorCallForManuallyManagedObject.ql
@@ -13,12 +13,12 @@
 import cpp
 import codingstandards.cpp.cert
 import ManuallyManagedLifetime
-import codingstandards.cpp.dataflow.DataFlow2
-import DataFlow2::PathGraph
+import codingstandards.cpp.dataflow.DataFlow
+import FreeWithoutDestructorFlow::PathGraph
 
-from FreeWithoutDestructorConfig dc, DataFlow2::PathNode source, DataFlow2::PathNode sink
+from FreeWithoutDestructorFlow::PathNode source, FreeWithoutDestructorFlow::PathNode sink
 where
   not isExcluded(sink.getNode().asExpr(),
     AllocationsPackage::missingDestructorCallForManuallyManagedObjectQuery()) and
-  dc.hasFlowPath(source, sink)
+  FreeWithoutDestructorFlow::flowPath(source, sink)
 select sink.getNode(), source, sink, "Memory freed without an appropriate destructor called."

--- a/cpp/common/src/codingstandards/cpp/Nullness.qll
+++ b/cpp/common/src/codingstandards/cpp/Nullness.qll
@@ -1,19 +1,14 @@
 import cpp
 import codingstandards.cpp.dataflow.DataFlow
-import codingstandards.cpp.dataflow.DataFlow2
 
 private class PointerToMember extends Variable {
   PointerToMember() { this.getType() instanceof PointerToMemberType }
 }
 
-class NullPointerToPointerMemberExpressionConfig extends DataFlow::Configuration {
-  NullPointerToPointerMemberExpressionConfig() {
-    this = "NullPointerToPointerMemberExpressionConfig"
-  }
+module NullPointerToPointerMemberExpressionConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source.asExpr() instanceof NullValue }
 
-  override predicate isSource(DataFlow::Node source) { source.asExpr() instanceof NullValue }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     // The null value can flow to a pointer-to-member expressions that points to a function
     exists(VariableCall call, VariableAccess va | call.getQualifier() = va and va = sink.asExpr() |
       va.getTarget() instanceof PointerToMember
@@ -24,12 +19,13 @@ class NullPointerToPointerMemberExpressionConfig extends DataFlow::Configuration
   }
 }
 
-class NullValueToAssignmentConfig extends DataFlow2::Configuration {
-  NullValueToAssignmentConfig() { this = "NullValueToAssignmentConfig" }
+module NullPointerToPointerMemberExpressionFlow =
+  DataFlow::Global<NullPointerToPointerMemberExpressionConfig>;
 
-  override predicate isSource(DataFlow::Node source) { source.asExpr() instanceof NullValue }
+module NullValueToAssignmentConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source.asExpr() instanceof NullValue }
 
-  override predicate isSink(DataFlow::Node sink) {
-    exists(Assignment a | a.getRValue() = sink.asExpr())
-  }
+  predicate isSink(DataFlow::Node sink) { exists(Assignment a | a.getRValue() = sink.asExpr()) }
 }
+
+module NullValueToAssignmentFlow = DataFlow::Global<NullValueToAssignmentConfig>;

--- a/cpp/common/src/codingstandards/cpp/allocations/PlacementNew.qll
+++ b/cpp/common/src/codingstandards/cpp/allocations/PlacementNew.qll
@@ -158,20 +158,20 @@ class AllocationExprPlacementNewOrigin extends PlacementNewMemoryOrigin {
  * A data flow configuration that identifies the origin of the placement argument to a placement
  * new expression.
  */
-class PlacementNewOriginConfig extends DataFlow::Configuration {
-  PlacementNewOriginConfig() { this = "PlacementNewOrigin" }
+module PlacementNewOriginConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) { source instanceof PlacementNewMemoryOrigin }
 
-  override predicate isSource(DataFlow::Node source) { source instanceof PlacementNewMemoryOrigin }
-
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     sink.asExpr() = any(PlacementNewExpr pne).getPlacementExpr()
     // TODO direct calls to placement operator new?
   }
 
-  override predicate isAdditionalFlowStep(DataFlow::Node stepFrom, DataFlow::Node stepTo) {
+  predicate isAdditionalFlowStep(DataFlow::Node stepFrom, DataFlow::Node stepTo) {
     // Slightly surprisingly, we can't see the `StaticOrCStyleCast`s as a source out-of-the-box with data
     // flow - it's only reported under taint tracking. We therefore add a step through static
     // casts so that we can see them as sources.
     stepTo.asExpr().(StaticOrCStyleCast).getExpr() = stepFrom.asExpr()
   }
 }
+
+module PlacementNewOriginFlow = DataFlow::Global<PlacementNewOriginConfig>;

--- a/cpp/common/src/codingstandards/cpp/rules/accessofundefinedmemberthroughnullpointer/AccessOfUndefinedMemberThroughNullPointer.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/accessofundefinedmemberthroughnullpointer/AccessOfUndefinedMemberThroughNullPointer.qll
@@ -8,21 +8,23 @@ import codingstandards.cpp.Exclusions
 import codingstandards.cpp.Nullness
 import codingstandards.cpp.Expr
 import codingstandards.cpp.dataflow.DataFlow
-import DataFlow::PathGraph
+import NullPointerToPointerMemberExpressionFlow::PathGraph
 
 abstract class AccessOfUndefinedMemberThroughNullPointerSharedQuery extends Query { }
 
 Query getQuery() { result instanceof AccessOfUndefinedMemberThroughNullPointerSharedQuery }
 
 query predicate problems(
-  PointerToMemberExpr pointerToMemberExpr, DataFlow::PathNode source, DataFlow::PathNode sink,
-  string message, Location sourceLocation, string sourceDescription
+  PointerToMemberExpr pointerToMemberExpr,
+  NullPointerToPointerMemberExpressionFlow::PathNode source,
+  NullPointerToPointerMemberExpressionFlow::PathNode sink, string message, Location sourceLocation,
+  string sourceDescription
 ) {
   not isExcluded(pointerToMemberExpr, getQuery()) and
   message =
     "A null pointer-to-member value from $@ is passed as the second operand to a pointer-to-member expression." and
   sink.getNode().asExpr() = pointerToMemberExpr.getPointerExpr() and
-  any(NullPointerToPointerMemberExpressionConfig config).hasFlowPath(source, sink) and
+  NullPointerToPointerMemberExpressionFlow::flowPath(source, sink) and
   sourceLocation = source.getNode().getLocation() and
   sourceDescription = "initialization"
 }

--- a/cpp/common/src/codingstandards/cpp/rules/accessofundefinedmemberthroughuninitializedstaticpointer/AccessOfUndefinedMemberThroughUninitializedStaticPointer.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/accessofundefinedmemberthroughuninitializedstaticpointer/AccessOfUndefinedMemberThroughUninitializedStaticPointer.qll
@@ -44,7 +44,7 @@ newtype TStaticMemberPointerAbstractValue =
   AssignedNullValue(StaticMemberPointer ptr, Expr val) {
     // A null value tracked via the data flow graph
     exists(ControlFlowNode n |
-      any(NullValueToAssignmentConfig config).hasFlow(_, DataFlow::exprNode(val)) and
+      NullValueToAssignmentFlow::flow(_, DataFlow::exprNode(val)) and
       n.(Assignment).getLValue() = ptr.getAnAccess() and
       n.(Assignment).getRValue() = val
     )
@@ -63,7 +63,7 @@ newtype TStaticMemberPointerAbstractValue =
   AssignedNonNullValue(StaticMemberPointer ptr, Expr val) {
     // A non-null value tracked via the data flow graph
     exists(ControlFlowNode n |
-      not any(NullValueToAssignmentConfig config).hasFlow(_, DataFlow::exprNode(val)) and
+      NullValueToAssignmentFlow::flow(_, DataFlow::exprNode(val)) and
       n.(Assignment).getLValue() = ptr.getAnAccess() and
       n.(Assignment).getRValue() = val
     )

--- a/cpp/common/src/codingstandards/cpp/rules/nonconstantformat/NonConstantFormat.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/nonconstantformat/NonConstantFormat.qll
@@ -106,28 +106,28 @@ predicate isSanitizerNode(DataFlow::Node node) {
   cannotContainString(node.getType())
 }
 
-class NonConstFlow extends TaintTracking::Configuration {
-  NonConstFlow() { this = "NonConstFlow" }
-
-  override predicate isSource(DataFlow::Node source) {
+module NonConstConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
     isNonConst(source) and
     not cannotContainString(source.getType())
   }
 
-  override predicate isSink(DataFlow::Node sink) {
+  predicate isSink(DataFlow::Node sink) {
     exists(FormattingFunctionCall fc | sink.asExpr() = fc.getArgument(fc.getFormatParameterIndex()))
   }
 
-  override predicate isSanitizer(DataFlow::Node node) { isSanitizerNode(node) }
+  predicate isBarrier(DataFlow::Node node) { isSanitizerNode(node) }
 }
+
+module NonConstFlow = TaintTracking::Global<NonConstConfig>;
 
 query predicate problems(
   Expr formatString, string message, FormattingFunctionCall call, string formatStringDescription
 ) {
   not isExcluded(formatString, getQuery()) and
   call.getArgument(call.getFormatParameterIndex()) = formatString and
-  exists(NonConstFlow cf, DataFlow::Node source, DataFlow::Node sink |
-    cf.hasFlow(source, sink) and
+  exists(DataFlow::Node source, DataFlow::Node sink |
+    NonConstFlow::flow(source, sink) and
     sink.asExpr() = formatString
   ) and
   message =

--- a/cpp/common/src/codingstandards/cpp/rules/placementnewinsufficientstorage/PlacementNewInsufficientStorage.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/placementnewinsufficientstorage/PlacementNewInsufficientStorage.qll
@@ -8,24 +8,23 @@ import codingstandards.cpp.Customizations
 import codingstandards.cpp.Exclusions
 import codingstandards.cpp.allocations.PlacementNew
 import codingstandards.cpp.dataflow.DataFlow
-import DataFlow::PathGraph
+import PlacementNewOriginFlow::PathGraph
 
 abstract class PlacementNewInsufficientStorageSharedQuery extends Query { }
 
 Query getQuery() { result instanceof PlacementNewInsufficientStorageSharedQuery }
 
 query predicate problems(
-  PlacementNewExpr placementNew, DataFlow::PathNode source, DataFlow::PathNode sink, string message,
-  PlacementNewMemoryOrigin memoryOrigin, string memoryOriginDescription
+  PlacementNewExpr placementNew, PlacementNewOriginFlow::PathNode source,
+  PlacementNewOriginFlow::PathNode sink, string message, PlacementNewMemoryOrigin memoryOrigin,
+  string memoryOriginDescription
 ) {
   not isExcluded(placementNew, getQuery()) and
   message =
     "Placement new expression is used with an insufficiently large memory allocation from $@." and
-  exists(PlacementNewOriginConfig config |
-    memoryOrigin = source.getNode() and
-    placementNew.getPlacementExpr() = sink.getNode().asExpr() and
-    memoryOriginDescription = memoryOrigin.toString() and
-    config.hasFlowPath(source, sink) and
-    memoryOrigin.getMaximumMemorySize() < placementNew.getMinimumAllocationSize()
-  )
+  memoryOrigin = source.getNode() and
+  placementNew.getPlacementExpr() = sink.getNode().asExpr() and
+  memoryOriginDescription = memoryOrigin.toString() and
+  PlacementNewOriginFlow::flowPath(source, sink) and
+  memoryOrigin.getMaximumMemorySize() < placementNew.getMinimumAllocationSize()
 }

--- a/cpp/common/src/codingstandards/cpp/rules/placementnewnotproperlyaligned/PlacementNewNotProperlyAligned.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/placementnewnotproperlyaligned/PlacementNewNotProperlyAligned.qll
@@ -8,7 +8,7 @@ import codingstandards.cpp.Customizations
 import codingstandards.cpp.Exclusions
 import codingstandards.cpp.allocations.PlacementNew
 import codingstandards.cpp.dataflow.DataFlow
-import DataFlow::PathGraph
+import PlacementNewOriginFlow::PathGraph
 
 abstract class PlacementNewNotProperlyAlignedSharedQuery extends Query { }
 
@@ -19,20 +19,19 @@ Query getQuery() { result instanceof PlacementNewNotProperlyAlignedSharedQuery }
  */
 
 query predicate problems(
-  PlacementNewExpr placementNew, DataFlow::PathNode source, DataFlow::PathNode sink, string message,
-  PlacementNewMemoryOrigin memoryOrigin, string memoryOriginDescription
+  PlacementNewExpr placementNew, PlacementNewOriginFlow::PathNode source,
+  PlacementNewOriginFlow::PathNode sink, string message, PlacementNewMemoryOrigin memoryOrigin,
+  string memoryOriginDescription
 ) {
   not isExcluded(placementNew, getQuery()) and
-  exists(PlacementNewOriginConfig config |
-    memoryOrigin = source.getNode() and
-    placementNew.getPlacementExpr() = sink.getNode().asExpr() and
-    memoryOriginDescription = memoryOrigin.toString() and
-    config.hasFlowPath(source, sink) and
-    exists(int originAlignment |
-      originAlignment = memoryOrigin.getAlignment() and
-      // The origin alignment should be exactly divisible by the placement alignment
-      (originAlignment / placementNew.getAllocatedType().getAlignment()).ceil() = 0 and
-      message = "Placement new expression is used with inappropriately aligned memory from $@."
-    )
+  memoryOrigin = source.getNode() and
+  placementNew.getPlacementExpr() = sink.getNode().asExpr() and
+  memoryOriginDescription = memoryOrigin.toString() and
+  PlacementNewOriginFlow::flowPath(source, sink) and
+  exists(int originAlignment |
+    originAlignment = memoryOrigin.getAlignment() and
+    // The origin alignment should be exactly divisible by the placement alignment
+    (originAlignment / placementNew.getAllocatedType().getAlignment()).ceil() = 0 and
+    message = "Placement new expression is used with inappropriately aligned memory from $@."
   )
 }

--- a/cpp/common/src/codingstandards/cpp/rules/useonlyarrayindexingforpointerarithmetic/UseOnlyArrayIndexingForPointerArithmetic.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/useonlyarrayindexingforpointerarithmetic/UseOnlyArrayIndexingForPointerArithmetic.qll
@@ -10,20 +10,18 @@ import codingstandards.cpp.dataflow.DataFlow
 
 abstract class UseOnlyArrayIndexingForPointerArithmeticSharedQuery extends Query { }
 
-class ArrayToArrayBaseConfig extends DataFlow::Configuration {
-  ArrayToArrayBaseConfig() { this = "ArrayToArrayBaseConfig" }
-
-  override predicate isSource(DataFlow::Node source) {
+module ArrayToArrayBaseConfig implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
     source.asExpr().(VariableAccess).getType() instanceof ArrayType
     or
     // Consider array to pointer decay for parameters.
     source.asExpr().(VariableAccess).getTarget().(Parameter).getType() instanceof ArrayType
   }
 
-  override predicate isSink(DataFlow::Node sink) {
-    exists(ArrayExpr e | e.getArrayBase() = sink.asExpr())
-  }
+  predicate isSink(DataFlow::Node sink) { exists(ArrayExpr e | e.getArrayBase() = sink.asExpr()) }
 }
+
+module ArrayToArrayBaseFlow = DataFlow::Global<ArrayToArrayBaseConfig>;
 
 predicate hasPointerResult(PointerArithmeticOperation op) {
   op instanceof PointerAddExpr
@@ -34,8 +32,7 @@ predicate hasPointerResult(PointerArithmeticOperation op) {
 predicate shouldBeArray(ArrayExpr arrayExpr) {
   arrayExpr.getArrayBase().getUnspecifiedType() instanceof PointerType and
   not exists(VariableAccess va |
-    any(ArrayToArrayBaseConfig config)
-        .hasFlow(DataFlow::exprNode(va), DataFlow::exprNode(arrayExpr.getArrayBase()))
+    ArrayToArrayBaseFlow::flow(DataFlow::exprNode(va), DataFlow::exprNode(arrayExpr.getArrayBase()))
   ) and
   not exists(Variable v |
     v.getAnAssignedValue().getType() instanceof ArrayType and

--- a/cpp/common/test/rules/donotsubtractpointersaddressingdifferentarrays/DoNotSubtractPointersAddressingDifferentArrays.expected
+++ b/cpp/common/test/rules/donotsubtractpointersaddressingdifferentarrays/DoNotSubtractPointersAddressingDifferentArrays.expected
@@ -4,15 +4,19 @@ problems
 | test.cpp:13:10:13:11 | p4 | test.cpp:5:14:5:15 | l2 | test.cpp:13:10:13:11 | p4 | Subtraction between left operand pointing to array $@ and other operand pointing to array $@. | test.cpp:3:7:3:8 | l2 | l2 | test.cpp:2:7:2:8 | l1 | l1 |
 | test.cpp:13:15:13:16 | l1 | test.cpp:13:15:13:16 | l1 | test.cpp:13:15:13:16 | l1 | Subtraction between right operand pointing to array $@ and other operand pointing to array $@. | test.cpp:2:7:2:8 | l1 | l1 | test.cpp:3:7:3:8 | l2 | l2 |
 edges
-| test.cpp:4:14:4:15 | l1 | test.cpp:10:10:10:11 | p1 |
-| test.cpp:4:14:4:15 | l1 | test.cpp:12:10:12:11 | p1 |
-| test.cpp:5:14:5:15 | l2 | test.cpp:11:10:11:11 | p2 |
-| test.cpp:5:14:5:15 | l2 | test.cpp:12:15:12:16 | p2 |
-| test.cpp:5:14:5:15 | l2 | test.cpp:13:10:13:11 | p4 |
-| test.cpp:5:14:5:15 | l2 | test.cpp:14:10:14:11 | p4 |
+| test.cpp:4:14:4:15 | l1 | test.cpp:4:14:4:18 | access to array |
+| test.cpp:4:14:4:18 | access to array | test.cpp:10:10:10:11 | p1 |
+| test.cpp:4:14:4:18 | access to array | test.cpp:12:10:12:11 | p1 |
+| test.cpp:5:14:5:15 | l2 | test.cpp:5:14:5:19 | access to array |
+| test.cpp:5:14:5:19 | access to array | test.cpp:11:10:11:11 | p2 |
+| test.cpp:5:14:5:19 | access to array | test.cpp:12:15:12:16 | p2 |
+| test.cpp:5:14:5:19 | access to array | test.cpp:13:10:13:11 | p4 |
+| test.cpp:5:14:5:19 | access to array | test.cpp:14:10:14:11 | p4 |
 nodes
 | test.cpp:4:14:4:15 | l1 | semmle.label | l1 |
+| test.cpp:4:14:4:18 | access to array | semmle.label | access to array |
 | test.cpp:5:14:5:15 | l2 | semmle.label | l2 |
+| test.cpp:5:14:5:19 | access to array | semmle.label | access to array |
 | test.cpp:10:10:10:11 | p1 | semmle.label | p1 |
 | test.cpp:10:15:10:16 | l1 | semmle.label | l1 |
 | test.cpp:11:10:11:11 | p2 | semmle.label | p2 |

--- a/cpp/common/test/rules/donotuserelationaloperatorswithdifferingarrays/DoNotUseRelationalOperatorsWithDifferingArrays.expected
+++ b/cpp/common/test/rules/donotuserelationaloperatorswithdifferingarrays/DoNotUseRelationalOperatorsWithDifferingArrays.expected
@@ -11,20 +11,26 @@ problems
 | test.cpp:25:7:25:14 | ... >= ... | test.cpp:25:13:25:14 | l3 | test.cpp:25:13:25:14 | l3 | Compare operation >= comparing right operand pointing to array $@ and other operand pointing to array $@. | test.cpp:4:7:4:8 | l3 | l3 | test.cpp:2:7:2:8 | l1 | l1 |
 edges
 | test.cpp:6:13:6:14 | l1 | test.cpp:13:12:13:13 | p0 |
-| test.cpp:7:14:7:15 | l1 | test.cpp:11:7:11:8 | p1 |
-| test.cpp:7:14:7:15 | l1 | test.cpp:13:7:13:8 | p1 |
-| test.cpp:7:14:7:15 | l1 | test.cpp:15:13:15:14 | p1 |
-| test.cpp:7:14:7:15 | l1 | test.cpp:17:7:17:8 | p1 |
-| test.cpp:7:14:7:15 | l1 | test.cpp:23:13:23:14 | p1 |
-| test.cpp:7:14:7:15 | l1 | test.cpp:25:7:25:8 | p1 |
-| test.cpp:8:14:8:15 | l1 | test.cpp:11:12:11:13 | p2 |
-| test.cpp:8:14:8:15 | l1 | test.cpp:21:7:21:8 | p2 |
-| test.cpp:9:14:9:15 | l2 | test.cpp:21:12:21:13 | p3 |
+| test.cpp:7:14:7:15 | l1 | test.cpp:7:14:7:18 | access to array |
+| test.cpp:7:14:7:18 | access to array | test.cpp:11:7:11:8 | p1 |
+| test.cpp:7:14:7:18 | access to array | test.cpp:13:7:13:8 | p1 |
+| test.cpp:7:14:7:18 | access to array | test.cpp:15:13:15:14 | p1 |
+| test.cpp:7:14:7:18 | access to array | test.cpp:17:7:17:8 | p1 |
+| test.cpp:7:14:7:18 | access to array | test.cpp:23:13:23:14 | p1 |
+| test.cpp:7:14:7:18 | access to array | test.cpp:25:7:25:8 | p1 |
+| test.cpp:8:14:8:15 | l1 | test.cpp:8:14:8:18 | access to array |
+| test.cpp:8:14:8:18 | access to array | test.cpp:11:12:11:13 | p2 |
+| test.cpp:8:14:8:18 | access to array | test.cpp:21:7:21:8 | p2 |
+| test.cpp:9:14:9:15 | l2 | test.cpp:9:14:9:18 | access to array |
+| test.cpp:9:14:9:18 | access to array | test.cpp:21:12:21:13 | p3 |
 nodes
 | test.cpp:6:13:6:14 | l1 | semmle.label | l1 |
 | test.cpp:7:14:7:15 | l1 | semmle.label | l1 |
+| test.cpp:7:14:7:18 | access to array | semmle.label | access to array |
 | test.cpp:8:14:8:15 | l1 | semmle.label | l1 |
+| test.cpp:8:14:8:18 | access to array | semmle.label | access to array |
 | test.cpp:9:14:9:15 | l2 | semmle.label | l2 |
+| test.cpp:9:14:9:18 | access to array | semmle.label | access to array |
 | test.cpp:11:7:11:8 | p1 | semmle.label | p1 |
 | test.cpp:11:12:11:13 | p2 | semmle.label | p2 |
 | test.cpp:13:7:13:8 | p1 | semmle.label | p1 |

--- a/cpp/common/test/rules/ownedpointervaluestoredinunrelatedsmartpointer/OwnedPointerValueStoredInUnrelatedSmartPointer.expected
+++ b/cpp/common/test/rules/ownedpointervaluestoredinunrelatedsmartpointer/OwnedPointerValueStoredInUnrelatedSmartPointer.expected
@@ -7,10 +7,14 @@ problems
 | test.cpp:17:27:17:28 | v1 | test.cpp:16:13:16:22 | new | test.cpp:17:27:17:28 | v1 | Raw pointer flows to initialize multiple unrelated smart pointers. |
 edges
 | test.cpp:3:14:3:15 | v1 | test.cpp:5:27:5:28 | v1 |
-| test.cpp:3:14:3:15 | v1 | test.cpp:6:31:6:33 | call to get |
+| test.cpp:3:14:3:15 | v1 | test.cpp:5:27:5:28 | v1 |
 | test.cpp:3:14:3:15 | v1 | test.cpp:7:28:7:29 | v2 |
 | test.cpp:4:13:4:14 | v1 | test.cpp:7:28:7:29 | v2 |
-| test.cpp:5:27:5:29 | call to shared_ptr | test.cpp:6:31:6:33 | call to get |
+| test.cpp:5:27:5:28 | v1 | test.cpp:5:27:5:29 | call to shared_ptr |
+| test.cpp:5:27:5:29 | call to shared_ptr | test.cpp:6:28:6:29 | p1 |
+| test.cpp:5:27:5:29 | call to shared_ptr | test.cpp:6:28:6:29 | p1 |
+| test.cpp:6:28:6:29 | p1 | test.cpp:6:31:6:33 | call to get |
+| test.cpp:6:28:6:29 | p1 | test.cpp:6:31:6:33 | call to get |
 | test.cpp:8:8:8:14 | 0 | test.cpp:9:28:9:29 | v2 |
 | test.cpp:10:8:10:17 | new | test.cpp:11:28:11:29 | v2 |
 | test.cpp:10:8:10:17 | new | test.cpp:12:28:12:29 | v2 |
@@ -21,7 +25,11 @@ nodes
 | test.cpp:3:14:3:15 | v1 | semmle.label | v1 |
 | test.cpp:4:13:4:14 | v1 | semmle.label | v1 |
 | test.cpp:5:27:5:28 | v1 | semmle.label | v1 |
+| test.cpp:5:27:5:28 | v1 | semmle.label | v1 |
 | test.cpp:5:27:5:29 | call to shared_ptr | semmle.label | call to shared_ptr |
+| test.cpp:5:27:5:29 | call to shared_ptr | semmle.label | call to shared_ptr |
+| test.cpp:6:28:6:29 | p1 | semmle.label | p1 |
+| test.cpp:6:28:6:29 | p1 | semmle.label | p1 |
 | test.cpp:6:31:6:33 | call to get | semmle.label | call to get |
 | test.cpp:7:28:7:29 | v2 | semmle.label | v2 |
 | test.cpp:8:8:8:14 | 0 | semmle.label | 0 |


### PR DESCRIPTION
## Description

Note that this targets `main`. Let me know if retargeting to `next` makes more sense.

The `DataFlow::Configuration` and `TaintTracking::Configuration` classes are going to be deprecated soon. Modernize the queries that use these by switching them over to the new `DataFlow::ConfigSig`.

This should not affect performance, but it's probably still good to test this. There are also some small changes to some of the paths in the test results. These look correct to me.

While doing this work, made the naming of the configurations more consistent. They now all end in `Config`.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)