### PR TITLE
Fix FP reported in 424

### DIFF
--- a/change_notes/2024-02-13-fix-fp-a15-4-4.md
+++ b/change_notes/2024-02-13-fix-fp-a15-4-4.md
@@ -1,0 +1,2 @@
+-`A15-4-4` - `MissingNoExcept.ql`:
+    - Fix FP reported in #424. Exclude functions calling `std::string::reserve` or `std::string::append` that may throw even if their signatures don't specify it.

--- a/cpp/autosar/test/rules/A15-4-4/test.cpp
+++ b/cpp/autosar/test/rules/A15-4-4/test.cpp
@@ -44,3 +44,14 @@ void test_swap_wrapper() noexcept {
   int b = 1;
   swap_wrapper(&a, &b);
 }
+
+#include <string>
+#include <stdexcept>
+
+std::string test_fp_reported_in_424(const std::string &s1, const std::string &s2) {
+  std::string s3;
+  s3.reserve(s1.size() + s2.size());
+  s3.append(s1.c_str(), s1.size());
+  s3.append(s2.c_str(), s2.size());
+  return s3;
+}

--- a/cpp/autosar/test/rules/A15-4-4/test.cpp
+++ b/cpp/autosar/test/rules/A15-4-4/test.cpp
@@ -45,10 +45,12 @@ void test_swap_wrapper() noexcept {
   swap_wrapper(&a, &b);
 }
 
-#include <string>
 #include <stdexcept>
+#include <string>
 
