### PR TITLE
Fix ODR violations in AUTOSAR A2-10-5 test

### DIFF
--- a/cpp/autosar/test/rules/A2-10-5/IdentifierNameOfANonMemberObjectWithExternalOrInternalLinkageIsReused.expected
+++ b/cpp/autosar/test/rules/A2-10-5/IdentifierNameOfANonMemberObjectWithExternalOrInternalLinkageIsReused.expected
@@ -1,6 +1,6 @@
 | test1a.cpp:2:12:2:13 | g1 | Identifier name of non-member object $@ reuses the identifier name of non-member object $@. | test1a.cpp:2:12:2:13 | g1 | g1 | test1b.cpp:2:12:2:13 | g1 | g1 |
 | test1a.cpp:6:12:6:13 | g3 | Identifier name of non-member object $@ reuses the identifier name of non-member object $@. | test1a.cpp:6:12:6:13 | g3 | g3 | test1b.cpp:6:12:6:13 | g3 | g3 |
-| test1a.cpp:17:43:17:43 | number_two | Identifier name of non-member object $@ reuses the identifier name of non-member object $@. | test1a.cpp:17:43:17:43 | number_two | number_two | test1b.cpp:11:43:11:43 | number_two | number_two |
+| test1a.cpp:17:50:17:50 | number_two | Identifier name of non-member object $@ reuses the identifier name of non-member object $@. | test1a.cpp:17:50:17:50 | number_two | number_two | test1b.cpp:11:50:11:50 | number_two | number_two |
 | test1b.cpp:2:12:2:13 | g1 | Identifier name of non-member object $@ reuses the identifier name of non-member object $@. | test1b.cpp:2:12:2:13 | g1 | g1 | test1a.cpp:2:12:2:13 | g1 | g1 |
 | test1b.cpp:6:12:6:13 | g3 | Identifier name of non-member object $@ reuses the identifier name of non-member object $@. | test1b.cpp:6:12:6:13 | g3 | g3 | test1a.cpp:6:12:6:13 | g3 | g3 |
-| test1b.cpp:11:43:11:43 | number_two | Identifier name of non-member object $@ reuses the identifier name of non-member object $@. | test1b.cpp:11:43:11:43 | number_two | number_two | test1a.cpp:17:43:17:43 | number_two | number_two |
+| test1b.cpp:11:50:11:50 | number_two | Identifier name of non-member object $@ reuses the identifier name of non-member object $@. | test1b.cpp:11:50:11:50 | number_two | number_two | test1a.cpp:17:50:17:50 | number_two | number_two |

--- a/cpp/autosar/test/rules/A2-10-5/test1a.cpp
+++ b/cpp/autosar/test/rules/A2-10-5/test1a.cpp
@@ -14,7 +14,7 @@ int test() { return number_one<int>; }
 
 long test2() { return number_one<long>; }
 
-template <class T> constexpr T number_two = T(1); // NON_COMPLIANT
+template <class T> static constexpr T number_two = T(1); // NON_COMPLIANT
 
 int test3() { return number_two<int>; }
 

--- a/cpp/autosar/test/rules/A2-10-5/test1b.cpp
+++ b/cpp/autosar/test/rules/A2-10-5/test1b.cpp
@@ -8,8 +8,8 @@ static int g3 = 0; // NON_COMPLIANT
 
 static void f1() {} // NON_COMPLIANT
 
-template <class T> constexpr T number_two = T(1); // NON_COMPLIANT
+template <class T> static constexpr T number_two = T(1); // NON_COMPLIANT
 
-int test3() { return number_two<int>; }
+int test5() { return number_two<int>; }
 
-long test4() { return number_two<long>; }
+long test6() { return number_two<long>; }


### PR DESCRIPTION
## Description

The CodeQL test framework assumes that all code will become part to the same nameless link target, which means that the duplicate declarations of `test3` and `test4` are ODR violations. Moreover, newer versions of the C/C++ frontend used in the C/C++ extractor will implement CWG 2387, which means that the instantiations of `number_two` will also cause ODR violations.

Fix the above by renaming `test3` and `test4` in `test`b.cpp` and making the `number_two` variable templates `static`.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)