### PR TITLE
Accept changes from #15549

### DIFF
--- a/c/cert/test/rules/ARR37-C/DoNotUsePointerArithmeticOnNonArrayObjectPointers.expected
+++ b/c/cert/test/rules/ARR37-C/DoNotUsePointerArithmeticOnNonArrayObjectPointers.expected
@@ -1,13 +1,13 @@
 edges
-| test.c:14:38:14:39 | p1 | test.c:18:10:18:11 | v1 |
-| test.c:14:38:14:39 | p1 | test.c:19:10:19:11 | v2 |
-| test.c:14:38:14:39 | p1 | test.c:20:10:20:11 | p1 |
-| test.c:14:38:14:39 | p1 | test.c:21:10:21:11 | p1 |
-| test.c:14:38:14:39 | p1 | test.c:22:9:22:10 | p1 |
-| test.c:14:38:14:39 | p1 | test.c:23:13:23:14 | p1 |
-| test.c:14:38:14:39 | p1 | test.c:24:9:24:10 | p1 |
-| test.c:14:38:14:39 | p1 | test.c:25:9:25:10 | p1 |
-| test.c:51:30:51:38 | & ... | test.c:14:38:14:39 | p1 |
+| test.c:14:38:14:39 | p1 | test.c:18:10:18:11 | v1 | provenance |  |
+| test.c:14:38:14:39 | p1 | test.c:19:10:19:11 | v2 | provenance |  |
+| test.c:14:38:14:39 | p1 | test.c:20:10:20:11 | p1 | provenance |  |
+| test.c:14:38:14:39 | p1 | test.c:21:10:21:11 | p1 | provenance |  |
+| test.c:14:38:14:39 | p1 | test.c:22:9:22:10 | p1 | provenance |  |
+| test.c:14:38:14:39 | p1 | test.c:23:13:23:14 | p1 | provenance |  |
+| test.c:14:38:14:39 | p1 | test.c:24:9:24:10 | p1 | provenance |  |
+| test.c:14:38:14:39 | p1 | test.c:25:9:25:10 | p1 | provenance |  |
+| test.c:51:30:51:38 | & ... | test.c:14:38:14:39 | p1 | provenance |  |
 nodes
 | test.c:14:38:14:39 | p1 | semmle.label | p1 |
 | test.c:18:10:18:11 | v1 | semmle.label | v1 |

--- a/c/cert/test/rules/ARR39-C/DoNotAddOrSubtractAScaledIntegerToAPointer.expected
+++ b/c/cert/test/rules/ARR39-C/DoNotAddOrSubtractAScaledIntegerToAPointer.expected
@@ -1,9 +1,9 @@
 edges
-| test.c:7:13:7:14 | p1 | test.c:9:9:9:10 | p1 |
-| test.c:16:19:16:41 | ... - ... | test.c:18:26:18:31 | offset |
-| test.c:16:19:16:41 | ... - ... | test.c:29:6:29:11 | offset |
-| test.c:17:17:17:26 | sizeof(<expr>) | test.c:23:9:23:12 | size |
-| test.c:29:6:29:11 | offset | test.c:7:13:7:14 | p1 |
+| test.c:7:13:7:14 | p1 | test.c:9:9:9:10 | p1 | provenance |  |
+| test.c:16:19:16:41 | ... - ... | test.c:18:26:18:31 | offset | provenance |  |
+| test.c:16:19:16:41 | ... - ... | test.c:29:6:29:11 | offset | provenance |  |
+| test.c:17:17:17:26 | sizeof(<expr>) | test.c:23:9:23:12 | size | provenance |  |
+| test.c:29:6:29:11 | offset | test.c:7:13:7:14 | p1 | provenance |  |
 nodes
 | test.c:7:13:7:14 | p1 | semmle.label | p1 |
 | test.c:9:9:9:10 | p1 | semmle.label | p1 |

--- a/c/cert/test/rules/EXP36-C/DoNotCastPointerToMoreStrictlyAlignedPointerType.expected
+++ b/c/cert/test/rules/EXP36-C/DoNotCastPointerToMoreStrictlyAlignedPointerType.expected
@@ -1,67 +1,67 @@
 edges
