### PR TITLE
A18-0-1: improve query logic

### DIFF
--- a/change_notes/2024-02-12-improve-a18-0-1.md
+++ b/change_notes/2024-02-12-improve-a18-0-1.md
@@ -1,0 +1,2 @@
+`A18-0-1` - `CLibraryFacilitiesNotAccessedThroughCPPLibraryHeaders.ql`:
+    - Improve query logic to only match on exact standard library names (exclude local files with same names. Now excludes sys/header.h type headers as well from the results as those are not C standard libraries).

--- a/cpp/autosar/src/rules/A18-0-1/CLibraryFacilitiesNotAccessedThroughCPPLibraryHeaders.ql
+++ b/cpp/autosar/src/rules/A18-0-1/CLibraryFacilitiesNotAccessedThroughCPPLibraryHeaders.ql
@@ -28,12 +28,13 @@ where
    *    not use any of 'signal.h's facilities, for example.
    */
 
-  filename = i.getIncludedFile().getBaseName() and
+  filename = i.getIncludeText().substring(1, i.getIncludeText().length() - 1) and
   filename in [
       "assert.h", "ctype.h", "errno.h", "fenv.h", "float.h", "inttypes.h", "limits.h", "locale.h",
       "math.h", "setjmp.h", "signal.h", "stdarg.h", "stddef.h", "stdint.h", "stdio.h", "stdlib.h",
       "string.h", "time.h", "uchar.h", "wchar.h", "wctype.h"
-    ]
+    ] and
+  not exists(i.getIncludedFile().getRelativePath())
 select i,
   "C library \"" + filename + "\" is included instead of the corresponding C++ library <c" +
     filename.prefix(filename.length() - 2) + ">."

--- a/cpp/autosar/test/rules/A18-0-1/lib/assert.h
+++ b/cpp/autosar/test/rules/A18-0-1/lib/assert.h
@@ -1,0 +1,4 @@
+#ifndef LIB_EXAMPLE_H_
+#define LIB_EXAMPLE_H_
+
+#endif

--- a/cpp/autosar/test/rules/A18-0-1/test.cpp
+++ b/cpp/autosar/test/rules/A18-0-1/test.cpp
@@ -40,3 +40,5 @@
 #include <cuchar>    // COMPLIANT
 #include <cwchar>    // COMPLIANT
 #include <cwctype>   // COMPLIANT
+
+#include "lib/assert.h" // COMPLIANT


### PR DESCRIPTION
## Description

closes #7 

implements the exact logic suggested in the issue. cannot think of any other heuristics to improve the query but think that these improvements should cover any additional cases that can be thought of at this time

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - A18-0-1

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)