### PR TITLE
M5-14-1: exclusion unevaluated contexts

### DIFF
--- a/change_notes/2024-02-26-exclusion-M5-14-1.md
+++ b/change_notes/2024-02-26-exclusion-M5-14-1.md
@@ -1,0 +1,2 @@
+- `M5-14-1` - `RightHandOperandOfALogicalAndOperatorsContainSideEffects.ql`:
+    - Fix FP reported in #375. Addresses incorrect detection of side effects in unevaluated contexts.

--- a/cpp/autosar/src/rules/M5-14-1/RightHandOperandOfALogicalAndOperatorsContainSideEffects.ql
+++ b/cpp/autosar/src/rules/M5-14-1/RightHandOperandOfALogicalAndOperatorsContainSideEffects.ql
@@ -18,6 +18,7 @@ import cpp
 import codingstandards.cpp.autosar
 import codingstandards.cpp.SideEffect
 import codingstandards.cpp.sideeffect.DefaultEffects
+import codingstandards.cpp.Expr
 
 from BinaryLogicalOperation op, Expr rhs
 where
@@ -25,6 +26,5 @@ where
     SideEffects1Package::rightHandOperandOfALogicalAndOperatorsContainSideEffectsQuery()) and
   rhs = op.getRightOperand() and
   hasSideEffect(rhs) and
-  not rhs.(NoExceptExpr).getExpr().isUnevaluated() and
-  not rhs.(SizeofExprOperator).getExprOperand().isUnevaluated()
+  not rhs instanceof UnevaluatedExprExtension
 select op, "The $@ may have a side effect that is not always evaluated.", rhs, "right-hand operand"

--- a/cpp/autosar/src/rules/M5-14-1/RightHandOperandOfALogicalAndOperatorsContainSideEffects.ql
+++ b/cpp/autosar/src/rules/M5-14-1/RightHandOperandOfALogicalAndOperatorsContainSideEffects.ql
@@ -25,26 +25,31 @@ import codingstandards.cpp.sideeffect.DefaultEffects
  */
 class UnevaluatedOperand extends Expr {
   Expr operator;
+
   UnevaluatedOperand() {
     exists(SizeofExprOperator op | op.getExprOperand() = this |
-      not this.getUnderlyingType().(ArrayType).hasArraySize()
-      and operator = op
+      not this.getUnderlyingType().(ArrayType).hasArraySize() and
+      operator = op
     )
     or
-    exists(NoExceptExpr e | e.getExpr() = this
-    and operator = e)
-    or 
-    exists(TypeidOperator t | t.getExpr() = this
-    and operator = t)
-    or 
-    exists(FunctionCall declval | declval.getTarget().hasQualifiedName("std", "declval")
-    and declval.getAChild() = this
-    and operator = declval)
+    exists(NoExceptExpr e |
+      e.getExpr() = this and
+      operator = e
+    )
+    or
+    exists(TypeidOperator t |
+      t.getExpr() = this and
+      operator = t
+    )
+    or
+    exists(FunctionCall declval |
+      declval.getTarget().hasQualifiedName("std", "declval") and
+      declval.getAChild() = this and
+      operator = declval
+    )
   }
 
-  Expr getOp(){
-    result = operator
-  }
+  Expr getOp() { result = operator }
 }
 
 from BinaryLogicalOperation op, Expr rhs
@@ -52,6 +57,6 @@ where
   not isExcluded(op,
     SideEffects1Package::rightHandOperandOfALogicalAndOperatorsContainSideEffectsQuery()) and
   rhs = op.getRightOperand() and
-  hasSideEffect(rhs)
-  and not exists(UnevaluatedOperand un | un.getOp() = rhs)
+  hasSideEffect(rhs) and
+  not exists(UnevaluatedOperand un | un.getOp() = rhs)
 select op, "The $@ may have a side effect that is not always evaluated.", rhs, "right-hand operand"

--- a/cpp/autosar/src/rules/M5-14-1/RightHandOperandOfALogicalAndOperatorsContainSideEffects.ql
+++ b/cpp/autosar/src/rules/M5-14-1/RightHandOperandOfALogicalAndOperatorsContainSideEffects.ql
@@ -19,44 +19,12 @@ import codingstandards.cpp.autosar
 import codingstandards.cpp.SideEffect
 import codingstandards.cpp.sideeffect.DefaultEffects
 
-/**
- * an operator that does not evaluate its operand
- * `decltype` also has a non evaluated operand but cannot be used in a `BinaryLogicalOperation`
- */
-class UnevaluatedOperand extends Expr {
-  Expr operator;
-
-  UnevaluatedOperand() {
-    exists(SizeofExprOperator op | op.getExprOperand() = this |
-      not this.getUnderlyingType().(ArrayType).hasArraySize() and
-      operator = op
-    )
-    or
-    exists(NoExceptExpr e |
-      e.getExpr() = this and
-      operator = e
-    )
-    or
-    exists(TypeidOperator t |
-      t.getExpr() = this and
-      operator = t
-    )
-    or
-    exists(FunctionCall declval |
-      declval.getTarget().hasQualifiedName("std", "declval") and
-      declval.getAChild() = this and
-      operator = declval
-    )
-  }
-
-  Expr getOp() { result = operator }
-}
-
 from BinaryLogicalOperation op, Expr rhs
 where
   not isExcluded(op,
     SideEffects1Package::rightHandOperandOfALogicalAndOperatorsContainSideEffectsQuery()) and
   rhs = op.getRightOperand() and
   hasSideEffect(rhs) and