-| test.c:75:14:75:16 | & ... | test.c:76:11:76:12 | v1 |
-| test.c:75:14:75:16 | & ... | test.c:77:12:77:13 | v1 |
-| test.c:75:14:75:16 | & ... | test.c:78:10:78:11 | v1 |
-| test.c:75:14:75:16 | & ... | test.c:79:12:79:13 | v1 |
-| test.c:75:14:75:16 | & ... | test.c:80:11:80:12 | v1 |
-| test.c:75:14:75:16 | & ... | test.c:81:13:81:14 | v1 |
-| test.c:84:14:84:16 | & ... | test.c:85:11:85:12 | v2 |
-| test.c:84:14:84:16 | & ... | test.c:86:12:86:13 | v2 |
-| test.c:84:14:84:16 | & ... | test.c:87:10:87:11 | v2 |
-| test.c:84:14:84:16 | & ... | test.c:88:12:88:13 | v2 |
-| test.c:84:14:84:16 | & ... | test.c:89:11:89:12 | v2 |
-| test.c:84:14:84:16 | & ... | test.c:90:13:90:14 | v2 |
-| test.c:93:14:93:16 | & ... | test.c:94:11:94:12 | v3 |
-| test.c:93:14:93:16 | & ... | test.c:95:12:95:13 | v3 |
-| test.c:93:14:93:16 | & ... | test.c:96:10:96:11 | v3 |
-| test.c:93:14:93:16 | & ... | test.c:97:12:97:13 | v3 |
-| test.c:93:14:93:16 | & ... | test.c:98:11:98:12 | v3 |
-| test.c:93:14:93:16 | & ... | test.c:99:13:99:14 | v3 |
-| test.c:102:14:102:16 | & ... | test.c:103:11:103:12 | v4 |
-| test.c:102:14:102:16 | & ... | test.c:104:12:104:13 | v4 |
-| test.c:102:14:102:16 | & ... | test.c:105:10:105:11 | v4 |
-| test.c:102:14:102:16 | & ... | test.c:106:12:106:13 | v4 |
-| test.c:102:14:102:16 | & ... | test.c:107:11:107:12 | v4 |
-| test.c:102:14:102:16 | & ... | test.c:108:13:108:14 | v4 |
-| test.c:111:14:111:16 | & ... | test.c:112:11:112:12 | v5 |
-| test.c:111:14:111:16 | & ... | test.c:113:12:113:13 | v5 |
-| test.c:111:14:111:16 | & ... | test.c:114:10:114:11 | v5 |
-| test.c:111:14:111:16 | & ... | test.c:115:12:115:13 | v5 |
-| test.c:111:14:111:16 | & ... | test.c:116:11:116:12 | v5 |
-| test.c:111:14:111:16 | & ... | test.c:117:13:117:14 | v5 |
-| test.c:120:14:120:16 | & ... | test.c:121:11:121:12 | v6 |
-| test.c:120:14:120:16 | & ... | test.c:122:12:122:13 | v6 |
-| test.c:120:14:120:16 | & ... | test.c:123:10:123:11 | v6 |
-| test.c:120:14:120:16 | & ... | test.c:124:12:124:13 | v6 |
-| test.c:120:14:120:16 | & ... | test.c:125:11:125:12 | v6 |
-| test.c:120:14:120:16 | & ... | test.c:126:13:126:14 | v6 |
-| test.c:129:22:129:22 | v | test.c:130:17:130:17 | v |
-| test.c:135:21:135:23 | & ... | test.c:129:22:129:22 | v |
-| test.c:138:21:138:23 | & ... | test.c:129:22:129:22 | v |
-| test.c:166:24:166:29 | call to malloc | test.c:167:13:167:15 | & ... |
-| test.c:166:24:166:29 | call to malloc | test.c:168:16:168:17 | s1 |
-| test.c:166:24:166:29 | call to malloc | test.c:169:13:169:14 | s1 |
-| test.c:166:24:166:29 | call to malloc | test.c:169:13:169:14 | s1 |
-| test.c:169:13:169:14 | s1 | test.c:129:22:129:22 | v |
-| test.c:174:13:174:14 | s2 | test.c:129:22:129:22 | v |
-| test.c:179:13:179:14 | s3 | test.c:129:22:129:22 | v |
-| test.c:183:14:183:26 | call to aligned_alloc | test.c:184:11:184:12 | v1 |
-| test.c:183:14:183:26 | call to aligned_alloc | test.c:185:10:185:11 | v1 |
-| test.c:183:14:183:26 | call to aligned_alloc | test.c:186:13:186:14 | v1 |
-| test.c:183:14:183:26 | call to aligned_alloc | test.c:187:13:187:14 | v1 |
-| test.c:187:13:187:14 | v1 | test.c:129:22:129:22 | v |
-| test.c:189:14:189:26 | call to aligned_alloc | test.c:190:13:190:14 | v2 |
-| test.c:190:13:190:14 | v2 | test.c:129:22:129:22 | v |
-| test.c:222:8:222:9 | p2 | test.c:223:11:223:12 | v1 |
-| test.c:222:8:222:9 | p2 | test.c:224:12:224:13 | v1 |
-| test.c:222:8:222:9 | p2 | test.c:225:10:225:11 | v1 |
-| test.c:222:8:222:9 | p2 | test.c:226:12:226:13 | v1 |
-| test.c:222:8:222:9 | p2 | test.c:227:11:227:12 | v1 |
-| test.c:222:8:222:9 | p2 | test.c:228:13:228:14 | v1 |
-| test.c:238:13:238:14 | & ... | test.c:244:12:244:13 | ip |
-| test.c:241:15:241:18 | & ... | test.c:247:9:247:12 | & ... |
-| test.c:252:16:252:18 | & ... | test.c:254:11:254:13 | ps1 |
-| test.c:252:16:252:18 | & ... | test.c:256:10:256:12 | ps1 |
+| test.c:75:14:75:16 | & ... | test.c:76:11:76:12 | v1 | provenance |  |
+| test.c:75:14:75:16 | & ... | test.c:77:12:77:13 | v1 | provenance |  |
+| test.c:75:14:75:16 | & ... | test.c:78:10:78:11 | v1 | provenance |  |
+| test.c:75:14:75:16 | & ... | test.c:79:12:79:13 | v1 | provenance |  |
+| test.c:75:14:75:16 | & ... | test.c:80:11:80:12 | v1 | provenance |  |
+| test.c:75:14:75:16 | & ... | test.c:81:13:81:14 | v1 | provenance |  |
+| test.c:84:14:84:16 | & ... | test.c:85:11:85:12 | v2 | provenance |  |
+| test.c:84:14:84:16 | & ... | test.c:86:12:86:13 | v2 | provenance |  |
+| test.c:84:14:84:16 | & ... | test.c:87:10:87:11 | v2 | provenance |  |
+| test.c:84:14:84:16 | & ... | test.c:88:12:88:13 | v2 | provenance |  |
+| test.c:84:14:84:16 | & ... | test.c:89:11:89:12 | v2 | provenance |  |
+| test.c:84:14:84:16 | & ... | test.c:90:13:90:14 | v2 | provenance |  |
+| test.c:93:14:93:16 | & ... | test.c:94:11:94:12 | v3 | provenance |  |
+| test.c:93:14:93:16 | & ... | test.c:95:12:95:13 | v3 | provenance |  |
+| test.c:93:14:93:16 | & ... | test.c:96:10:96:11 | v3 | provenance |  |
+| test.c:93:14:93:16 | & ... | test.c:97:12:97:13 | v3 | provenance |  |
+| test.c:93:14:93:16 | & ... | test.c:98:11:98:12 | v3 | provenance |  |
+| test.c:93:14:93:16 | & ... | test.c:99:13:99:14 | v3 | provenance |  |
+| test.c:102:14:102:16 | & ... | test.c:103:11:103:12 | v4 | provenance |  |
+| test.c:102:14:102:16 | & ... | test.c:104:12:104:13 | v4 | provenance |  |
+| test.c:102:14:102:16 | & ... | test.c:105:10:105:11 | v4 | provenance |  |
+| test.c:102:14:102:16 | & ... | test.c:106:12:106:13 | v4 | provenance |  |
+| test.c:102:14:102:16 | & ... | test.c:107:11:107:12 | v4 | provenance |  |
+| test.c:102:14:102:16 | & ... | test.c:108:13:108:14 | v4 | provenance |  |
+| test.c:111:14:111:16 | & ... | test.c:112:11:112:12 | v5 | provenance |  |
+| test.c:111:14:111:16 | & ... | test.c:113:12:113:13 | v5 | provenance |  |
+| test.c:111:14:111:16 | & ... | test.c:114:10:114:11 | v5 | provenance |  |
+| test.c:111:14:111:16 | & ... | test.c:115:12:115:13 | v5 | provenance |  |
+| test.c:111:14:111:16 | & ... | test.c:116:11:116:12 | v5 | provenance |  |
+| test.c:111:14:111:16 | & ... | test.c:117:13:117:14 | v5 | provenance |  |
+| test.c:120:14:120:16 | & ... | test.c:121:11:121:12 | v6 | provenance |  |
+| test.c:120:14:120:16 | & ... | test.c:122:12:122:13 | v6 | provenance |  |
+| test.c:120:14:120:16 | & ... | test.c:123:10:123:11 | v6 | provenance |  |
+| test.c:120:14:120:16 | & ... | test.c:124:12:124:13 | v6 | provenance |  |
+| test.c:120:14:120:16 | & ... | test.c:125:11:125:12 | v6 | provenance |  |
+| test.c:120:14:120:16 | & ... | test.c:126:13:126:14 | v6 | provenance |  |
+| test.c:129:22:129:22 | v | test.c:130:17:130:17 | v | provenance |  |
+| test.c:135:21:135:23 | & ... | test.c:129:22:129:22 | v | provenance |  |
+| test.c:138:21:138:23 | & ... | test.c:129:22:129:22 | v | provenance |  |
+| test.c:166:24:166:29 | call to malloc | test.c:167:13:167:15 | & ... | provenance |  |
+| test.c:166:24:166:29 | call to malloc | test.c:168:16:168:17 | s1 | provenance |  |
+| test.c:166:24:166:29 | call to malloc | test.c:169:13:169:14 | s1 | provenance |  |
+| test.c:166:24:166:29 | call to malloc | test.c:169:13:169:14 | s1 | provenance |  |
+| test.c:169:13:169:14 | s1 | test.c:129:22:129:22 | v | provenance |  |
+| test.c:174:13:174:14 | s2 | test.c:129:22:129:22 | v | provenance |  |
+| test.c:179:13:179:14 | s3 | test.c:129:22:129:22 | v | provenance |  |
+| test.c:183:14:183:26 | call to aligned_alloc | test.c:184:11:184:12 | v1 | provenance |  |
+| test.c:183:14:183:26 | call to aligned_alloc | test.c:185:10:185:11 | v1 | provenance |  |
+| test.c:183:14:183:26 | call to aligned_alloc | test.c:186:13:186:14 | v1 | provenance |  |
+| test.c:183:14:183:26 | call to aligned_alloc | test.c:187:13:187:14 | v1 | provenance |  |
+| test.c:187:13:187:14 | v1 | test.c:129:22:129:22 | v | provenance |  |
+| test.c:189:14:189:26 | call to aligned_alloc | test.c:190:13:190:14 | v2 | provenance |  |
+| test.c:190:13:190:14 | v2 | test.c:129:22:129:22 | v | provenance |  |
+| test.c:222:8:222:9 | p2 | test.c:223:11:223:12 | v1 | provenance |  |
+| test.c:222:8:222:9 | p2 | test.c:224:12:224:13 | v1 | provenance |  |
+| test.c:222:8:222:9 | p2 | test.c:225:10:225:11 | v1 | provenance |  |
+| test.c:222:8:222:9 | p2 | test.c:226:12:226:13 | v1 | provenance |  |
+| test.c:222:8:222:9 | p2 | test.c:227:11:227:12 | v1 | provenance |  |
+| test.c:222:8:222:9 | p2 | test.c:228:13:228:14 | v1 | provenance |  |
+| test.c:238:13:238:14 | & ... | test.c:244:12:244:13 | ip | provenance |  |
+| test.c:241:15:241:18 | & ... | test.c:247:9:247:12 | & ... | provenance |  |
+| test.c:252:16:252:18 | & ... | test.c:254:11:254:13 | ps1 | provenance |  |
+| test.c:252:16:252:18 | & ... | test.c:256:10:256:12 | ps1 | provenance |  |
 nodes
 | test.c:7:11:7:13 | & ... | semmle.label | & ... |
 | test.c:8:12:8:14 | & ... | semmle.label | & ... |

