### PR TITLE
Use database extensionals instead of their wrapper classes in two predicates

### DIFF
--- a/cpp/common/src/codingstandards/cpp/enhancements/ControlFlowGraphEnhancements.qll
+++ b/cpp/common/src/codingstandards/cpp/enhancements/ControlFlowGraphEnhancements.qll
@@ -10,8 +10,8 @@ import cpp
  * should be in this relation.
  */
 pragma[noinline]
-private predicate isFunction(Element el) {
-  el instanceof Function
+private predicate isFunction(@element el) {
+  el instanceof @function
   or
   el.(Expr).getParent() = el
 }
@@ -22,7 +22,7 @@ private predicate isFunction(Element el) {
  */
 pragma[noopt]
 private predicate callHasNoTarget(@funbindexpr fc) {
-  exists(Function f |
+  exists(@function f |
     funbind(fc, f) and
     not isFunction(f)
   )


### PR DESCRIPTION
## Description

We are planning to change the charpred of `Function` in the CodeQL C++ library, which means the code changed here will no longer compile. By switching to the extensionals, the code will keep compiling.

DIL before:
```
noinline
`ConstantExprs::isFunction/1#600714be`(
  /* Element::Element */ interned unique entity el
)
{
  exists(interned dontcare string _, interned dontcare int _1 |
    functions(el, _, _1)
  ) or
  exists(interned dontcare int _ | exprparents(el, _, el))
}

noopt
`ConstantExprs::callHasNoTarget/1#e6e8caa4`(
  /* @funbindexpr */ interned unique entity fc
)
{
  exists(/* Function::Function */ interned entity f |
    funbind(fc, f) and not(`ConstantExprs::isFunction/1#600714be`(f))
  )
}
```

DIL after:
```
noinline
`ConstantExprs::isFunction/1#600714be`(/* @element */ interned unique entity el)
{
  exists(interned dontcare string _, interned dontcare int _1 |
    functions(el, _, _1)
  ) or
  exists(interned dontcare int _ | exprparents(el, _, el))
}

noopt
`ConstantExprs::callHasNoTarget/1#e6e8caa4`(
  /* @funbindexpr */ interned unique entity fc
)
{
  exists(/* @function */ interned entity f |
    funbind(fc, f) and not(`ConstantExprs::isFunction/1#600714be`(f))
  )
}
```

cc @MathiasVP 

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)