### PR TITLE
A2-10-4: exclude partially specialized template variables

### DIFF
--- a/change_notes/2024-02-12-exclusion-A2-10-4.md
+++ b/change_notes/2024-02-12-exclusion-A2-10-4.md
@@ -1,0 +1,2 @@
+`A2-10-4` - `IdentifierNameOfStaticNonMemberObjectReusedInNamespace.ql`:
+    - Fix FP reported in #385. Addresses incorrect detection of partially specialized template variables as conflicting reuses.

--- a/change_notes/2024-02-12-exclusion-A2-10-4.md
+++ b/change_notes/2024-02-12-exclusion-A2-10-4.md
@@ -1,2 +1,2 @@
-`A2-10-4` - `IdentifierNameOfStaticNonMemberObjectReusedInNamespace.ql`:
+- `A2-10-4` - `IdentifierNameOfStaticNonMemberObjectReusedInNamespace.ql`:
     - Fix FP reported in #385. Addresses incorrect detection of partially specialized template variables as conflicting reuses.

--- a/cpp/autosar/src/rules/A2-10-4/IdentifierNameOfStaticNonMemberObjectReusedInNamespace.ql
+++ b/cpp/autosar/src/rules/A2-10-4/IdentifierNameOfStaticNonMemberObjectReusedInNamespace.ql
@@ -20,7 +20,9 @@ class CandidateVariable extends Variable {
   CandidateVariable() {
     hasDefinition() and
     isStatic() and
-    not this instanceof MemberVariable
+    not this instanceof MemberVariable and
+    //exclude partially specialized template variables
+    not exists(TemplateVariable v | this = v.getAnInstantiation())
   }
 }
 

--- a/cpp/autosar/src/rules/M3-9-1/TypesNotIdenticalInReturnDeclarations.ql
+++ b/cpp/autosar/src/rules/M3-9-1/TypesNotIdenticalInReturnDeclarations.ql
@@ -15,8 +15,6 @@
 
 import cpp
 import codingstandards.cpp.autosar
-import cpp
-import codingstandards.cpp.autosar
 
 from FunctionDeclarationEntry f1, FunctionDeclarationEntry f2
 where

--- a/cpp/autosar/test/rules/A2-10-4/test1a.cpp
+++ b/cpp/autosar/test/rules/A2-10-4/test1a.cpp
@@ -13,4 +13,10 @@ namespace ns3 {
 static void f1() {}
 
 void f2() {}
+
+// Variable templates can cause false positives
+template <int x> static int number_one = 0; // COMPLIANT
+
+template <> static int number_one<1> = 1; // COMPLIANT
+template <> static int number_one<2> = 2; // COMPLIANT
 } // namespace ns3


### PR DESCRIPTION
## Description

fixes #385 

cannot replicate for M3-9-1 however

the implementations of that rule uses declaration entries, so those are actually correctly not conflicting between a template variable and within any of its specializations.

the tests used to try to replicate for that one:
test_types_not_identical_in_object_declarations.cpp -
```
// Variable templates can cause false positives
template <int x> static int number_one = 0; // COMPLIANT

template <> static int number_one<1> = 1;     // COMPLIANT
template <> static float number_one<2> = 2.0; // COMPLIANT
```

test_types_not_identical_in_return_declarations.cpp
```
// Variable templates can cause false positives
template <int x> static int number_one = 0; // COMPLIANT

template <> static int number_one<0> = 0;     // COMPLIANT
template <> static float number_one<2> = 1.0; // COMPLIANT
```

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - A2-10-4

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)