--- a/c/cert/test/rules/EXP37-C/DoNotCallFunctionPointerWithIncompatibleType.expected
+++ b/c/cert/test/rules/EXP37-C/DoNotCallFunctionPointerWithIncompatibleType.expected
@@ -1,11 +1,11 @@
 edges
-| test.c:48:68:48:70 | fns [f1] | test.c:49:3:49:5 | fns [f1] |
-| test.c:49:3:49:5 | fns [f1] | test.c:49:8:49:9 | f1 |
-| test.c:61:28:61:29 | f2 | test.c:62:3:62:11 | v1_called |
-| test.c:73:3:73:5 | fns [post update] [f1] | test.c:75:45:75:48 | & ... [f1] |
-| test.c:73:3:73:13 | ... = ... | test.c:73:3:73:5 | fns [post update] [f1] |
-| test.c:73:12:73:13 | v2 | test.c:73:3:73:13 | ... = ... |
-| test.c:75:45:75:48 | & ... [f1] | test.c:48:68:48:70 | fns [f1] |
+| test.c:48:68:48:70 | fns [f1] | test.c:49:3:49:5 | fns [f1] | provenance |  |
+| test.c:49:3:49:5 | fns [f1] | test.c:49:8:49:9 | f1 | provenance |  |
+| test.c:61:28:61:29 | f2 | test.c:62:3:62:11 | v1_called | provenance |  |
+| test.c:73:3:73:5 | fns [post update] [f1] | test.c:75:45:75:48 | & ... [f1] | provenance |  |
+| test.c:73:3:73:13 | ... = ... | test.c:73:3:73:5 | fns [post update] [f1] | provenance |  |
+| test.c:73:12:73:13 | v2 | test.c:73:3:73:13 | ... = ... | provenance |  |
+| test.c:75:45:75:48 | & ... [f1] | test.c:48:68:48:70 | fns [f1] | provenance |  |
 nodes
 | test.c:48:68:48:70 | fns [f1] | semmle.label | fns [f1] |
 | test.c:49:3:49:5 | fns [f1] | semmle.label | fns [f1] |

--- a/c/cert/test/rules/EXP39-C/DoNotAccessVariableViaPointerOfIncompatibleType.expected
+++ b/c/cert/test/rules/EXP39-C/DoNotAccessVariableViaPointerOfIncompatibleType.expected
@@ -1,15 +1,15 @@
 edges
-| test.c:49:8:49:9 | s3 | test.c:50:8:50:9 | s1 |
-| test.c:60:16:60:18 | E1A | test.c:61:16:61:17 | e1 |
-| test.c:60:16:60:18 | E1A | test.c:65:10:65:12 | & ... |
-| test.c:68:22:68:22 | v | test.c:68:41:68:41 | v |
-| test.c:72:13:72:15 | & ... | test.c:68:22:68:22 | v |
-| test.c:74:13:74:15 | & ... | test.c:68:22:68:22 | v |
-| test.c:97:32:97:37 | call to malloc | test.c:98:40:98:41 | s2 |
-| test.c:97:32:97:37 | call to malloc | test.c:98:40:98:41 | s2 |
-| test.c:98:32:98:38 | call to realloc | test.c:99:3:99:4 | s3 |
-| test.c:98:32:98:38 | call to realloc | test.c:100:10:100:11 | s3 |
-| test.c:98:40:98:41 | s2 | test.c:98:32:98:38 | call to realloc |
+| test.c:49:8:49:9 | s3 | test.c:50:8:50:9 | s1 | provenance |  |
+| test.c:60:16:60:18 | E1A | test.c:61:16:61:17 | e1 | provenance |  |
+| test.c:60:16:60:18 | E1A | test.c:65:10:65:12 | & ... | provenance |  |
+| test.c:68:22:68:22 | v | test.c:68:41:68:41 | v | provenance |  |
+| test.c:72:13:72:15 | & ... | test.c:68:22:68:22 | v | provenance |  |
+| test.c:74:13:74:15 | & ... | test.c:68:22:68:22 | v | provenance |  |
+| test.c:97:32:97:37 | call to malloc | test.c:98:40:98:41 | s2 | provenance |  |
+| test.c:97:32:97:37 | call to malloc | test.c:98:40:98:41 | s2 | provenance |  |
+| test.c:98:32:98:38 | call to realloc | test.c:99:3:99:4 | s3 | provenance |  |
+| test.c:98:32:98:38 | call to realloc | test.c:100:10:100:11 | s3 | provenance |  |
+| test.c:98:40:98:41 | s2 | test.c:98:32:98:38 | call to realloc | provenance |  |
 nodes
 | test.c:6:19:6:20 | & ... | semmle.label | & ... |
 | test.c:11:10:11:11 | & ... | semmle.label | & ... |

--- a/c/cert/test/rules/EXP40-C/DoNotModifyConstantObjects.expected
+++ b/c/cert/test/rules/EXP40-C/DoNotModifyConstantObjects.expected
@@ -1,11 +1,11 @@
 edges
-| test.c:5:8:5:9 | & ... | test.c:6:4:6:5 | aa |
-| test.c:26:15:26:15 | a | test.c:27:4:27:4 | a |
-| test.c:34:13:34:14 | & ... | test.c:39:7:39:8 | p1 |
-| test.c:39:7:39:8 | p1 | test.c:26:15:26:15 | a |
-| test.c:40:7:40:9 | * ... | test.c:26:15:26:15 | a |
-| test.c:59:7:59:8 | & ... | test.c:60:4:60:4 | p |
-| test.c:79:11:79:16 | call to strchr | test.c:81:6:81:12 | ... ++ |
+| test.c:5:8:5:9 | & ... | test.c:6:4:6:5 | aa | provenance |  |
+| test.c:26:15:26:15 | a | test.c:27:4:27:4 | a | provenance |  |
+| test.c:34:13:34:14 | & ... | test.c:39:7:39:8 | p1 | provenance |  |
+| test.c:39:7:39:8 | p1 | test.c:26:15:26:15 | a | provenance |  |
+| test.c:40:7:40:9 | * ... | test.c:26:15:26:15 | a | provenance |  |
+| test.c:59:7:59:8 | & ... | test.c:60:4:60:4 | p | provenance |  |
+| test.c:79:11:79:16 | call to strchr | test.c:81:6:81:12 | ... ++ | provenance |  |
 nodes
 | test.c:5:8:5:9 | & ... | semmle.label | & ... |
 | test.c:6:4:6:5 | aa | semmle.label | aa |

--- a/c/cert/test/rules/FIO32-C/DoNotPerformFileOperationsOnDevices.expected
+++ b/c/cert/test/rules/FIO32-C/DoNotPerformFileOperationsOnDevices.expected
@@ -1,6 +1,6 @@
 edges
