### PR TITLE
Address FP reported in #10

### DIFF
--- a/change_notes/2024-02-22-fix-fp-a5-0-2-and-change-alert-m5-3-1.md
+++ b/change_notes/2024-02-22-fix-fp-a5-0-2-and-change-alert-m5-3-1.md
@@ -1,0 +1,4 @@
+- `A5-0-2` - `NonBooleanIterationCondition.ql`:
+  - Address FP reported in #10. Exclude conditions in uninstantiated templates.
+- `M5-3-1` - `EachOperandOfTheOperatorTheLogicalAndOrTheLogicalOperatorsShallHaveTypeBool.ql`:
+  - Adjust the alert message to comply with the style guide.

--- a/cpp/autosar/src/rules/M5-3-1/EachOperandOfTheOperatorTheLogicalAndOrTheLogicalOperatorsShallHaveTypeBool.ql
+++ b/cpp/autosar/src/rules/M5-3-1/EachOperandOfTheOperatorTheLogicalAndOrTheLogicalOperatorsShallHaveTypeBool.ql
@@ -29,4 +29,4 @@ where
     rt = t.getUnderlyingType().getUnspecifiedType() and rt.getBaseType() instanceof BoolType
   ) and
   not operand.isFromUninstantiatedTemplate(_)
-select operand, "bool operator called with a non-bool operand of type " + t.getName() + "."
+select operand, "Call to bool operator with a non-bool operand of type '" + t.getName() + "'."

--- a/cpp/autosar/test/rules/M5-3-1/EachOperandOfTheOperatorTheLogicalAndOrTheLogicalOperatorsShallHaveTypeBool.expected
+++ b/cpp/autosar/test/rules/M5-3-1/EachOperandOfTheOperatorTheLogicalAndOrTheLogicalOperatorsShallHaveTypeBool.expected
@@ -1,3 +1,3 @@
-| test.cpp:10:8:10:8 | 0 | bool operator called with a non-bool operand of type int. |
-| test.cpp:12:7:12:7 | 0 | bool operator called with a non-bool operand of type int. |
-| test.cpp:12:13:12:17 | ... + ... | bool operator called with a non-bool operand of type int. |
+| test.cpp:10:8:10:8 | 0 | Call to bool operator with a non-bool operand of type 'int'. |
+| test.cpp:12:7:12:7 | 0 | Call to bool operator with a non-bool operand of type 'int'. |
+| test.cpp:12:13:12:17 | ... + ... | Call to bool operator with a non-bool operand of type 'int'. |

--- a/cpp/common/src/codingstandards/cpp/rules/nonbooleaniterationstmt/NonBooleanIterationStmt.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/nonbooleaniterationstmt/NonBooleanIterationStmt.qll
@@ -18,6 +18,8 @@ query predicate problems(Loop loopStmt, string message) {
     not explicitConversionType instanceof BoolType and
     //exclude any generated conditions
     not condition.isCompilerGenerated() and
+    // exclude any conditions in uninstantiated templates, because their type will be unknown.
+    not condition.isFromUninstantiatedTemplate(_) and
     message = "Iteration condition has non boolean type " + explicitConversionType + "."
   )
 }

--- a/cpp/common/src/codingstandards/cpp/rules/nonbooleaniterationstmt/NonBooleanIterationStmt.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/nonbooleaniterationstmt/NonBooleanIterationStmt.qll
@@ -1,5 +1,5 @@
 /**
- * Provides a library which includes a `problems` predicate for reporting....
+ * Provides a library which includes a `problems` predicate for reporting non-boolean iteration conditions.
  */
 
 import cpp
@@ -16,7 +16,7 @@ query predicate problems(Loop loopStmt, string message) {
     condition = loopStmt.getCondition() and
     explicitConversionType = condition.getExplicitlyConverted().getType().getUnspecifiedType() and
     not explicitConversionType instanceof BoolType and
-    //exclude any generated conditions
+    // exclude any generated conditions
     not condition.isCompilerGenerated() and
     // exclude any conditions in uninstantiated templates, because their type will be unknown.
     not condition.isFromUninstantiatedTemplate(_) and

--- a/cpp/common/test/rules/nonbooleanifstmt/test.cpp
+++ b/cpp/common/test/rules/nonbooleanifstmt/test.cpp
@@ -46,3 +46,16 @@ void test_boolean_conditions() {
   if (a) { // COMPLIANT - a has an explicit operator bool()
   }
 }
+
+template <typename T> bool test_fp_reported_in_10a(T &p1) {
+  if (p1.length() > 10) { // COMPLIANT
+    return true;
+  }
+  return false;
+}
+
+#include <string>
+void test_fp_reported_in_10b() {
+  std::string s;
+  test_fp_reported_in_10a(s);
+}

--- a/cpp/common/test/rules/nonbooleaniterationstmt/test.cpp
+++ b/cpp/common/test/rules/nonbooleaniterationstmt/test.cpp
@@ -42,3 +42,16 @@ class ClassC {
     }
   }
 };
+
+#include <vector>
+template <typename T> void test_fp_reported_in_10a(std::vector<T> &p1) {
+  for (typename std::vector<T>::iterator it = p1.begin(); it != p1.end();
+       ++it) { // COMPLIANT
+    (*it)++;
+  }
+}
+
+void test_fp_reported_in_10b() {
+  std::vector<int> vl1;
+  test_fp_reported_in_10a(vl1);
+}


### PR DESCRIPTION
## Description

Resolve #10 

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - A5-0-2
     - M5-3-1

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)