### PR TITLE
Resolve issue 351

### DIFF
--- a/change_notes/2023-02-07-extend-getatypeuse.md
+++ b/change_notes/2023-02-07-extend-getatypeuse.md
@@ -1,0 +1,2 @@
+`A0-4-1` - `FloatingPointImplementationShallComplyWithIeeeStandard.ql`:
+    - May return more results due to improvements to underlying `getATypeUse`.

--- a/cpp/common/src/codingstandards/cpp/TypeUses.qll
+++ b/cpp/common/src/codingstandards/cpp/TypeUses.qll
@@ -132,6 +132,9 @@ private Locatable getATypeUse_i(Type type) {
       result = nq and
       type = nq.getQualifyingElement()
     )
+    // Temporary object creation of type `type`
+    or
+    exists(TemporaryObjectExpr toe | result = toe | type = toe.getType())
   )
   or
   // Recursive case - used by a used type

--- a/cpp/common/src/codingstandards/cpp/TypeUses.qll
+++ b/cpp/common/src/codingstandards/cpp/TypeUses.qll
@@ -82,7 +82,8 @@ private Locatable getATypeUse_i(Type type, string reason) {
       // Ignore self referential variables and parameters
       not v.getDeclaringType().refersTo(type) and
       not type = v.(Parameter).getFunction().getDeclaringType()
-    ) and reason = "used as a variable type"
+    ) and
+    reason = "used as a variable type"
     or
     // Used a function return type
     exists(Function f |
@@ -93,7 +94,8 @@ private Locatable getATypeUse_i(Type type, string reason) {
       type = f.getType() and reason = "used as a function return type"
       or
       type = f.getATemplateArgument() and reason = "used as a function template argument"
-    )     or
+    )
+    or
     // Used either in a function call as a template argument, or as the declaring type
     // of the function
     exists(FunctionCall fc | result = fc |
@@ -115,10 +117,12 @@ private Locatable getATypeUse_i(Type type, string reason) {
     reason = "used in a sizeof expr"
     or
     // A use in a `Cast`
-    exists(Cast c | c = result | type = c.getType()) and reason = "used in a cast"
+    exists(Cast c | c = result | type = c.getType()) and
+    reason = "used in a cast"
     or
     // Use of the type name in source
-    exists(TypeName t | t = result | type = t.getType()) and reason = "used in a typename"
+    exists(TypeName t | t = result | type = t.getType()) and
+    reason = "used in a typename"
     or
     // Access of an enum constant
     exists(EnumConstantAccess eca | result = eca | type = eca.getTarget().getDeclaringEnum()) and
@@ -128,15 +132,17 @@ private Locatable getATypeUse_i(Type type, string reason) {
     exists(FieldAccess fa |
       result = fa and
       type = fa.getTarget().getDeclaringType()
-    ) and reason = "used in a field access"
+    ) and
+    reason = "used in a field access"
     or
     // Name qualifiers
     exists(NameQualifier nq |
       result = nq and
       type = nq.getQualifyingElement()
-    ) and reason = "used in name qualifier"
-    // Temporary object creation of type `type`
+    ) and
+    reason = "used in name qualifier"
     or
+    // Temporary object creation of type `type`
     exists(TemporaryObjectExpr toe | result = toe | type = toe.getType()) and
     reason = "used in temporary object expr"
   )
@@ -160,8 +166,8 @@ private Locatable getATypeUse_i(Type type, string reason) {
     reason = "used in template class instantiation"
     or
     // This is a TemplateClass where one of the specializations is used
-    type = used.(ClassTemplateSpecialization).getPrimaryTemplate()
-    and reason = "used in template class specialization"
+    type = used.(ClassTemplateSpecialization).getPrimaryTemplate() and
+    reason = "used in template class specialization"
     or
     // Alias templates - alias templates and instantiations are not properly captured by the
     // extractor (last verified in CodeQL CLI 2.7.6). The only distinguishing factor is that
@@ -176,6 +182,7 @@ private Locatable getATypeUse_i(Type type, string reason) {
       not exists(instantiation.getLocation()) and
       // Template and instantiation both have the same qualified name
       template.getQualifiedName() = instantiation.getQualifiedName()
-    ) and reason = "used in alias template instantiation"
+    ) and
+    reason = "used in alias template instantiation"
   )
 }

--- a/cpp/common/test/rules/unusedtypedeclarations/test.cpp
+++ b/cpp/common/test/rules/unusedtypedeclarations/test.cpp
@@ -111,3 +111,14 @@ template <typename T> using Z = Y<T>;  // COMPLIANT - used below
 template <typename T> using AA = Y<T>; // NON_COMPLIANT - never instantiated
 
 void test_alias_template() { Z<int> v; }
+
+void test_temporary_object_creation() {
+  auto l1 = [](const auto &p1) noexcept {
+    class C1 { // COMPLIANT - used in temporary object construction
+    public:
+      constexpr static const char *m1() noexcept { return "foo"; }
+    };
+
+    return C1{p1};
+  };
+}


### PR DESCRIPTION
## Description

Resolves #351 by including type usage in temporary object expression.
This will increase the accuracy of `getATypeUse` in the case of partially initiated template members where there is a temporary object expression referring to the type, but no  
resolution of the `auto` return type because the member is not initialized.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)