-| test.c:20:15:20:23 | scanf output argument | test.c:21:8:21:16 | *file_name |
-| test.c:45:15:45:23 | scanf output argument | test.c:46:29:46:37 | *file_name |
+| test.c:20:15:20:23 | scanf output argument | test.c:21:8:21:16 | *file_name | provenance |  |
+| test.c:45:15:45:23 | scanf output argument | test.c:46:29:46:37 | *file_name | provenance |  |
 nodes
 | test.c:20:15:20:23 | scanf output argument | semmle.label | scanf output argument |
 | test.c:21:8:21:16 | *file_name | semmle.label | *file_name |

--- a/c/cert/test/rules/MEM36-C/DoNotModifyAlignmentOfMemoryWithRealloc.expected
+++ b/c/cert/test/rules/MEM36-C/DoNotModifyAlignmentOfMemoryWithRealloc.expected
@@ -1,9 +1,9 @@
 edges
-| test.c:5:10:5:22 | call to aligned_alloc | test.c:15:8:15:28 | call to aligned_alloc_wrapper |
-| test.c:8:29:8:31 | ptr | test.c:8:64:8:66 | ptr |
-| test.c:15:8:15:28 | call to aligned_alloc_wrapper | test.c:16:24:16:25 | v1 |
-| test.c:16:24:16:25 | v1 | test.c:8:29:8:31 | ptr |
-| test.c:22:8:22:20 | call to aligned_alloc | test.c:23:16:23:17 | v3 |
+| test.c:5:10:5:22 | call to aligned_alloc | test.c:15:8:15:28 | call to aligned_alloc_wrapper | provenance |  |
+| test.c:8:29:8:31 | ptr | test.c:8:64:8:66 | ptr | provenance |  |
+| test.c:15:8:15:28 | call to aligned_alloc_wrapper | test.c:16:24:16:25 | v1 | provenance |  |
+| test.c:16:24:16:25 | v1 | test.c:8:29:8:31 | ptr | provenance |  |
+| test.c:22:8:22:20 | call to aligned_alloc | test.c:23:16:23:17 | v3 | provenance |  |
 nodes
 | test.c:5:10:5:22 | call to aligned_alloc | semmle.label | call to aligned_alloc |
 | test.c:8:29:8:31 | ptr | semmle.label | ptr |

--- a/c/common/test/rules/constlikereturnvalue/ConstLikeReturnValue.expected
+++ b/c/common/test/rules/constlikereturnvalue/ConstLikeReturnValue.expected
@@ -3,11 +3,11 @@ problems
 | test.c:64:5:64:9 | conv4 | test.c:61:11:61:20 | call to localeconv | test.c:64:5:64:9 | conv4 | The object returned by the function localeconv should not be modified. |
 | test.c:73:5:73:8 | conv | test.c:69:25:69:34 | call to localeconv | test.c:73:5:73:8 | conv | The object returned by the function localeconv should not be modified. |
 edges
-| test.c:5:18:5:22 | c_str | test.c:8:8:8:12 | c_str |
-| test.c:15:16:15:21 | call to getenv | test.c:21:9:21:12 | env1 |
-| test.c:21:9:21:12 | env1 | test.c:5:18:5:22 | c_str |
-| test.c:61:11:61:20 | call to localeconv | test.c:64:5:64:9 | conv4 |
-| test.c:69:25:69:34 | call to localeconv | test.c:73:5:73:8 | conv |
+| test.c:5:18:5:22 | c_str | test.c:8:8:8:12 | c_str | provenance |  |
+| test.c:15:16:15:21 | call to getenv | test.c:21:9:21:12 | env1 | provenance |  |
+| test.c:21:9:21:12 | env1 | test.c:5:18:5:22 | c_str | provenance |  |
+| test.c:61:11:61:20 | call to localeconv | test.c:64:5:64:9 | conv4 | provenance |  |
+| test.c:69:25:69:34 | call to localeconv | test.c:73:5:73:8 | conv | provenance |  |
 nodes
 | test.c:5:18:5:22 | c_str | semmle.label | c_str |
 | test.c:8:8:8:12 | c_str | semmle.label | c_str |

--- a/c/common/test/rules/donotsubtractpointersaddressingdifferentarrays/DoNotSubtractPointersAddressingDifferentArrays.expected
+++ b/c/common/test/rules/donotsubtractpointersaddressingdifferentarrays/DoNotSubtractPointersAddressingDifferentArrays.expected
@@ -4,14 +4,14 @@ problems
 | test.c:13:10:13:11 | p4 | test.c:5:14:5:15 | l2 | test.c:13:10:13:11 | p4 | Subtraction between left operand pointing to array $@ and other operand pointing to array $@. | test.c:3:7:3:8 | l2 | l2 | test.c:2:7:2:8 | l1 | l1 |
 | test.c:13:15:13:16 | l1 | test.c:13:15:13:16 | l1 | test.c:13:15:13:16 | l1 | Subtraction between right operand pointing to array $@ and other operand pointing to array $@. | test.c:2:7:2:8 | l1 | l1 | test.c:3:7:3:8 | l2 | l2 |
 edges
-| test.c:4:14:4:15 | l1 | test.c:4:14:4:18 | access to array |
-| test.c:4:14:4:18 | access to array | test.c:10:10:10:11 | p1 |
-| test.c:4:14:4:18 | access to array | test.c:12:10:12:11 | p1 |
-| test.c:5:14:5:15 | l2 | test.c:5:14:5:19 | access to array |
-| test.c:5:14:5:19 | access to array | test.c:11:10:11:11 | p2 |
-| test.c:5:14:5:19 | access to array | test.c:12:15:12:16 | p2 |
-| test.c:5:14:5:19 | access to array | test.c:13:10:13:11 | p4 |
-| test.c:5:14:5:19 | access to array | test.c:14:10:14:11 | p4 |
+| test.c:4:14:4:15 | l1 | test.c:4:14:4:18 | access to array | provenance |  |
+| test.c:4:14:4:18 | access to array | test.c:10:10:10:11 | p1 | provenance |  |
+| test.c:4:14:4:18 | access to array | test.c:12:10:12:11 | p1 | provenance |  |
+| test.c:5:14:5:15 | l2 | test.c:5:14:5:19 | access to array | provenance |  |
+| test.c:5:14:5:19 | access to array | test.c:11:10:11:11 | p2 | provenance |  |
+| test.c:5:14:5:19 | access to array | test.c:12:15:12:16 | p2 | provenance |  |
+| test.c:5:14:5:19 | access to array | test.c:13:10:13:11 | p4 | provenance |  |
+| test.c:5:14:5:19 | access to array | test.c:14:10:14:11 | p4 | provenance |  |
 nodes
 | test.c:4:14:4:15 | l1 | semmle.label | l1 |
 | test.c:4:14:4:18 | access to array | semmle.label | access to array |

--- a/c/common/test/rules/donotuserelationaloperatorswithdifferingarrays/DoNotUseRelationalOperatorsWithDifferingArrays.expected
+++ b/c/common/test/rules/donotuserelationaloperatorswithdifferingarrays/DoNotUseRelationalOperatorsWithDifferingArrays.expected
@@ -10,19 +10,19 @@ problems
 | test.c:25:7:25:14 | ... >= ... | test.c:7:14:7:15 | l1 | test.c:25:7:25:8 | p1 | Compare operation >= comparing left operand pointing to array $@ and other operand pointing to array $@. | test.c:2:7:2:8 | l1 | l1 | test.c:4:7:4:8 | l3 | l3 |
 | test.c:25:7:25:14 | ... >= ... | test.c:25:13:25:14 | l3 | test.c:25:13:25:14 | l3 | Compare operation >= comparing right operand pointing to array $@ and other operand pointing to array $@. | test.c:4:7:4:8 | l3 | l3 | test.c:2:7:2:8 | l1 | l1 |
 edges
