### PR TITLE
A4-7-1: Exclude pointer increment/decrement expressions

### DIFF
--- a/change_notes/2024-01-17-a4-7-1-exclude-pointers.md
+++ b/change_notes/2024-01-17-a4-7-1-exclude-pointers.md
@@ -1,0 +1,1 @@
+ * `A4-7-1` - exclude pointer increment and decrement operators from this rule.

--- a/cpp/autosar/test/rules/A4-7-1/test.cpp
+++ b/cpp/autosar/test/rules/A4-7-1/test.cpp
@@ -63,3 +63,9 @@ void test_loop_bound_bad(unsigned int n) {
               // reached
   }
 }
+
+void test_pointer() {
+  int *p = nullptr;
+  p++; // COMPLIANT - not covered by this rule
+  p--; // COMPLIANT - not covered by this rule
+}

--- a/cpp/common/src/codingstandards/cpp/Overflow.qll
+++ b/cpp/common/src/codingstandards/cpp/Overflow.qll
@@ -1,5 +1,5 @@
 /**
- * This module provides predicates for checking whether an operation overflows or wraps.
+ * This module provides predicates for checking whether an integer operation overflows, underflows or wraps.
  */
 
 import cpp
@@ -10,10 +10,12 @@ import codingstandards.cpp.dataflow.TaintTracking
 import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 
 /**
- * An operation that may overflow or underflow.
+ * An integer operation that may overflow, underflow or wrap.
  */
 class InterestingOverflowingOperation extends Operation {
   InterestingOverflowingOperation() {
+    // We are only interested in integer experssions
+    this.getUnderlyingType() instanceof IntegralType and
     // Might overflow or underflow
     (
       exprMightOverflowNegatively(this)


### PR DESCRIPTION
## Description

Exclude pointer increment/decrement operations as the rule only covers integer expressions.

Fixes https://github.com/github/codeql-coding-standards/issues/379.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `A4-7-1`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)