### PR TITLE
A2-3-1: Exclude wide string literals and utf8 string literals

### DIFF
--- a/change_notes/2024-01-17-fix-reported-fp-for-a2-3-1.md
+++ b/change_notes/2024-01-17-fix-reported-fp-for-a2-3-1.md
@@ -1,2 +1,2 @@
 `A2-3-1`: ` cpp/autosar/invalid-character-in-string-literal`
-    - Exclude wide string literals and utf8 string literal.
+    - Fixes #311. Exclude wide string literals and utf8 string literal.

--- a/change_notes/2024-01-17-fix-reported-fp-for-a2-3-1.md
+++ b/change_notes/2024-01-17-fix-reported-fp-for-a2-3-1.md
@@ -1,0 +1,2 @@
+`A2-3-1`: ` cpp/autosar/invalid-character-in-string-literal`
+    - Exclude wide string literals and utf8 string literal.

--- a/cpp/autosar/src/rules/A2-3-1/InvalidCharacterInStringLiteral.ql
+++ b/cpp/autosar/src/rules/A2-3-1/InvalidCharacterInStringLiteral.ql
@@ -17,6 +17,7 @@
 
 import cpp
 import codingstandards.cpp.autosar
+import codingstandards.cpp.Literals
 
 bindingset[s]
 string getCharOutsideBasicSourceCharSet(string s) {
@@ -27,6 +28,9 @@ string getCharOutsideBasicSourceCharSet(string s) {
 from StringLiteral s, string ch
 where
   not isExcluded(s, NamingPackage::invalidCharacterInStringLiteralQuery()) and
-  ch = getCharOutsideBasicSourceCharSet(s.getValueText())
+  ch = getCharOutsideBasicSourceCharSet(s.getValueText()) and
+  // wide string and utf8 string literals are exempted.
+  not s instanceof WideStringLiteral and
+  not s instanceof Utf8StringLiteral
 select s,
   "String literal uses the character '" + ch + "' that is outside the language basic character set."

--- a/cpp/autosar/test/rules/A2-3-1/InvalidCharacterInComment.expected
+++ b/cpp/autosar/test/rules/A2-3-1/InvalidCharacterInComment.expected
@@ -1,2 +1,2 @@
 | test.cpp:3:1:3:37 | // Invalid character \u00ce\u00b1 NON_COMPLIANT | Comment uses the character '\u00ce\u00b1' that is outside the language basic character set. |
-| test.cpp:10:1:12:2 | /*\nInvalid character \u00e2\u0086\u00a6 NON_COMPLIANT\n*/ | Comment uses the character '\u00e2\u0086\u00a6' that is outside the language basic character set. |
+| test.cpp:12:1:14:2 | /*\nInvalid character \u00e2\u0086\u00a6 NON_COMPLIANT\n*/ | Comment uses the character '\u00e2\u0086\u00a6' that is outside the language basic character set. |

--- a/cpp/autosar/test/rules/A2-3-1/InvalidCharacterInStringLiteral.expected
+++ b/cpp/autosar/test/rules/A2-3-1/InvalidCharacterInStringLiteral.expected
@@ -1,1 +1,1 @@
-| test.cpp:7:20:7:22 | \u00ce\u00b1 | String literal uses the character '\u03b1' that is outside the language basic character set. |
+| test.cpp:7:21:7:23 | \u00ce\u00b1 | String literal uses the character '\u03b1' that is outside the language basic character set. |

--- a/cpp/autosar/test/rules/A2-3-1/test.cpp
+++ b/cpp/autosar/test/rules/A2-3-1/test.cpp
@@ -12,3 +12,7 @@ int valid;
 /*
 Invalid character ↦ NON_COMPLIANT
 */
+
+/*
+Valid character @ in comments COMPLIANT
+*/

--- a/cpp/autosar/test/rules/A2-3-1/test.cpp
+++ b/cpp/autosar/test/rules/A2-3-1/test.cpp
@@ -4,7 +4,9 @@
 double α = 2.;                   // NON_COMPLIANT; U+03b1
 void *to_𐆅_and_beyond = nullptr; // NON_COMPLIANT; U+10185
 int l1_\u00A8;                   // COMPLIANT[FALSE_POSITIVE]
-const char *euro = "α";          // NON_COMPLIANT
+const char *euro1 = "α";         // NON_COMPLIANT
+const wchar_t *euro2 = L"α";     // COMPLIANT
+const char *euro3 = u8"α";       // COMPLIANT
 
 int valid;
 /*

--- a/cpp/common/src/codingstandards/cpp/Literals.qll
+++ b/cpp/common/src/codingstandards/cpp/Literals.qll
@@ -14,25 +14,17 @@ string getTruncatedLiteralText(Literal l) {
 }
 
 class WideStringLiteral extends StringLiteral {
-  WideStringLiteral() {
-    this.getValueText().regexpMatch("(?s)\\s*L\".*")
-  } 
+  WideStringLiteral() { this.getValueText().regexpMatch("(?s)\\s*L\".*") }
 }
 
 class Utf8StringLiteral extends StringLiteral {
-  Utf8StringLiteral() {
-    this.getValueText().regexpMatch("(?s)\\s*u8\".*")
-  } 
+  Utf8StringLiteral() { this.getValueText().regexpMatch("(?s)\\s*u8\".*") }
 }
 
 class Utf16StringLiteral extends StringLiteral {
-  Utf16StringLiteral() {
-    this.getValueText().regexpMatch("(?s)\\s*u\".*")
-  } 
+  Utf16StringLiteral() { this.getValueText().regexpMatch("(?s)\\s*u\".*") }
 }
 
 class Utf32StringLiteral extends StringLiteral {
-  Utf32StringLiteral() {
-    this.getValueText().regexpMatch("(?s)\\s*U\".*")
-  } 
+  Utf32StringLiteral() { this.getValueText().regexpMatch("(?s)\\s*U\".*") }
 }

--- a/cpp/common/src/codingstandards/cpp/Literals.qll
+++ b/cpp/common/src/codingstandards/cpp/Literals.qll
@@ -12,3 +12,27 @@ string getTruncatedLiteralText(Literal l) {
     else result = text
   )
 }
+
+class WideStringLiteral extends StringLiteral {
+  WideStringLiteral() {
+    this.getValueText().regexpMatch("(?s)\\s*L\".*")
+  } 
+}
+
+class Utf8StringLiteral extends StringLiteral {
+  Utf8StringLiteral() {
+    this.getValueText().regexpMatch("(?s)\\s*u8\".*")
+  } 
+}
+
+class Utf16StringLiteral extends StringLiteral {
+  Utf16StringLiteral() {
+    this.getValueText().regexpMatch("(?s)\\s*u\".*")
+  } 
+}
+
+class Utf32StringLiteral extends StringLiteral {
+  Utf32StringLiteral() {
+    this.getValueText().regexpMatch("(?s)\\s*U\".*")
+  } 
+}


### PR DESCRIPTION
## Description

This fixes #311 

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - cpp/autosar/invalid-character-in-string-literal

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)