### PR TITLE
Fix 152: Adding query for depencence on operator precedence

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -271,6 +271,7 @@
                 "Null",
                 "OperatorInvariants",
                 "Operators",
+                "OrderOfEvaluation",
                 "OutOfBounds",
                 "Pointers",
                 "Pointers1",

--- a/cpp/autosar/src/rules/M5-0-2/InsufficientUseOfParentheses.ql
+++ b/cpp/autosar/src/rules/M5-0-2/InsufficientUseOfParentheses.ql
@@ -20,9 +20,10 @@ import semmle.code.cpp.commons.Assertions
 
 class InsufficientlyParenthesizedExpr extends Expr {
   InsufficientlyParenthesizedExpr() {
-    // Exclude assertions because if the child is the expression being asserted it
-    // is not necessary to add parenthesis.
-    not any(Assertion a).getAsserted() = this and
+    // Exclude expressions affected by macros, including assertions, because
+    // it is unclear that the expression must be parenthesized since it seems
+    // to be the top-level expression instead of an operand of a binary or ternary operation.
+    not this.isAffectedByMacro() and
     (
       exists(BinaryOperation root, BinaryOperation child | child = this |
         root.getAnOperand() = child and

--- a/cpp/autosar/src/rules/M5-0-2/InsufficientUseOfParentheses.ql
+++ b/cpp/autosar/src/rules/M5-0-2/InsufficientUseOfParentheses.ql
@@ -1,0 +1,23 @@
+/**
+ * @id cpp/autosar/insufficient-use-of-parentheses
+ * @name M5-0-2: Limited dependence should be placed on C++ operator precedence rules in expressions
+ * @description The use of parentheses can be used to emphasize precedence and increase code
+ *              readability.
+ * @kind problem
+ * @precision medium
+ * @problem.severity recommendation
+ * @tags external/autosar/id/m5-0-2
+ *       external/autosar/audit
+ *       readability
+ *       external/autosar/allocated-target/implementation
+ *       external/autosar/enforcement/partially-automated
+ *       external/autosar/obligation/advisory
+ */
+
+import cpp
+import codingstandards.cpp.autosar
+
+from Expr e
+where
+  not isExcluded(e, OrderOfEvaluationPackage::insufficientUseOfParenthesesQuery())
+select e, "Insufficient use of parenthesis in expression."

--- a/cpp/autosar/src/rules/M5-0-2/InsufficientUseOfParentheses.ql
+++ b/cpp/autosar/src/rules/M5-0-2/InsufficientUseOfParentheses.ql
@@ -16,18 +16,24 @@
 
 import cpp
 import codingstandards.cpp.autosar
+import semmle.code.cpp.commons.Assertions
 
 class InsufficientlyParenthesizedExpr extends Expr {
   InsufficientlyParenthesizedExpr() {
-    exists(BinaryOperation root, BinaryOperation child | child = this |
-      root.getAnOperand() = child and
-      root.getOperator() != child.getOperator() and
-      not any(ParenthesisExpr pe).getExpr() = child
-    )
-    or
-    exists(ConditionalExpr root, BinaryOperation child | child = this |
-      root.getAnOperand() = child and
-      not any(ParenthesisExpr pe).getExpr() = child
+    // Exclude assertions because if the child is the expression being asserted it
+    // is not necessary to add parenthesis.
+    not any(Assertion a).getAsserted() = this and
+    (
+      exists(BinaryOperation root, BinaryOperation child | child = this |
+        root.getAnOperand() = child and
+        root.getOperator() != child.getOperator() and
+        not any(ParenthesisExpr pe).getExpr() = child
+      )
+      or
+      exists(ConditionalExpr root, BinaryOperation child | child = this |
+        root.getAnOperand() = child and
+        not any(ParenthesisExpr pe).getExpr() = child
+      )
     )
   }
 }

--- a/cpp/autosar/src/rules/M5-0-2/InsufficientUseOfParentheses.ql
+++ b/cpp/autosar/src/rules/M5-0-2/InsufficientUseOfParentheses.ql
@@ -17,7 +17,21 @@
 import cpp
 import codingstandards.cpp.autosar
 
-from Expr e
-where
-  not isExcluded(e, OrderOfEvaluationPackage::insufficientUseOfParenthesesQuery())
-select e, "Insufficient use of parenthesis in expression."
+class InsufficientlyParenthesizedExpr extends Expr {
+  InsufficientlyParenthesizedExpr() {
+    exists(BinaryOperation root, BinaryOperation child | child = this |
+      root.getAnOperand() = child and
+      root.getOperator() != child.getOperator() and
+      not any(ParenthesisExpr pe).getExpr() = child
+    )
+    or
+    exists(ConditionalExpr root, BinaryOperation child | child = this |
+      root.getAnOperand() = child and
+      not any(ParenthesisExpr pe).getExpr() = child
+    )
+  }
+}
+
+from InsufficientlyParenthesizedExpr e
+where not isExcluded(e, OrderOfEvaluationPackage::insufficientUseOfParenthesesQuery())
+select e, "Dependence on operator precedence rules."

--- a/cpp/autosar/test/rules/M5-0-2/InsufficientUseOfParentheses.expected
+++ b/cpp/autosar/test/rules/M5-0-2/InsufficientUseOfParentheses.expected
@@ -1,0 +1,1 @@
+No expected results have yet been specified

--- a/cpp/autosar/test/rules/M5-0-2/InsufficientUseOfParentheses.expected
+++ b/cpp/autosar/test/rules/M5-0-2/InsufficientUseOfParentheses.expected
@@ -1,1 +1,8 @@
-No expected results have yet been specified
+| test.cpp:40:8:40:13 | ... * ... | Dependence on operator precedence rules. |
+| test.cpp:41:19:41:24 | ... * ... | Dependence on operator precedence rules. |
+| test.cpp:42:8:42:13 | ... * ... | Dependence on operator precedence rules. |
+| test.cpp:42:17:42:22 | ... * ... | Dependence on operator precedence rules. |
+| test.cpp:48:8:48:15 | ... == ... | Dependence on operator precedence rules. |
+| test.cpp:49:26:49:32 | ... - ... | Dependence on operator precedence rules. |
+| test.cpp:50:8:50:15 | ... == ... | Dependence on operator precedence rules. |
+| test.cpp:50:24:50:30 | ... - ... | Dependence on operator precedence rules. |

--- a/cpp/autosar/test/rules/M5-0-2/InsufficientUseOfParentheses.qlref
+++ b/cpp/autosar/test/rules/M5-0-2/InsufficientUseOfParentheses.qlref
@@ -1,0 +1,1 @@
+rules/M5-0-2/InsufficientUseOfParentheses.ql

--- a/cpp/autosar/test/rules/M5-0-2/test.cpp
+++ b/cpp/autosar/test/rules/M5-0-2/test.cpp
@@ -32,3 +32,20 @@ void f1() {
   l1 = (*l7)[l2];           // NON_COMPLIANT[FALSE_NEGATIVE]
   char l8 = (char)(l1 + 1); // NON_COMPLIANT[FALSE_NEGATIVE]
 }
+
+void test_insufficient_parentheses() {
+  int l1, l2, l3;
+
+  l1 = (2 * l2) + (3 * l3);  // COMPLIANT
+  l1 = 2 * l2 + (3 * l3);    // NON_COMPLIANT
+  l1 = (2 * l2) + 3 * l3;    // NON_COMPLIANT
+  l1 = 2 * l2 + 3 * l3;      // NON_COMPLIANT
+  l1 = (2 * l2) + l3 + 1;    // COMPLIANT
+  l1 = (l2 + 1) - (l2 + l3); // COMPLIANT
+  l1 = l2 + l3 + 1;          // COMPLIANT
+
+  l1 = (l2 == l3) ? l2 : (l2 - l3); // COMPLIANT
+  l1 = l2 == l3 ? l2 : (l2 - l3);   // NON_COMPLIANT
+  l1 = (l2 == l3) ? l2 : l2 - l3;   // NON_COMPLIANT
+  l1 = l2 == l3 ? l2 : l2 - l3;     // NON_COMPLIANT
+}

--- a/cpp/common/src/codingstandards/cpp/exclusions/cpp/OrderOfEvaluation.qll
+++ b/cpp/common/src/codingstandards/cpp/exclusions/cpp/OrderOfEvaluation.qll
@@ -8,6 +8,7 @@ newtype OrderOfEvaluationQuery =
   TOperandsOfALogicalAndOrNotParenthesizedQuery() or
   TExplicitConstructionOfUnnamedTemporaryQuery() or
   TGratuitousUseOfParenthesesQuery() or
+  TInsufficientUseOfParenthesesQuery() or
   TIncrementAndDecrementOperatorsMixedWithOtherOperatorsInExpressionQuery() or
   TAssignmentInSubExpressionQuery()
 
@@ -47,6 +48,15 @@ predicate isOrderOfEvaluationQueryMetadata(
   queryId =
     // `@id` for the `gratuitousUseOfParentheses` query
     "cpp/autosar/gratuitous-use-of-parentheses" and
+  ruleId = "M5-0-2" and
+  category = "advisory"
+  or
+  query =
+    // `Query` instance for the `insufficientUseOfParentheses` query
+    OrderOfEvaluationPackage::insufficientUseOfParenthesesQuery() and
+  queryId =
+    // `@id` for the `insufficientUseOfParentheses` query
+    "cpp/autosar/insufficient-use-of-parentheses" and
   ruleId = "M5-0-2" and
   category = "advisory"
   or
@@ -96,6 +106,13 @@ module OrderOfEvaluationPackage {
     result =
       // `Query` type for `gratuitousUseOfParentheses` query
       TQueryCPP(TOrderOfEvaluationPackageQuery(TGratuitousUseOfParenthesesQuery()))
+  }
+
+  Query insufficientUseOfParenthesesQuery() {
+    //autogenerate `Query` type
+    result =
+      // `Query` type for `insufficientUseOfParentheses` query
+      TQueryCPP(TOrderOfEvaluationPackageQuery(TInsufficientUseOfParenthesesQuery()))
   }
 
   Query incrementAndDecrementOperatorsMixedWithOtherOperatorsInExpressionQuery() {

--- a/rule_packages/cpp/OrderOfEvaluation.json
+++ b/rule_packages/cpp/OrderOfEvaluation.json
@@ -90,6 +90,18 @@
             "external/autosar/audit",
             "readability"
           ]
+        },
+        {
+          "description": "The use of parentheses can be used to emphasize precedence and increase code readability.",
+          "kind": "problem",
+          "name": "Limited dependence should be placed on C++ operator precedence rules in expressions",
+          "precision": "medium",
+          "severity": "recommendation",
+          "short_name": "InsufficientUseOfParentheses",
+          "tags": [
+            "external/autosar/audit",
+            "readability"
+          ]
         }
       ],
       "title": "Limited dependence should be placed on C++ operator precedence rules in expressions."


### PR DESCRIPTION
## Description

Resolve #152.

Adding query to find operands of binary operations and ternary operators that should be parenthesized.
The query does not implement the case where associativity may compute a different result due to integer promotions. 

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [x] Queries have been added for the following rules:
     - M5-0-2
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)