### PR TITLE
Fix FP reported in #388

### DIFF
--- a/change_notes/2024-02-14-fix-fp-m0-1-4.md
+++ b/change_notes/2024-02-14-fix-fp-m0-1-4.md
@@ -1,0 +1,4 @@
+- `M0-1-4` - `SingleUseMemberPODVariable.ql`:
+  - Address FP reported in #388. Include aggregrate initialization as a use of a member.
+  - Include indirect initialization of members. For example, casting a pointer to a buffer to a struct pointer.
+  - Reformat the alert message to adhere to the style-guide.

--- a/cpp/autosar/src/rules/M0-1-4/SingleUseMemberPODVariable.ql
+++ b/cpp/autosar/src/rules/M0-1-4/SingleUseMemberPODVariable.ql
@@ -24,5 +24,5 @@ where
   not isExcluded(v, DeadCodePackage::singleUseMemberPODVariableQuery()) and
   isSingleUseNonVolatilePODVariable(v)
 select v,
-  "Member POD variable '" + v.getName() + "' in '" + v.getDeclaringType().getName() + "' is only $@.",
-  getSingleUse(v), "used once"
+  "Member POD variable '" + v.getName() + "' in '" + v.getDeclaringType().getName() +
+    "' is only $@.", getSingleUse(v), "used once"

--- a/cpp/autosar/src/rules/M0-1-4/SingleUseMemberPODVariable.ql
+++ b/cpp/autosar/src/rules/M0-1-4/SingleUseMemberPODVariable.ql
@@ -24,5 +24,5 @@ where
   not isExcluded(v, DeadCodePackage::singleUseMemberPODVariableQuery()) and
   isSingleUseNonVolatilePODVariable(v)
 select v,
-  "Member POD variable " + v.getName() + " in " + v.getDeclaringType().getName() + " is only $@.",
+  "Member POD variable '" + v.getName() + "' in '" + v.getDeclaringType().getName() + "' is only $@.",
   getSingleUse(v), "used once"