-| test.c:6:13:6:14 | l1 | test.c:13:12:13:13 | p0 |
-| test.c:7:14:7:15 | l1 | test.c:7:14:7:18 | access to array |
-| test.c:7:14:7:18 | access to array | test.c:11:7:11:8 | p1 |
-| test.c:7:14:7:18 | access to array | test.c:13:7:13:8 | p1 |
-| test.c:7:14:7:18 | access to array | test.c:15:13:15:14 | p1 |
-| test.c:7:14:7:18 | access to array | test.c:17:7:17:8 | p1 |
-| test.c:7:14:7:18 | access to array | test.c:23:13:23:14 | p1 |
-| test.c:7:14:7:18 | access to array | test.c:25:7:25:8 | p1 |
-| test.c:8:14:8:15 | l1 | test.c:8:14:8:18 | access to array |
-| test.c:8:14:8:18 | access to array | test.c:11:12:11:13 | p2 |
-| test.c:8:14:8:18 | access to array | test.c:21:7:21:8 | p2 |
-| test.c:9:14:9:15 | l2 | test.c:9:14:9:18 | access to array |
-| test.c:9:14:9:18 | access to array | test.c:21:12:21:13 | p3 |
+| test.c:6:13:6:14 | l1 | test.c:13:12:13:13 | p0 | provenance |  |
+| test.c:7:14:7:15 | l1 | test.c:7:14:7:18 | access to array | provenance |  |
+| test.c:7:14:7:18 | access to array | test.c:11:7:11:8 | p1 | provenance |  |
+| test.c:7:14:7:18 | access to array | test.c:13:7:13:8 | p1 | provenance |  |
+| test.c:7:14:7:18 | access to array | test.c:15:13:15:14 | p1 | provenance |  |
+| test.c:7:14:7:18 | access to array | test.c:17:7:17:8 | p1 | provenance |  |
+| test.c:7:14:7:18 | access to array | test.c:23:13:23:14 | p1 | provenance |  |
+| test.c:7:14:7:18 | access to array | test.c:25:7:25:8 | p1 | provenance |  |
+| test.c:8:14:8:15 | l1 | test.c:8:14:8:18 | access to array | provenance |  |
+| test.c:8:14:8:18 | access to array | test.c:11:12:11:13 | p2 | provenance |  |
+| test.c:8:14:8:18 | access to array | test.c:21:7:21:8 | p2 | provenance |  |
+| test.c:9:14:9:15 | l2 | test.c:9:14:9:18 | access to array | provenance |  |
+| test.c:9:14:9:18 | access to array | test.c:21:12:21:13 | p3 | provenance |  |
 nodes
 | test.c:6:13:6:14 | l1 | semmle.label | l1 |
 | test.c:7:14:7:15 | l1 | semmle.label | l1 |

--- a/c/common/test/rules/onlyfreememoryallocateddynamicallyshared/OnlyFreeMemoryAllocatedDynamicallyShared.expected
+++ b/c/common/test/rules/onlyfreememoryallocateddynamicallyshared/OnlyFreeMemoryAllocatedDynamicallyShared.expected
@@ -6,10 +6,10 @@ problems
 | test.c:18:36:18:38 | ptr | test.c:27:7:27:8 | & ... | test.c:18:36:18:38 | ptr | Free expression frees memory which was not dynamically allocated. |
 | test.c:26:8:26:8 | p | test.c:25:13:25:14 | & ... | test.c:26:8:26:8 | p | Free expression frees memory which was not dynamically allocated. |
 edges
-| test.c:18:24:18:26 | ptr | test.c:18:36:18:38 | ptr |
-| test.c:25:13:25:14 | & ... | test.c:26:8:26:8 | p |
-| test.c:27:7:27:8 | & ... | test.c:28:15:28:15 | p |
-| test.c:28:15:28:15 | p | test.c:18:24:18:26 | ptr |
+| test.c:18:24:18:26 | ptr | test.c:18:36:18:38 | ptr | provenance |  |
+| test.c:25:13:25:14 | & ... | test.c:26:8:26:8 | p | provenance |  |
+| test.c:27:7:27:8 | & ... | test.c:28:15:28:15 | p | provenance |  |
+| test.c:28:15:28:15 | p | test.c:18:24:18:26 | ptr | provenance |  |
 nodes
 | test.c:8:8:8:10 | g_p | semmle.label | g_p |
 | test.c:10:8:10:10 | g_p | semmle.label | g_p |

--- a/c/misra/test/rules/RULE-21-14/MemcmpUsedToCompareNullTerminatedStrings.expected
+++ b/c/misra/test/rules/RULE-21-14/MemcmpUsedToCompareNullTerminatedStrings.expected
@@ -1,10 +1,10 @@
 edges
-| test.c:12:13:12:15 | a | test.c:14:10:14:10 | a |
-| test.c:12:13:12:15 | a | test.c:23:13:23:13 | a |
-| test.c:12:13:12:15 | a | test.c:24:10:24:10 | a |
-| test.c:13:13:13:15 | b | test.c:14:13:14:13 | b |
-| test.c:18:15:18:28 | {...} | test.c:21:10:21:10 | e |
-| test.c:19:15:19:28 | {...} | test.c:21:13:21:13 | f |
+| test.c:12:13:12:15 | a | test.c:14:10:14:10 | a | provenance |  |
+| test.c:12:13:12:15 | a | test.c:23:13:23:13 | a | provenance |  |
+| test.c:12:13:12:15 | a | test.c:24:10:24:10 | a | provenance |  |
+| test.c:13:13:13:15 | b | test.c:14:13:14:13 | b | provenance |  |
+| test.c:18:15:18:28 | {...} | test.c:21:10:21:10 | e | provenance |  |
+| test.c:19:15:19:28 | {...} | test.c:21:13:21:13 | f | provenance |  |
 nodes
 | test.c:10:10:10:12 | a | semmle.label | a |
 | test.c:10:15:10:17 | b | semmle.label | b |

--- a/cpp/autosar/test/rules/A18-1-4/PointerToAnElementOfAnArrayPassedToASmartPointer.expected
+++ b/cpp/autosar/test/rules/A18-1-4/PointerToAnElementOfAnArrayPassedToASmartPointer.expected
@@ -1,10 +1,10 @@
 edges
-| test.cpp:3:36:3:45 | new[] | test.cpp:19:27:19:44 | call to allocate_int_array |
-| test.cpp:3:36:3:45 | new[] | test.cpp:23:12:23:29 | call to allocate_int_array |
-| test.cpp:3:36:3:45 | new[] | test.cpp:27:20:27:37 | call to allocate_int_array |
-| test.cpp:11:29:11:41 | call to unique_ptr | test.cpp:12:27:12:28 | v2 |
-| test.cpp:12:27:12:28 | v2 | test.cpp:12:30:12:36 | call to release |
-| test.cpp:27:20:27:37 | call to allocate_int_array | test.cpp:32:12:32:20 | int_array |
+| test.cpp:3:36:3:45 | new[] | test.cpp:19:27:19:44 | call to allocate_int_array | provenance |  |
+| test.cpp:3:36:3:45 | new[] | test.cpp:23:12:23:29 | call to allocate_int_array | provenance |  |
+| test.cpp:3:36:3:45 | new[] | test.cpp:27:20:27:37 | call to allocate_int_array | provenance |  |
+| test.cpp:11:29:11:41 | call to unique_ptr | test.cpp:12:27:12:28 | v2 | provenance |  |
+| test.cpp:12:27:12:28 | v2 | test.cpp:12:30:12:36 | call to release | provenance |  |
+| test.cpp:27:20:27:37 | call to allocate_int_array | test.cpp:32:12:32:20 | int_array | provenance |  |
 nodes
 | test.cpp:3:36:3:45 | new[] | semmle.label | new[] |
 | test.cpp:11:29:11:41 | call to unique_ptr | semmle.label | call to unique_ptr |

--- a/cpp/autosar/test/rules/A5-0-4/PointerArithmeticUsedWithPointersToNonFinalClasses.expected
+++ b/cpp/autosar/test/rules/A5-0-4/PointerArithmeticUsedWithPointersToNonFinalClasses.expected
@@ -1,15 +1,15 @@
 edges