-  not exists(UnevaluatedOperand un | un.getOp() = rhs)
+  not rhs.(NoExceptExpr).getExpr().isUnevaluated() and
+  not rhs.(SizeofExprOperator).getExprOperand().isUnevaluated()
 select op, "The $@ may have a side effect that is not always evaluated.", rhs, "right-hand operand"

--- a/cpp/autosar/test/rules/M5-14-1/RightHandOperandOfALogicalAndOperatorsContainSideEffects.expected
+++ b/cpp/autosar/test/rules/M5-14-1/RightHandOperandOfALogicalAndOperatorsContainSideEffects.expected
@@ -1,3 +1,4 @@
 | test.cpp:15:7:15:14 | ... \|\| ... | The $@ may have a side effect that is not always evaluated. | test.cpp:15:12:15:14 | ... ++ | right-hand operand |
 | test.cpp:18:7:18:21 | ... \|\| ... | The $@ may have a side effect that is not always evaluated. | test.cpp:18:13:18:20 | ... == ... | right-hand operand |
 | test.cpp:21:7:21:15 | ... \|\| ... | The $@ may have a side effect that is not always evaluated. | test.cpp:21:12:21:13 | call to f1 | right-hand operand |
+| test.cpp:40:7:40:41 | ... \|\| ... | The $@ may have a side effect that is not always evaluated. | test.cpp:40:26:40:26 | call to operator== | right-hand operand |

--- a/cpp/autosar/test/rules/M5-14-1/test.cpp
+++ b/cpp/autosar/test/rules/M5-14-1/test.cpp
@@ -29,8 +29,14 @@ int g1 = 0;
 int f4() { return g1++; }
 int f5() { return 1; }
 
+#include <typeinfo>
+
 void f6() {
-  if (noexcept(f5()) &&noexcept(
-          f4())) { // COMPLIANT  - noexcept operands not evaluated
-  }
+  if (1 && sizeof(f4())) {
+  } // COMPLIANT  - sizeof operands not evaluated
+  if (1 &&noexcept(f4()) &&noexcept(f4())) {
+  } // COMPLIANT  - noexcept operands not evaluated
+
+  if (1 || (typeid(f5()) == typeid(f4()))) {
+  } // NON_COMPLIANT  - typeid operands not evaluated, but the ==operator is
 }

--- a/cpp/autosar/test/rules/M5-14-1/test.cpp
+++ b/cpp/autosar/test/rules/M5-14-1/test.cpp
@@ -24,3 +24,13 @@ void f3(bool b) {
   if (b || f2()) { // COMPLIANT, f2 has local side-effects
   }
 }
+
+int g1 = 0;
+int f4() { return g1++; }
+int f5() { return 1; }
+
+void f6() {
+  if (noexcept(f5()) &&noexcept(
+          f4())) { // COMPLIANT  - noexcept operands not evaluated
+  }
+}

--- a/cpp/common/src/codingstandards/cpp/Expr.qll
+++ b/cpp/common/src/codingstandards/cpp/Expr.qll
@@ -189,3 +189,17 @@ module MisraExpr {
     CValue() { isCValue(this) }
   }
 }
+
+/**
+ * an operator that does not evaluate its operand
+ */
+class UnevaluatedExprExtension extends Expr {
+  UnevaluatedExprExtension() {
+    this.getChild(_).isUnevaluated()
+    or
+    exists(FunctionCall declval |
+      declval.getTarget().hasQualifiedName("std", "declval") and
+      declval.getAChild() = this
+    )
+  }
+}

--- a/cpp/common/src/codingstandards/cpp/Expr.qll
+++ b/cpp/common/src/codingstandards/cpp/Expr.qll
@@ -195,7 +195,7 @@ module MisraExpr {
  */
 class UnevaluatedExprExtension extends Expr {
   UnevaluatedExprExtension() {
-    this.getChild(_).isUnevaluated()
+    this.getAChild().isUnevaluated()
     or
     exists(FunctionCall declval |
       declval.getTarget().hasQualifiedName("std", "declval") and

--- a/cpp/common/test/includes/standard-library/typeinfo.h
+++ b/cpp/common/test/includes/standard-library/typeinfo.h
@@ -4,5 +4,6 @@ namespace std {
 struct type_info {
   const char *name() const noexcept;
   std::size_t hash_code() const noexcept;
+  bool operator==(const type_info &rhs) const;
 };
 } // namespace std


### PR DESCRIPTION
## Description

fixes #375 

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - M5-14-1

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)