--- a/cpp/autosar/src/rules/M0-1-4/SingleUsePODVariable.qll
+++ b/cpp/autosar/src/rules/M0-1-4/SingleUsePODVariable.qll
@@ -51,7 +51,6 @@ Expr getIndirectSubObjectAssignedValue(MemberVariable subobject) {
 /** Gets a "use" count according to rule M0-1-4. */
 int getUseCount(Variable v) {
   // We enforce that it's a POD type variable, so if it has an initializer it is explicit
-  //v.getFile().getBaseName() = "test_member.cpp" and
   result =
     count(getAUserInitializedValue(v)) +
       count(VariableAccess access | access = v.getAnAccess() and not access.isCompilerGenerated()) +

--- a/cpp/autosar/test/rules/M0-1-4/SingleUseMemberPODVariable.expected
+++ b/cpp/autosar/test/rules/M0-1-4/SingleUseMemberPODVariable.expected
@@ -1,9 +1,9 @@
-| test_global_or_namespace.cpp:16:7:16:7 | x | Member POD variable x in GA is only $@. | test_global_or_namespace.cpp:38:6:38:6 | x | used once |
-| test_global_or_namespace.cpp:54:7:54:7 | x | Member POD variable x in N1A is only $@. | test_global_or_namespace.cpp:76:6:76:6 | x | used once |
-| test_member.cpp:5:7:5:8 | m2 | Member POD variable m2 in A is only $@. | test_member.cpp:9:21:9:25 | constructor init of field m2 | used once |
-| test_member.cpp:6:7:6:8 | m3 | Member POD variable m3 in A is only $@. | test_member.cpp:10:23:10:24 | m3 | used once |
-| test_member.cpp:7:7:7:8 | m4 | Member POD variable m4 in A is only $@. | test_member.cpp:14:23:14:24 | m4 | used once |
-| test_member.cpp:18:9:18:11 | sm1 | Member POD variable sm1 in s1 is only $@. | test_member.cpp:23:6:23:8 | sm1 | used once |
-| test_member.cpp:36:7:36:8 | m1 | Member POD variable m1 in C is only $@. | test_member.cpp:39:21:39:22 | m1 | used once |
-| test_member.cpp:37:7:37:8 | m2 | Member POD variable m2 in C is only $@. | test_member.cpp:46:5:46:6 | m2 | used once |
-| test_member.cpp:55:5:55:6 | m3 | Member POD variable m3 in E<B> is only $@. | test_member.cpp:56:27:56:32 | constructor init of field m3 | used once |
+| test_global_or_namespace.cpp:16:7:16:7 | x | Member POD variable 'x' in 'GA' is only $@. | test_global_or_namespace.cpp:38:6:38:6 | x | used once |
+| test_global_or_namespace.cpp:54:7:54:7 | x | Member POD variable 'x' in 'N1A' is only $@. | test_global_or_namespace.cpp:76:6:76:6 | x | used once |
+| test_member.cpp:5:7:5:8 | m2 | Member POD variable 'm2' in 'A' is only $@. | test_member.cpp:9:21:9:25 | constructor init of field m2 | used once |
+| test_member.cpp:6:7:6:8 | m3 | Member POD variable 'm3' in 'A' is only $@. | test_member.cpp:10:23:10:24 | m3 | used once |
+| test_member.cpp:7:7:7:8 | m4 | Member POD variable 'm4' in 'A' is only $@. | test_member.cpp:14:23:14:24 | m4 | used once |
+| test_member.cpp:18:9:18:11 | sm1 | Member POD variable 'sm1' in 's1' is only $@. | test_member.cpp:23:6:23:8 | sm1 | used once |
+| test_member.cpp:36:7:36:8 | m1 | Member POD variable 'm1' in 'C' is only $@. | test_member.cpp:39:21:39:22 | m1 | used once |
+| test_member.cpp:37:7:37:8 | m2 | Member POD variable 'm2' in 'C' is only $@. | test_member.cpp:46:5:46:6 | m2 | used once |
+| test_member.cpp:55:5:55:6 | m3 | Member POD variable 'm3' in 'E<B>' is only $@. | test_member.cpp:56:27:56:32 | constructor init of field m3 | used once |

--- a/cpp/autosar/test/rules/M0-1-4/test_member.cpp
+++ b/cpp/autosar/test/rules/M0-1-4/test_member.cpp
@@ -93,4 +93,41 @@ void test_array_initialized_members() {
 
   l1[0].m1;
 }
+
+void test_indirect_assigned_members(void *opaque) {
+  struct s1 {
+    int m1; // COMPLIANT
+  };
+
+  struct s1 *p = (struct s1 *)opaque;
+  p->m1;
+
+  struct s2 {
+    int m1; // COMPLIANT
+  };
+
+  char buffer[sizeof(struct s2) + 8] = {0};
+  struct s2 *l2 = (struct s2 *)&buffer[8];
+  l2->m1;
+}
+
+void test_external_assigned_members(void (*fp)(unsigned char *)) {
+
+  struct s1 {
+    int m1; // COMPLIANT
+  };
+
+  struct s1 l1;
+  fp((unsigned char *)&l1);
+  l1.m1;
+
+  struct s2 {
+    int m1; // COMPLIANT
+  };
+
+  struct s2 (*copy_init)();
+  struct s2 l2 = copy_init();
+  l2.m1;
+}
+
 } // namespace test

--- a/cpp/autosar/test/rules/M0-1-4/test_member.cpp
+++ b/cpp/autosar/test/rules/M0-1-4/test_member.cpp
@@ -72,4 +72,25 @@ void test_e() { // Ensure that the template E is fully instantiated
   e2.getT();
 }
 
+void test_fp_reported_in_388() {
+  struct s1 {
+    int m1; // COMPLIANT
+  };
+
+  s1 l1 = {1}; // m1 is used here
+  l1.m1;
+}
+
+void test_array_initialized_members() {
+  struct s1 {
+    int m1; // COMPLIANT
+  };
+
+  struct s1 l1[] = {
+      {.m1 = 1},
+      {.m1 = 2},
+  };
+
+  l1[0].m1;
+}
 } // namespace test


### PR DESCRIPTION
## Description

Resolve #388 

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - M0-1-4

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)