-| test.cpp:10:18:10:20 | foo | test.cpp:11:23:11:25 | foo |
-| test.cpp:10:18:10:20 | foo | test.cpp:11:50:11:52 | foo |
-| test.cpp:22:18:22:20 | foo | test.cpp:24:18:24:20 | foo |
-| test.cpp:35:11:35:17 | new | test.cpp:38:6:38:7 | l1 |
-| test.cpp:35:11:35:17 | new | test.cpp:39:6:39:7 | l1 |
-| test.cpp:37:11:37:13 | & ... | test.cpp:40:6:40:7 | l3 |
-| test.cpp:37:11:37:13 | & ... | test.cpp:41:6:41:7 | l3 |
-| test.cpp:38:6:38:7 | l1 | test.cpp:10:18:10:20 | foo |
-| test.cpp:39:6:39:7 | l1 | test.cpp:22:18:22:20 | foo |
-| test.cpp:40:6:40:7 | l3 | test.cpp:10:18:10:20 | foo |
-| test.cpp:41:6:41:7 | l3 | test.cpp:22:18:22:20 | foo |
+| test.cpp:10:18:10:20 | foo | test.cpp:11:23:11:25 | foo | provenance |  |
+| test.cpp:10:18:10:20 | foo | test.cpp:11:50:11:52 | foo | provenance |  |
+| test.cpp:22:18:22:20 | foo | test.cpp:24:18:24:20 | foo | provenance |  |
+| test.cpp:35:11:35:17 | new | test.cpp:38:6:38:7 | l1 | provenance |  |
+| test.cpp:35:11:35:17 | new | test.cpp:39:6:39:7 | l1 | provenance |  |
+| test.cpp:37:11:37:13 | & ... | test.cpp:40:6:40:7 | l3 | provenance |  |
+| test.cpp:37:11:37:13 | & ... | test.cpp:41:6:41:7 | l3 | provenance |  |
+| test.cpp:38:6:38:7 | l1 | test.cpp:10:18:10:20 | foo | provenance |  |
+| test.cpp:39:6:39:7 | l1 | test.cpp:22:18:22:20 | foo | provenance |  |
+| test.cpp:40:6:40:7 | l3 | test.cpp:10:18:10:20 | foo | provenance |  |
+| test.cpp:41:6:41:7 | l3 | test.cpp:22:18:22:20 | foo | provenance |  |
 nodes
 | test.cpp:10:18:10:20 | foo | semmle.label | foo |
 | test.cpp:11:23:11:25 | foo | semmle.label | foo |

--- a/cpp/autosar/test/rules/A5-1-7/LambdaPassedToTypeid.expected
+++ b/cpp/autosar/test/rules/A5-1-7/LambdaPassedToTypeid.expected
@@ -1,6 +1,6 @@
 edges
-| test.cpp:5:13:5:30 | [...](...){...} | test.cpp:8:38:8:39 | l1 |
-| test.cpp:6:13:6:30 | [...](...){...} | test.cpp:9:38:9:39 | l2 |
+| test.cpp:5:13:5:30 | [...](...){...} | test.cpp:8:38:8:39 | l1 | provenance |  |
+| test.cpp:6:13:6:30 | [...](...){...} | test.cpp:9:38:9:39 | l2 | provenance |  |
 nodes
 | test.cpp:5:13:5:30 | [...](...){...} | semmle.label | [...](...){...} |
 | test.cpp:6:13:6:30 | [...](...){...} | semmle.label | [...](...){...} |

--- a/cpp/cert/test/rules/CTR56-CPP/DoNotUsePointerArithmeticOnPolymorphicObjects.expected
+++ b/cpp/cert/test/rules/CTR56-CPP/DoNotUsePointerArithmeticOnPolymorphicObjects.expected
@@ -1,15 +1,15 @@
 edges
-| test.cpp:15:19:15:21 | foo | test.cpp:16:24:16:26 | foo |
-| test.cpp:15:19:15:21 | foo | test.cpp:16:51:16:53 | foo |
-| test.cpp:27:19:27:21 | foo | test.cpp:29:18:29:20 | foo |
-| test.cpp:40:12:40:19 | new | test.cpp:43:6:43:7 | l1 |
-| test.cpp:40:12:40:19 | new | test.cpp:44:6:44:7 | l1 |
-| test.cpp:42:12:42:14 | & ... | test.cpp:45:6:45:7 | l3 |
-| test.cpp:42:12:42:14 | & ... | test.cpp:46:6:46:7 | l3 |
-| test.cpp:43:6:43:7 | l1 | test.cpp:15:19:15:21 | foo |
-| test.cpp:44:6:44:7 | l1 | test.cpp:27:19:27:21 | foo |
-| test.cpp:45:6:45:7 | l3 | test.cpp:15:19:15:21 | foo |
-| test.cpp:46:6:46:7 | l3 | test.cpp:27:19:27:21 | foo |
+| test.cpp:15:19:15:21 | foo | test.cpp:16:24:16:26 | foo | provenance |  |
+| test.cpp:15:19:15:21 | foo | test.cpp:16:51:16:53 | foo | provenance |  |
+| test.cpp:27:19:27:21 | foo | test.cpp:29:18:29:20 | foo | provenance |  |
+| test.cpp:40:12:40:19 | new | test.cpp:43:6:43:7 | l1 | provenance |  |
+| test.cpp:40:12:40:19 | new | test.cpp:44:6:44:7 | l1 | provenance |  |
+| test.cpp:42:12:42:14 | & ... | test.cpp:45:6:45:7 | l3 | provenance |  |
+| test.cpp:42:12:42:14 | & ... | test.cpp:46:6:46:7 | l3 | provenance |  |
+| test.cpp:43:6:43:7 | l1 | test.cpp:15:19:15:21 | foo | provenance |  |
+| test.cpp:44:6:44:7 | l1 | test.cpp:27:19:27:21 | foo | provenance |  |
+| test.cpp:45:6:45:7 | l3 | test.cpp:15:19:15:21 | foo | provenance |  |
+| test.cpp:46:6:46:7 | l3 | test.cpp:27:19:27:21 | foo | provenance |  |
 nodes
 | test.cpp:15:19:15:21 | foo | semmle.label | foo |
 | test.cpp:16:24:16:26 | foo | semmle.label | foo |

--- a/cpp/cert/test/rules/EXP51-CPP/DoNotDeleteAnArrayThroughAPointerOfTheIncorrectType.expected
+++ b/cpp/cert/test/rules/EXP51-CPP/DoNotDeleteAnArrayThroughAPointerOfTheIncorrectType.expected
@@ -1,6 +1,6 @@
 edges
-| test.cpp:6:19:6:37 | new[] | test.cpp:9:12:9:13 | l1 |
-| test.cpp:7:22:7:40 | new[] | test.cpp:10:12:10:13 | l2 |
+| test.cpp:6:19:6:37 | new[] | test.cpp:9:12:9:13 | l1 | provenance |  |
+| test.cpp:7:22:7:40 | new[] | test.cpp:10:12:10:13 | l2 | provenance |  |
 nodes
 | test.cpp:6:19:6:37 | new[] | semmle.label | new[] |
 | test.cpp:7:22:7:40 | new[] | semmle.label | new[] |

--- a/cpp/cert/test/rules/MEM53-CPP/MissingConstructorCallForManuallyManagedObject.expected
+++ b/cpp/cert/test/rules/MEM53-CPP/MissingConstructorCallForManuallyManagedObject.expected
@@ -1,5 +1,5 @@
 edges
-| test.cpp:65:21:65:34 | call to operator new | test.cpp:67:26:67:32 | call to realloc |
+| test.cpp:65:21:65:34 | call to operator new | test.cpp:67:26:67:32 | call to realloc | provenance |  |
 nodes
 | test.cpp:16:26:16:31 | call to malloc | semmle.label | call to malloc |
 | test.cpp:17:38:17:43 | call to malloc | semmle.label | call to malloc |

