### PR TITLE
Include test case FP/FN report

### DIFF
--- a/cpp/autosar/test/rules/A12-0-1/MissingSpecialMemberFunction.expected
+++ b/cpp/autosar/test/rules/A12-0-1/MissingSpecialMemberFunction.expected
@@ -1,2 +1,8 @@
 | test.cpp:12:7:12:8 | C3 | Class $@ has provided at least one user-defined special member function but is missing definitions for all five special member functions. | test.cpp:12:7:12:8 | C3 | C3 |
 | test.cpp:28:7:28:8 | C5 | Class $@ has provided at least one user-defined special member function but is missing definitions for all five special member functions. | test.cpp:28:7:28:8 | C5 | C5 |
+| test.cpp:51:7:51:9 | C10 | Class $@ has provided at least one user-defined special member function but is missing definitions for all five special member functions. | test.cpp:51:7:51:9 | C10 | C10 |
+| test.cpp:55:7:55:9 | C11 | Class $@ has provided at least one user-defined special member function but is missing definitions for all five special member functions. | test.cpp:55:7:55:9 | C11 | C11 |
+| test.cpp:59:7:59:9 | C12 | Class $@ has provided at least one user-defined special member function but is missing definitions for all five special member functions. | test.cpp:59:7:59:9 | C12 | C12 |
+| test.cpp:63:7:63:9 | C13 | Class $@ has provided at least one user-defined special member function but is missing definitions for all five special member functions. | test.cpp:63:7:63:9 | C13 | C13 |
+| test.cpp:67:7:67:9 | C14 | Class $@ has provided at least one user-defined special member function but is missing definitions for all five special member functions. | test.cpp:67:7:67:9 | C14 | C14 |
+| test.cpp:71:7:71:9 | C15 | Class $@ has provided at least one user-defined special member function but is missing definitions for all five special member functions. | test.cpp:71:7:71:9 | C15 | C15 |

--- a/cpp/autosar/test/rules/A12-0-1/test.cpp
+++ b/cpp/autosar/test/rules/A12-0-1/test.cpp
@@ -47,3 +47,64 @@ struct C9 { // COMPLIANT
   C9() {}
   C9(int x) {}
 };
+
+class C10 {
+  ~C10() = default; // NON_COMPLIANT
+};
+
+class C11 {
+  ~C11() = delete; // NON_COMPLIANT
+};
+
+class C12 {
+  C12(C12 const &); // NON_COMPLIANT
+};
+
+class C13 {
+  C13(C13 const &) = default; // NON_COMPLIANT
+};
+
+class C14 {
+  C14(C14 const &) = delete; // NON_COMPLIANT
+};
+
+class C15 {
+  C15& operator=(C15 const &); // NON_COMPLIANT
+};
+
+template<typename T>
+class C16 { // COMPLIANT
+  C16() = default;};
+
+template<typename T>
+class C17 { // COMPLIANT
+  C17() = default;
+  C17(C17 const &) = default;
+  C17(C17 &&) = default;
+  virtual ~C17() = default;
+  C17 &operator=(C17 const &) = default;
+  C17 &operator=(C17 &&) = default;
+};
+
+template<typename T>
+class C18 { // COMPLIANT
+  C18() = default;
+  C18(C18 const &) = delete;
+  C18(C18 &&) = delete;
+  virtual ~C18() = default;
+  C18 &operator=(C18 const &) = delete;
+  C18 &operator=(C18 &&) = delete;
+};
+
+template<typename T>
+class C19 { // COMPLIANT
+  public:
+  explicit C19(T i) : i(i) {}
+  C19(C19 const &) = delete;
+  C19(C19 &&) = delete;
+  virtual ~C19() = default;
+  C19 &operator=(C19 const &) = delete;
+  C19 &operator=(C19 &&) = delete;
+  private:
+    T i;
+};

--- a/cpp/autosar/test/rules/A12-0-1/test.cpp
+++ b/cpp/autosar/test/rules/A12-0-1/test.cpp
@@ -69,15 +69,14 @@ class C14 {
 };
 
 class C15 {
-  C15& operator=(C15 const &); // NON_COMPLIANT
+  C15 &operator=(C15 const &); // NON_COMPLIANT
 };
 
-template<typename T>
-class C16 { // COMPLIANT
-  C16() = default;};
+template <typename T> class C16 { // COMPLIANT
+  C16() = default;
+};
 
-template<typename T>
-class C17 { // COMPLIANT
+template <typename T> class C17 { // COMPLIANT
   C17() = default;
   C17(C17 const &) = default;
   C17(C17 &&) = default;
@@ -86,8 +85,7 @@ class C17 { // COMPLIANT
   C17 &operator=(C17 &&) = default;
 };
 
-template<typename T>
-class C18 { // COMPLIANT
+template <typename T> class C18 { // COMPLIANT
   C18() = default;
   C18(C18 const &) = delete;
   C18(C18 &&) = delete;
@@ -96,15 +94,15 @@ class C18 { // COMPLIANT
   C18 &operator=(C18 &&) = delete;
 };
 
-template<typename T>
-class C19 { // COMPLIANT
-  public:
+template <typename T> class C19 { // COMPLIANT
+public:
   explicit C19(T i) : i(i) {}
   C19(C19 const &) = delete;
   C19(C19 &&) = delete;
   virtual ~C19() = default;
   C19 &operator=(C19 const &) = delete;
   C19 &operator=(C19 &&) = delete;
-  private:
-    T i;
+
+private:
+  T i;
 };


### PR DESCRIPTION
## Description

This PR include the test case in FP/FN report #8.
The test case could no reproduce the issue, but it is a good test case to have because it includes an uninitialized template.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)