-std::string test_fp_reported_in_424(const std::string &s1, const std::string &s2) {
+std::string test_fp_reported_in_424(
+    const std::string &s1,
+    const std::string &s2) { // COMPLIANT - `reserve` and `append` may throw.
   std::string s3;
   s3.reserve(s1.size() + s2.size());
   s3.append(s1.c_str(), s1.size());

--- a/cpp/common/src/codingstandards/cpp/exceptions/ExceptionFlow.qll
+++ b/cpp/common/src/codingstandards/cpp/exceptions/ExceptionFlow.qll
@@ -5,6 +5,7 @@
 import cpp
 import codingstandards.cpp.standardlibrary.Exceptions
 import codingstandards.cpp.exceptions.ExceptionSpecifications
+import codingstandards.cpp.exceptions.ExceptionFlowCustomizations
 import ThirdPartyExceptions
 
 /*
@@ -269,72 +270,6 @@ ExceptionType getAFunctionThrownType(Function f, ThrowingExpr throwingExpr) {
     isCaught(cb, result) and
     cb = candidates(throwingExpr, _, _)
   )
-}
-
-/** A `ThrowingExpr` which is the origin of a exceptions in the program. */
-abstract class OriginThrowingExpr extends ThrowingExpr { }
-
-/** An expression which directly throws. */
-class DirectThrowExprThrowingExpr extends DirectThrowExpr, OriginThrowingExpr {
-  override ExceptionType getAnExceptionType() { result = getExceptionType() }
-}
-
-/** An `typeid` expression which may throw `std::bad_typeid`. */
-class TypeIdThrowingExpr extends TypeidOperator, OriginThrowingExpr {
-  override ExceptionType getAnExceptionType() { result instanceof StdBadTypeId }
-}
-
-/** An `new[]` expression which may throw `std::bad_array_new_length`. */
-class NewThrowingExpr extends NewArrayExpr, OriginThrowingExpr {
-  NewThrowingExpr() {
-    // If the extent is known to be below 0 at runtime
-    getExtent().getValue().toInt() < 0
-    or
-    // initializer has more elements than the array size
-    getExtent().getValue().toInt() < getInitializer().(ArrayAggregateLiteral).getArraySize()
-  }
-
-  override ExceptionType getAnExceptionType() { result instanceof StdBadArrayNewLength }
-}
-
-/** A `ReThrowExpr` which throws a previously caught exception. */
-class ReThrowExprThrowingExpr extends ReThrowExpr, ThrowingExpr {
-  predicate rethrows(CatchBlock cb, ExceptionType et, ThrowingExpr te) {
-    // Find the nearest CatchBlock
-    cb = getNearestCatch(this.getEnclosingStmt()) and
-    // Find an `ExceptionType` which is caught by this catch block, and `ThrowingExpr` which throws that exception type
-    catches(cb, te, et)
-  }
-
-  override ExceptionType getAnExceptionType() { rethrows(_, result, _) }
-
-  CatchBlock getCatchBlock() { rethrows(result, _, _) }
-}
-
-/** An expression which calls a function which may throw an exception. */
-class FunctionCallThrowingExpr extends FunctionCall, ThrowingExpr {
-  override ExceptionType getAnExceptionType() {
-    exists(Function target |
-      target = getTarget() and
-      result = getAFunctionThrownType(target, _) and
-      // [expect.spec] states that throwing an exception type that is prohibited
-      // by the specification will result in the program terminating, unless
-      // a custom `unexpected_handler` is registered that throws an exception type
-      // which is compatible with the dynamic exception specification, or the
-      // dynamic exception specification lists `std::bad_exception`, in which case
-      // a `std::bad_exception` is thrown.
-      // As dynamic exception specifications and the `unexpected_handler` are both
-      // deprecated in C++14 and removed in C++17, we assume a default
-      // `std::unexpected` handler that calls `std::terminate` and therefore
-      // do not propagate such exceptions to the call sites for the function.
-      not (
-        hasDynamicExceptionSpecification(target) and
-        not result = getAHandledExceptionType(target.getAThrownType())
-        or
-        isNoExceptTrue(target)
-      )
-    )
-  }
 }
 
 module ExceptionPathGraph {

--- a/cpp/common/src/codingstandards/cpp/exceptions/ExceptionFlowCustomizations.qll
+++ b/cpp/common/src/codingstandards/cpp/exceptions/ExceptionFlowCustomizations.qll
@@ -1,0 +1,68 @@
+import cpp
+private import codingstandards.cpp.exceptions.ExceptionFlow
+
+/** A `ThrowingExpr` which is the origin of a exceptions in the program. */
+abstract class OriginThrowingExpr extends ThrowingExpr { }
+
+/** An expression which directly throws. */
+class DirectThrowExprThrowingExpr extends DirectThrowExpr, OriginThrowingExpr {
+  override ExceptionType getAnExceptionType() { result = getExceptionType() }
+}
+
+/** A `ReThrowExpr` which throws a previously caught exception. */
+class ReThrowExprThrowingExpr extends ReThrowExpr, ThrowingExpr {
+  predicate rethrows(CatchBlock cb, ExceptionType et, ThrowingExpr te) {
+    // Find the nearest CatchBlock
+    cb = getNearestCatch(this.getEnclosingStmt()) and
+    // Find an `ExceptionType` which is caught by this catch block, and `ThrowingExpr` which throws that exception type
+    catches(cb, te, et)
+  }
+
+  override ExceptionType getAnExceptionType() { rethrows(_, result, _) }
+
+  CatchBlock getCatchBlock() { rethrows(result, _, _) }
+}
+
+/** An expression which calls a function which may throw an exception. */
+class FunctionCallThrowingExpr extends FunctionCall, ThrowingExpr {
+  override ExceptionType getAnExceptionType() {
+    exists(Function target |
+      target = getTarget() and
+      result = getAFunctionThrownType(target, _) and
+      // [expect.spec] states that throwing an exception type that is prohibited
+      // by the specification will result in the program terminating, unless
+      // a custom `unexpected_handler` is registered that throws an exception type
+      // which is compatible with the dynamic exception specification, or the
+      // dynamic exception specification lists `std::bad_exception`, in which case
+      // a `std::bad_exception` is thrown.
+      // As dynamic exception specifications and the `unexpected_handler` are both
+      // deprecated in C++14 and removed in C++17, we assume a default
+      // `std::unexpected` handler that calls `std::terminate` and therefore
+      // do not propagate such exceptions to the call sites for the function.
+      not (
+        hasDynamicExceptionSpecification(target) and
+        not result = getAHandledExceptionType(target.getAThrownType())
+        or
+        isNoExceptTrue(target)
+      )
+    )
+  }
+}
+
+/** An `typeid` expression which may throw `std::bad_typeid`. */
+private class TypeIdThrowingExpr extends TypeidOperator, OriginThrowingExpr {
+  override ExceptionType getAnExceptionType() { result instanceof StdBadTypeId }
+}
+
+/** An `new[]` expression which may throw `std::bad_array_new_length`. */
+private class NewThrowingExpr extends NewArrayExpr, OriginThrowingExpr {
+  NewThrowingExpr() {
+    // If the extent is known to be below 0 at runtime
+    getExtent().getValue().toInt() < 0
+    or
+    // initializer has more elements than the array size
+    getExtent().getValue().toInt() < getInitializer().(ArrayAggregateLiteral).getArraySize()
+  }
+
+  override ExceptionType getAnExceptionType() { result instanceof StdBadArrayNewLength }
+}

--- a/cpp/common/src/ext/stdc++.model.yml
+++ b/cpp/common/src/ext/stdc++.model.yml
@@ -1,0 +1,7 @@
+extensions:
+  - addsTo:
+      pack: codeql/common-cpp-coding-standards
+      extensible: throwingFunctionModel
+    data:
+      - ["std", "basic_string", "append", "std", "out_of_range"] 
+      - ["std", "basic_string", "reserve", "std", "length_error"] 

--- a/cpp/common/src/qlpack.yml
+++ b/cpp/common/src/qlpack.yml
@@ -3,3 +3,5 @@ version: 2.22.0-dev
 license: MIT
 dependencies:
   codeql/cpp-all: 0.9.3
+dataExtensions:
+  - ext/*.model.yml

--- a/cpp/common/test/includes/standard-library/stdexcept.h
+++ b/cpp/common/test/includes/standard-library/stdexcept.h
@@ -28,5 +28,7 @@ public:
 template <typename T> [[noreturn]] void throw_with_nested(T &&t);
 template <typename E> void rethrow_if_nested(E const &e);
 
+class length_error : public logic_error{};
+class out_of_range: public logic_error{};
 } // namespace std
 #endif // _GHLIBCPP_STDEXCEPT

--- a/cpp/common/test/includes/standard-library/string
+++ b/cpp/common/test/includes/standard-library/string
@@ -166,6 +166,8 @@ public:
   int compare(const charT *s) const;
   int compare(size_type pos1, size_type n1, const charT *s) const;
   int compare(size_type pos1, size_type n1, const charT *s, size_type n2) const;
+
+  void reserve(size_type new_cap = 0);
 };
 
 template <class charT, class traits, class Allocator>


### PR DESCRIPTION
## Description

Resolves #424 

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)