--- a/cpp/cert/test/rules/MEM53-CPP/MissingDestructorCallForManuallyManagedObject.expected
+++ b/cpp/cert/test/rules/MEM53-CPP/MissingDestructorCallForManuallyManagedObject.expected
@@ -1,8 +1,8 @@
 edges
-| test.cpp:16:26:16:31 | call to malloc | test.cpp:22:8:22:9 | a1 |
-| test.cpp:17:38:17:43 | call to malloc | test.cpp:23:8:23:9 | a2 |
-| test.cpp:18:26:18:39 | call to operator new | test.cpp:26:21:26:22 | a3 |
-| test.cpp:20:29:20:42 | call to operator new | test.cpp:27:21:27:22 | a4 |
+| test.cpp:16:26:16:31 | call to malloc | test.cpp:22:8:22:9 | a1 | provenance |  |
+| test.cpp:17:38:17:43 | call to malloc | test.cpp:23:8:23:9 | a2 | provenance |  |
+| test.cpp:18:26:18:39 | call to operator new | test.cpp:26:21:26:22 | a3 | provenance |  |
+| test.cpp:20:29:20:42 | call to operator new | test.cpp:27:21:27:22 | a4 | provenance |  |
 nodes
 | test.cpp:16:26:16:31 | call to malloc | semmle.label | call to malloc |
 | test.cpp:17:38:17:43 | call to malloc | semmle.label | call to malloc |

--- a/cpp/common/test/rules/accessofundefinedmemberthroughnullpointer/AccessOfUndefinedMemberThroughNullPointer.expected
+++ b/cpp/common/test/rules/accessofundefinedmemberthroughnullpointer/AccessOfUndefinedMemberThroughNullPointer.expected
@@ -2,8 +2,8 @@ problems
 | test.cpp:10:3:10:13 | call to expression | test.cpp:8:22:8:28 | 0 | test.cpp:10:9:10:10 | l2 | A null pointer-to-member value from $@ is passed as the second operand to a pointer-to-member expression. | test.cpp:8:22:8:28 | test.cpp:8:22:8:28 | initialization |
 | test.cpp:11:8:11:9 | l3 | test.cpp:9:17:9:23 | 0 | test.cpp:11:8:11:9 | l3 | A null pointer-to-member value from $@ is passed as the second operand to a pointer-to-member expression. | test.cpp:9:17:9:23 | test.cpp:9:17:9:23 | initialization |
 edges
-| test.cpp:8:22:8:28 | 0 | test.cpp:10:9:10:10 | l2 |
-| test.cpp:9:17:9:23 | 0 | test.cpp:11:8:11:9 | l3 |
+| test.cpp:8:22:8:28 | 0 | test.cpp:10:9:10:10 | l2 | provenance |  |
+| test.cpp:9:17:9:23 | 0 | test.cpp:11:8:11:9 | l3 | provenance |  |
 nodes
 | test.cpp:8:22:8:28 | 0 | semmle.label | 0 |
 | test.cpp:9:17:9:23 | 0 | semmle.label | 0 |

--- a/cpp/common/test/rules/donotsubtractpointersaddressingdifferentarrays/DoNotSubtractPointersAddressingDifferentArrays.expected
+++ b/cpp/common/test/rules/donotsubtractpointersaddressingdifferentarrays/DoNotSubtractPointersAddressingDifferentArrays.expected
@@ -4,14 +4,14 @@ problems
 | test.cpp:13:10:13:11 | p4 | test.cpp:5:14:5:15 | l2 | test.cpp:13:10:13:11 | p4 | Subtraction between left operand pointing to array $@ and other operand pointing to array $@. | test.cpp:3:7:3:8 | l2 | l2 | test.cpp:2:7:2:8 | l1 | l1 |
 | test.cpp:13:15:13:16 | l1 | test.cpp:13:15:13:16 | l1 | test.cpp:13:15:13:16 | l1 | Subtraction between right operand pointing to array $@ and other operand pointing to array $@. | test.cpp:2:7:2:8 | l1 | l1 | test.cpp:3:7:3:8 | l2 | l2 |
 edges
-| test.cpp:4:14:4:15 | l1 | test.cpp:4:14:4:18 | access to array |
-| test.cpp:4:14:4:18 | access to array | test.cpp:10:10:10:11 | p1 |
-| test.cpp:4:14:4:18 | access to array | test.cpp:12:10:12:11 | p1 |
-| test.cpp:5:14:5:15 | l2 | test.cpp:5:14:5:19 | access to array |
-| test.cpp:5:14:5:19 | access to array | test.cpp:11:10:11:11 | p2 |
-| test.cpp:5:14:5:19 | access to array | test.cpp:12:15:12:16 | p2 |
-| test.cpp:5:14:5:19 | access to array | test.cpp:13:10:13:11 | p4 |
-| test.cpp:5:14:5:19 | access to array | test.cpp:14:10:14:11 | p4 |
+| test.cpp:4:14:4:15 | l1 | test.cpp:4:14:4:18 | access to array | provenance |  |
+| test.cpp:4:14:4:18 | access to array | test.cpp:10:10:10:11 | p1 | provenance |  |
+| test.cpp:4:14:4:18 | access to array | test.cpp:12:10:12:11 | p1 | provenance |  |
+| test.cpp:5:14:5:15 | l2 | test.cpp:5:14:5:19 | access to array | provenance |  |
+| test.cpp:5:14:5:19 | access to array | test.cpp:11:10:11:11 | p2 | provenance |  |
+| test.cpp:5:14:5:19 | access to array | test.cpp:12:15:12:16 | p2 | provenance |  |
+| test.cpp:5:14:5:19 | access to array | test.cpp:13:10:13:11 | p4 | provenance |  |
+| test.cpp:5:14:5:19 | access to array | test.cpp:14:10:14:11 | p4 | provenance |  |
 nodes
 | test.cpp:4:14:4:15 | l1 | semmle.label | l1 |
 | test.cpp:4:14:4:18 | access to array | semmle.label | access to array |

--- a/cpp/common/test/rules/donotuserelationaloperatorswithdifferingarrays/DoNotUseRelationalOperatorsWithDifferingArrays.expected
+++ b/cpp/common/test/rules/donotuserelationaloperatorswithdifferingarrays/DoNotUseRelationalOperatorsWithDifferingArrays.expected
@@ -10,19 +10,19 @@ problems
 | test.cpp:25:7:25:14 | ... >= ... | test.cpp:7:14:7:15 | l1 | test.cpp:25:7:25:8 | p1 | Compare operation >= comparing left operand pointing to array $@ and other operand pointing to array $@. | test.cpp:2:7:2:8 | l1 | l1 | test.cpp:4:7:4:8 | l3 | l3 |
 | test.cpp:25:7:25:14 | ... >= ... | test.cpp:25:13:25:14 | l3 | test.cpp:25:13:25:14 | l3 | Compare operation >= comparing right operand pointing to array $@ and other operand pointing to array $@. | test.cpp:4:7:4:8 | l3 | l3 | test.cpp:2:7:2:8 | l1 | l1 |
 edges
