### PR TITLE
Address FN reported in #400

### DIFF
--- a/change_notes/2024-02-13-fix-fn-M7-3-6.md
+++ b/change_notes/2024-02-13-fix-fn-M7-3-6.md
@@ -1,0 +1,2 @@
+- `M7-3-6` - `UsingDeclarationsUsedInHeaderFiles.ql`:
+  - Address FN reported in #400. Only using-declarations are exempted from class- and function-scope.

--- a/cpp/autosar/src/rules/M7-3-6/UsingDeclarationsUsedInHeaderFiles.ql
+++ b/cpp/autosar/src/rules/M7-3-6/UsingDeclarationsUsedInHeaderFiles.ql
@@ -28,5 +28,13 @@ predicate isInClassScope(UsingEntry u) { exists(Class c | u.getEnclosingElement(
 from UsingEntry u
 where
   not isExcluded(u, BannedSyntaxPackage::usingDeclarationsUsedInHeaderFilesQuery()) and
-  (isInHeaderFile(u) and not isInFunctionScope(u) and not isInClassScope(u))
+  isInHeaderFile(u) and
+  (
+    u instanceof UsingDeclarationEntry
+    implies
+    (
+      not isInFunctionScope(u) and
+      not isInClassScope(u)
+    )
+  )
 select u, "Using directive or declaration used in a header file " + u.getFile() + "."

--- a/cpp/autosar/test/rules/M7-3-6/UsingDeclarationsUsedInHeaderFiles.expected
+++ b/cpp/autosar/test/rules/M7-3-6/UsingDeclarationsUsedInHeaderFiles.expected
@@ -1,1 +1,2 @@
 | test.h:4:1:4:21 | using namespace std | Using directive or declaration used in a header file test.h. |
+| test.h:18:3:18:21 | using namespace std | Using directive or declaration used in a header file test.h. |

--- a/cpp/autosar/test/rules/M7-3-6/test.h
+++ b/cpp/autosar/test/rules/M7-3-6/test.h
@@ -7,11 +7,15 @@ namespace my_namespace {
 int MY_CONST = 0;
 };
 
-int f() {
+void f() {
 
   using my_namespace::MY_CONST; // COMPLIANT - function scope
 
   int x = MY_CONST;
 }
 
+void test_fn_reported_in_400() {
+  using namespace std; // NON_COMPLIANT - only using declarations are exempted
+                       // in function scope.
+}
 #endif


### PR DESCRIPTION
Only using-declaratons are exempt from class- and
function-scope use.

## Description

Resolves #400 

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - M7-3-6

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)