### PR TITLE
A8-4-7: exclude user defined operators and move constructors

### DIFF
--- a/change_notes/2024-01-25-fix-reported-fp-for-a8-4-7.md
+++ b/change_notes/2024-01-25-fix-reported-fp-for-a8-4-7.md
@@ -1,0 +1,2 @@
+`A8-4-7`: ` cpp/autosar/in-parameters-for-cheap-to-copy-types-not-passed-by-value`
+    - Fixes #397. Exclude user defined operators and move constructors.

--- a/cpp/autosar/src/rules/A8-4-7/InParametersForCheapToCopyTypesNotPassedByValue.ql
+++ b/cpp/autosar/src/rules/A8-4-7/InParametersForCheapToCopyTypesNotPassedByValue.ql
@@ -35,6 +35,8 @@ where
   t.isConst() and
   not exists(CatchBlock cb | cb.getParameter() = v) and
   not exists(CopyConstructor cc | cc.getAParameter() = v) and
+  not exists(MoveConstructor mc | mc.getAParameter() = v) and
+  not exists(Operator op | op.getAParameter() = v) and
   not v.isFromUninstantiatedTemplate(_)
 select v,
   "Parameter " + v.getName() + " is the trivially copyable type " + t.getName() +

--- a/cpp/autosar/test/rules/A8-4-7/test.cpp
+++ b/cpp/autosar/test/rules/A8-4-7/test.cpp
@@ -37,4 +37,12 @@ inline S1 Value(size_t n, const char *data) {} // COMPLIANT
 struct A {
   int n;
   A(const A &a) : n(a.n) {} // COMPLIANT user-defined copy ctor
+  A(const A &&other_a);     // COMPLIANT user-defined move ctor
+};
+
+class C1 {};
+
+class C2 : public C1 {
+public:
+  C2 &operator=(const C2 &); // COMPLIANT
 };


### PR DESCRIPTION
## Description

fixes #397 . excludes user defined operators

additionally included an exclusion for move constructors

specifically chose to not use the [`SpecialMemberFunctions`](https://github.com/github/codeql-coding-standards/blob/main/cpp/common/src/codingstandards/cpp/Class.qll#L76) as the exclusion because I think this applies to other operators than just described there (example `C2& operator+=(const C2& rhs);`)

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [ ] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)