### PR TITLE
M16-1-1: Optimize query and improve detection of nested uses of `defined`

### DIFF
--- a/change_notes/2023-12-06-m16-1-1-perf.md
+++ b/change_notes/2023-12-06-m16-1-1-perf.md
@@ -1,0 +1,3 @@
+ * `M16-1-1`
+   - Optimize query to improve performance
+   - Improve detection of macros whose body contains the `defined` operator after the start of the macro (e.g. `#define X Y || defined(Z)`).

--- a/cpp/autosar/src/rules/M16-1-1/DefinedPreProcessorOperatorGeneratedFromExpansionFound.ql
+++ b/cpp/autosar/src/rules/M16-1-1/DefinedPreProcessorOperatorGeneratedFromExpansionFound.ql
@@ -16,16 +16,19 @@ import cpp
 import codingstandards.cpp.autosar
 import DefinedMacro
 
-from DefinedMacro m, PreprocessorBranch e
+/**
+ * An `if` or `elif` preprocessor branch.
+ */
+class PreprocessorIfOrElif extends PreprocessorBranch {
+  PreprocessorIfOrElif() {
+    this instanceof PreprocessorIf or
+    this instanceof PreprocessorElif
+  }
+}
+
+from PreprocessorIfOrElif e, MacroUsesDefined m
 where
-  (
-    e instanceof PreprocessorIf or
-    e instanceof PreprocessorElif
-  ) and
-  (
-    e.getHead().regexpMatch(m.getAUse().getHead() + "\\s*\\(.*")
-    or
-    e.getHead().regexpMatch(m.getAUse().getHead().replaceAll("(", "\\(").replaceAll(")", "\\)"))
-  ) and
-  not isExcluded(e)
+  not isExcluded(e, MacrosPackage::definedPreProcessorOperatorInOneOfTheTwoStandardFormsQuery()) and
+  // A`#if` or `#elif` which uses a macro which uses `defined`
+  exists(e.getHead().regexpFind(m.getRegexForMatch(), _, _))
 select e, "The macro $@ expands to 'defined'", m, m.getName()

--- a/cpp/autosar/test/rules/M16-1-1/DefinedPreProcessorOperatorGeneratedFromExpansionFound.expected
+++ b/cpp/autosar/test/rules/M16-1-1/DefinedPreProcessorOperatorGeneratedFromExpansionFound.expected
@@ -1,2 +1,4 @@
-| test.cpp:22:1:22:18 | #if DBLWRAPUSES(X) | The macro $@ expands to 'defined' | test.cpp:18:1:18:22 | #define BADDEF defined | BADDEF |
+| test.cpp:22:1:22:18 | #if DBLWRAPUSES(X) | The macro $@ expands to 'defined' | test.cpp:21:1:21:24 | #define DBLWRAPUSES USES | DBLWRAPUSES |
 | test.cpp:26:1:26:16 | #if BADDEFTWO(X) | The macro $@ expands to 'defined' | test.cpp:25:1:25:31 | #define BADDEFTWO(X) defined(X) | BADDEFTWO |
+| test.cpp:29:1:29:16 | #if BADDEFTWO(Y) | The macro $@ expands to 'defined' | test.cpp:25:1:25:31 | #define BADDEFTWO(X) defined(X) | BADDEFTWO |
+| test.cpp:42:1:42:11 | #if WRAPPER | The macro $@ expands to 'defined' | test.cpp:40:1:40:35 | #define WRAPPER X < Y \|\| defined(z) | WRAPPER |

--- a/cpp/autosar/test/rules/M16-1-1/DefinedPreProcessorOperatorInOneOfTheTwoStandardForms.expected
+++ b/cpp/autosar/test/rules/M16-1-1/DefinedPreProcessorOperatorInOneOfTheTwoStandardForms.expected
@@ -2,4 +2,4 @@
 | test.cpp:9:1:9:19 | #elif defined X < Y | Use of defined with non-standard form: X < Y. |
 | test.cpp:13:1:13:18 | #if defined(X > Y) | Use of defined with non-standard form: X > Y. |
 | test.cpp:14:1:14:20 | #elif defined(X < Y) | Use of defined with non-standard form: X < Y. |
-| test.cpp:34:1:34:47 | #if defined(X) \|\| defined _Y_ + X && defined(Y) | Use of defined with non-standard form: _Y_ + X. |
+| test.cpp:37:1:37:47 | #if defined(X) \|\| defined _Y_ + X && defined(Y) | Use of defined with non-standard form: _Y_ + X. |

--- a/cpp/autosar/test/rules/M16-1-1/test.cpp
+++ b/cpp/autosar/test/rules/M16-1-1/test.cpp
@@ -26,10 +26,18 @@
 #if BADDEFTWO(X) // NON_COMPLIANT
 #endif
 
+#if BADDEFTWO(Y) // NON_COMPLIANT
+#endif
+
 // clang-format off
 #if defined (X) || (defined(_Y_)) // COMPLIANT
 // clang-format on
 #endif
 
 #if defined(X) || defined _Y_ + X && defined(Y) // NON_COMPLIANT
+#endif
+
+#define WRAPPER X < Y || defined(z)
+
+#if WRAPPER // NON_COMPLIANT
 #endif


### PR DESCRIPTION
## Description

Addresses https://github.com/github/codeql-coding-standards/issues/470.

  - Improve query performance:
    - Switch to the correct form of `isExcluded` avoids calculating (and applying) a list of all excluded elements in the program. (I will put up a separate PR to address other instances of this same problem).
    - Re-implement `DefinedMacro` with a simpler form of recursion - previously the `anyAliasing` predicate used recursion in two parts
    - Simplification of `where` clause, so we only apply a single regex for all cases.
  - Improve detection of macros whose body contains the `defined` operator after the start of the macro (e.g. `#define X Y || defined(Z)`).
  - Enable deviations to be applied for this rule.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `M16-1-1`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)