-| test.cpp:6:13:6:14 | l1 | test.cpp:13:12:13:13 | p0 |
-| test.cpp:7:14:7:15 | l1 | test.cpp:7:14:7:18 | access to array |
-| test.cpp:7:14:7:18 | access to array | test.cpp:11:7:11:8 | p1 |
-| test.cpp:7:14:7:18 | access to array | test.cpp:13:7:13:8 | p1 |
-| test.cpp:7:14:7:18 | access to array | test.cpp:15:13:15:14 | p1 |
-| test.cpp:7:14:7:18 | access to array | test.cpp:17:7:17:8 | p1 |
-| test.cpp:7:14:7:18 | access to array | test.cpp:23:13:23:14 | p1 |
-| test.cpp:7:14:7:18 | access to array | test.cpp:25:7:25:8 | p1 |
-| test.cpp:8:14:8:15 | l1 | test.cpp:8:14:8:18 | access to array |
-| test.cpp:8:14:8:18 | access to array | test.cpp:11:12:11:13 | p2 |
-| test.cpp:8:14:8:18 | access to array | test.cpp:21:7:21:8 | p2 |
-| test.cpp:9:14:9:15 | l2 | test.cpp:9:14:9:18 | access to array |
-| test.cpp:9:14:9:18 | access to array | test.cpp:21:12:21:13 | p3 |
+| test.cpp:6:13:6:14 | l1 | test.cpp:13:12:13:13 | p0 | provenance |  |
+| test.cpp:7:14:7:15 | l1 | test.cpp:7:14:7:18 | access to array | provenance |  |
+| test.cpp:7:14:7:18 | access to array | test.cpp:11:7:11:8 | p1 | provenance |  |
+| test.cpp:7:14:7:18 | access to array | test.cpp:13:7:13:8 | p1 | provenance |  |
+| test.cpp:7:14:7:18 | access to array | test.cpp:15:13:15:14 | p1 | provenance |  |
+| test.cpp:7:14:7:18 | access to array | test.cpp:17:7:17:8 | p1 | provenance |  |
+| test.cpp:7:14:7:18 | access to array | test.cpp:23:13:23:14 | p1 | provenance |  |
+| test.cpp:7:14:7:18 | access to array | test.cpp:25:7:25:8 | p1 | provenance |  |
+| test.cpp:8:14:8:15 | l1 | test.cpp:8:14:8:18 | access to array | provenance |  |
+| test.cpp:8:14:8:18 | access to array | test.cpp:11:12:11:13 | p2 | provenance |  |
+| test.cpp:8:14:8:18 | access to array | test.cpp:21:7:21:8 | p2 | provenance |  |
+| test.cpp:9:14:9:15 | l2 | test.cpp:9:14:9:18 | access to array | provenance |  |
+| test.cpp:9:14:9:18 | access to array | test.cpp:21:12:21:13 | p3 | provenance |  |
 nodes
 | test.cpp:6:13:6:14 | l1 | semmle.label | l1 |
 | test.cpp:7:14:7:15 | l1 | semmle.label | l1 |

--- a/cpp/common/test/rules/ownedpointervaluestoredinunrelatedsmartpointer/OwnedPointerValueStoredInUnrelatedSmartPointer.expected
+++ b/cpp/common/test/rules/ownedpointervaluestoredinunrelatedsmartpointer/OwnedPointerValueStoredInUnrelatedSmartPointer.expected
@@ -6,21 +6,21 @@ problems
 | test.cpp:12:28:12:29 | v2 | test.cpp:10:8:10:17 | new | test.cpp:12:28:12:29 | v2 | Raw pointer flows to initialize multiple unrelated smart pointers. |
 | test.cpp:17:27:17:28 | v1 | test.cpp:16:13:16:22 | new | test.cpp:17:27:17:28 | v1 | Raw pointer flows to initialize multiple unrelated smart pointers. |
 edges
-| test.cpp:3:14:3:15 | v1 | test.cpp:5:27:5:28 | v1 |
-| test.cpp:3:14:3:15 | v1 | test.cpp:5:27:5:28 | v1 |
-| test.cpp:3:14:3:15 | v1 | test.cpp:7:28:7:29 | v2 |
-| test.cpp:4:13:4:14 | v1 | test.cpp:7:28:7:29 | v2 |
-| test.cpp:5:27:5:28 | v1 | test.cpp:5:27:5:29 | call to shared_ptr |
-| test.cpp:5:27:5:29 | call to shared_ptr | test.cpp:6:28:6:29 | p1 |
-| test.cpp:5:27:5:29 | call to shared_ptr | test.cpp:6:28:6:29 | p1 |
-| test.cpp:6:28:6:29 | p1 | test.cpp:6:31:6:33 | call to get |
-| test.cpp:6:28:6:29 | p1 | test.cpp:6:31:6:33 | call to get |
-| test.cpp:8:8:8:14 | 0 | test.cpp:9:28:9:29 | v2 |
-| test.cpp:10:8:10:17 | new | test.cpp:11:28:11:29 | v2 |
-| test.cpp:10:8:10:17 | new | test.cpp:12:28:12:29 | v2 |
-| test.cpp:16:13:16:22 | new | test.cpp:17:27:17:28 | v1 |
-| test.cpp:16:13:16:22 | new | test.cpp:19:6:19:7 | v1 |
-| test.cpp:19:6:19:7 | v1 | test.cpp:3:14:3:15 | v1 |
+| test.cpp:3:14:3:15 | v1 | test.cpp:5:27:5:28 | v1 | provenance |  |
+| test.cpp:3:14:3:15 | v1 | test.cpp:5:27:5:28 | v1 | provenance |  |
+| test.cpp:3:14:3:15 | v1 | test.cpp:7:28:7:29 | v2 | provenance |  |
+| test.cpp:4:13:4:14 | v1 | test.cpp:7:28:7:29 | v2 | provenance |  |
+| test.cpp:5:27:5:28 | v1 | test.cpp:5:27:5:29 | call to shared_ptr | provenance |  |
+| test.cpp:5:27:5:29 | call to shared_ptr | test.cpp:6:28:6:29 | p1 | provenance |  |
+| test.cpp:5:27:5:29 | call to shared_ptr | test.cpp:6:28:6:29 | p1 | provenance |  |
+| test.cpp:6:28:6:29 | p1 | test.cpp:6:31:6:33 | call to get | provenance |  |
+| test.cpp:6:28:6:29 | p1 | test.cpp:6:31:6:33 | call to get | provenance |  |
+| test.cpp:8:8:8:14 | 0 | test.cpp:9:28:9:29 | v2 | provenance |  |
+| test.cpp:10:8:10:17 | new | test.cpp:11:28:11:29 | v2 | provenance |  |
+| test.cpp:10:8:10:17 | new | test.cpp:12:28:12:29 | v2 | provenance |  |
+| test.cpp:16:13:16:22 | new | test.cpp:17:27:17:28 | v1 | provenance |  |
+| test.cpp:16:13:16:22 | new | test.cpp:19:6:19:7 | v1 | provenance |  |
+| test.cpp:19:6:19:7 | v1 | test.cpp:3:14:3:15 | v1 | provenance |  |
 nodes
 | test.cpp:3:14:3:15 | v1 | semmle.label | v1 |
 | test.cpp:4:13:4:14 | v1 | semmle.label | v1 |

--- a/cpp/common/test/rules/throwingoperatornewreturnsnull/ThrowingOperatorNewReturnsNull.expected
+++ b/cpp/common/test/rules/throwingoperatornewreturnsnull/ThrowingOperatorNewReturnsNull.expected
@@ -3,8 +3,8 @@ problems
 | test.cpp:12:5:12:19 | return ... | test.cpp:12:12:12:18 | 0 | test.cpp:12:12:12:18 | 0 | operator new(size_t) may return null instead of throwing a std::bad_alloc exception. |
 | test.cpp:14:5:14:33 | return ... | test.cpp:4:10:4:23 | call to operator new | test.cpp:14:12:14:26 | call to can_return_null | operator new(size_t) may return null instead of throwing a std::bad_alloc exception. |
 edges
-| test.cpp:4:10:4:23 | call to operator new | test.cpp:14:12:14:26 | call to can_return_null |
-| test.cpp:8:23:8:23 | 0 | test.cpp:10:12:10:24 | localVariable |
+| test.cpp:4:10:4:23 | call to operator new | test.cpp:14:12:14:26 | call to can_return_null | provenance |  |
+| test.cpp:8:23:8:23 | 0 | test.cpp:10:12:10:24 | localVariable | provenance |  |
 nodes
 | test.cpp:4:10:4:23 | call to operator new | semmle.label | call to operator new |
 | test.cpp:8:23:8:23 | 0 | semmle.label | 0 |


### PR DESCRIPTION
## Description

@aschackmull is adding a column to the `edges` relation in https://github.com/github/codeql/pull/15549. This PR accepts the changes in test.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)