### PR TITLE
Use an IPA type for flow states

### DIFF
--- a/c/cert/src/rules/EXP39-C/DoNotAccessVariableViaPointerOfIncompatibleType.ql
+++ b/c/cert/src/rules/EXP39-C/DoNotAccessVariableViaPointerOfIncompatibleType.ql
@@ -42,20 +42,16 @@ class ReallocationFunction extends AllocationFunction {
   ReallocationFunction() { exists(this.getReallocPtrArg()) }
 }
 
-/**
- * A data-flow state for a pointer which has not been reallocated.
- */
-class IndirectCastDefaultFlowState extends DataFlow::FlowState {
-  IndirectCastDefaultFlowState() { this = "IndirectCastDefaultFlowState" }
-}
-
-/**
- * A data-flow state for a pointer which has been reallocated but
- * has not yet been zeroed with a memset call.
- */
-class IndirectCastReallocatedFlowState extends DataFlow::FlowState {
-  IndirectCastReallocatedFlowState() { this = "IndirectCastReallocatedFlowState" }
-}
+newtype IndirectCastFlowState =
+  /**
+   * A data-flow state for a pointer which has not been reallocated.
+   */
+  IndirectCastDefaultFlowState() or
+  /**
+   * A data-flow state for a pointer which has been reallocated but
+   * has not yet been zeroed with a memset call.
+   */
+  IndirectCastReallocatedFlowState()
 
 /**
  * A data-flow configuration to track the flow from cast expressions to either
@@ -63,7 +59,7 @@ class IndirectCastReallocatedFlowState extends DataFlow::FlowState {
  * to `realloc` but not cleared via a function call to `memset`.
  */
 module IndirectCastConfig implements DataFlow::StateConfigSig {
-  class FlowState = DataFlow::FlowState;
+  class FlowState = IndirectCastFlowState;
 
   predicate isSource(DataFlow::Node source, FlowState state) {
     state instanceof IndirectCastDefaultFlowState and


### PR DESCRIPTION
## Description

This is a small followup to https://github.com/github/codeql-coding-standards/pull/468. As part of deprecating the old dataflow configurations, `DataFlow::FlowState` will also be deprecated. Do not use this class by introducing a IPA type, and using that instead of subclasses of `DataFlow::FlowState`.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)