### PR TITLE
CTR55-CPP: address 374

### DIFF
--- a/change_notes/2024-03-22-fix-fp-ctr55-cpp.md
+++ b/change_notes/2024-03-22-fix-fp-ctr55-cpp.md
@@ -1,0 +1,2 @@
+- `CTR55-CPP` - `DoNotUseAnAdditiveOperatorOnAnIterator.ql`:
+  - Address reported FP in #374. Improve logic on valid end checks on iterators.

--- a/change_notes/2024-03-22-fix-fp-ctr55-cpp.md
+++ b/change_notes/2024-03-22-fix-fp-ctr55-cpp.md
@@ -1,2 +1,2 @@
 - `CTR55-CPP` - `DoNotUseAnAdditiveOperatorOnAnIterator.ql`:
-  - Address reported FP in #374. Improve logic on valid end checks on iterators.
+  - Address reported FP in #374. Improve logic on valid end checks and size checks on iterators.

--- a/cpp/cert/src/rules/CTR52-CPP/GuaranteeGenericCppLibraryFunctionsDoNotOverflow.ql
+++ b/cpp/cert/src/rules/CTR52-CPP/GuaranteeGenericCppLibraryFunctionsDoNotOverflow.ql
@@ -80,7 +80,7 @@ where
     iteratorCreationCall = outputContainer.getAnIteratorFunctionCall() and
     iteratorCreationCall = c.getOutputIteratorSource()
   |
-    size_compare_bounds_checked(iteratorCreationCall, c)
+    sizeCompareBoundsChecked(iteratorCreationCall, c)
     or
     // Container created with sufficient size for the input
     exists(ContainerAccessWithoutRangeCheck::ContainerConstructorCall outputIteratorConstructor |

--- a/cpp/cert/src/rules/CTR52-CPP/GuaranteeGenericCppLibraryFunctionsDoNotOverflow.ql
+++ b/cpp/cert/src/rules/CTR52-CPP/GuaranteeGenericCppLibraryFunctionsDoNotOverflow.ql
@@ -80,16 +80,7 @@ where
     iteratorCreationCall = outputContainer.getAnIteratorFunctionCall() and
     iteratorCreationCall = c.getOutputIteratorSource()
   |
-    // Guarded by a bounds check that ensures our destination is larger than "some" value
-    exists(
-      GuardCondition guard, ContainerAccessWithoutRangeCheck::ContainerSizeCall sizeCall,
-      boolean branch
-    |
-      globalValueNumber(sizeCall.getQualifier()) =
-        globalValueNumber(iteratorCreationCall.getQualifier()) and
-      guard.controls(c.getBasicBlock(), branch) and
-      relOpWithSwapAndNegate(guard, sizeCall, _, Greater(), _, branch)
-    )
+    size_compare_bounds_checked(iteratorCreationCall, c)
     or
     // Container created with sufficient size for the input
     exists(ContainerAccessWithoutRangeCheck::ContainerConstructorCall outputIteratorConstructor |

--- a/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
+++ b/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
@@ -35,10 +35,9 @@ predicate sizeCheckedAbove(ContainerIteratorAccess it, IteratorSource source) {
  */
 predicate validEndBoundCheck(ContainerIteratorAccess it, IteratorSource source) {
   exists(
-    STLContainer c, BasicBlock b, GuardCondition l, ContainerIteratorAccess otherAccess,
-    IteratorSource end
+    ContainerAccessWithoutRangeCheck::ContainerEndCall end, BasicBlock b, GuardCondition l,
+    ContainerIteratorAccess otherAccess
   |
-    end = c.getAnIteratorEndFunctionCall() and
     //guard controls the access
     l.controls(b, _) and
     b.contains(it) and

--- a/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
+++ b/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
@@ -14,14 +14,14 @@
 import cpp
 import codingstandards.cpp.cert
 import codingstandards.cpp.Iterators
+import semmle.code.cpp.controlflow.Dominance
 
 /**
  * any `.size()` check above our access
  */
-predicate size_checked_above(ContainerIteratorAccess it, IteratorSource source) {
-  exists(STLContainer c, FunctionCall guardCall |
-    c.getACallToSize() = guardCall and
-    guardCall = it.getAPredecessor*() and
+predicate sizeCheckedAbove(ContainerIteratorAccess it, IteratorSource source) {
+  exists(ContainerAccessWithoutRangeCheck::ContainerSizeCall guardCall |
+    strictlyDominates(guardCall, it) and
     //make sure its the same container providing its size as giving the iterator
     globalValueNumber(guardCall.getQualifier()) = globalValueNumber(source.getQualifier()) and
     // and the size call we match must be after the assignment call
@@ -30,16 +30,22 @@ predicate size_checked_above(ContainerIteratorAccess it, IteratorSource source) 
 }
 
 /**
- * some loop check exists like: `iterator != end`
+ * some guard exists like: `iterator != end`
  * where a relevant`.end()` call flowed into end
  */
-predicate valid_end_bound_check(ContainerIteratorAccess it, IteratorSource source) {
-  exists(STLContainer c, Loop l, ContainerIteratorAccess otherAccess, IteratorSource end |
+predicate validEndBoundCheck(ContainerIteratorAccess it, IteratorSource source) {
+  exists(
+    STLContainer c, BasicBlock b, GuardCondition l, ContainerIteratorAccess otherAccess,
+    IteratorSource end
+  |
     end = c.getAnIteratorEndFunctionCall() and
-    //flow exists between end() and the loop condition
-    DataFlow::localFlow(DataFlow::exprNode(end), DataFlow::exprNode(l.getCondition().getAChild())) and
-    l.getCondition().getAChild() = otherAccess and
-    //make sure its the same iterator being checked as incremented
+    //guard controls the access
+    l.controls(b, _) and
+    b.contains(it) and
+    //guard is comprised of (anything flowing to) end check and an iterator access
+    DataFlow::localFlow(DataFlow::exprNode(end), DataFlow::exprNode(l.getChild(_))) and
+    l.getChild(_) = otherAccess and
+    //make sure its the same iterator being checked in the guard as accessed
     otherAccess.getOwningContainer() = it.getOwningContainer() and
     //make sure its the same container providing its end as giving the iterator
     globalValueNumber(end.getQualifier()) = globalValueNumber(source.getQualifier())
@@ -52,7 +58,7 @@ where
   it.isAdditiveOperation() and
   not exists(RangeBasedForStmt fs | fs.getUpdate().getAChild*() = it) and
   source = it.getANearbyAssigningIteratorCall() and
-  not size_compare_bounds_checked(source, it) and
-  not valid_end_bound_check(it, source) and
-  not size_checked_above(it, source)
+  not sizeCompareBoundsChecked(source, it) and
+  not validEndBoundCheck(it, source) and
+  not sizeCheckedAbove(it, source)
 select it, "Increment of iterator may overflow since its bounds are not checked."

--- a/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
+++ b/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
@@ -17,16 +17,28 @@ import codingstandards.cpp.Iterators
 import semmle.code.cpp.controlflow.Dominance
 
 /**
- * any `.size()` check above our access
+ * something like:
+ * `end = begin() + size()`
  */
-predicate sizeCheckedAbove(ContainerIteratorAccess it, IteratorSource source) {
-  exists(ContainerAccessWithoutRangeCheck::ContainerSizeCall guardCall |
-    strictlyDominates(guardCall, it) and
-    //make sure its the same container providing its size as giving the iterator
-    globalValueNumber(guardCall.getQualifier()) = globalValueNumber(source.getQualifier()) and
-    // and the size call we match must be after the assignment call
-    source.getASuccessor*() = guardCall
+Expr calculatedEndCheck(AdditiveOperatorFunctionCall calc) {
+  exists(
+    ContainerAccessWithoutRangeCheck::ContainerSizeCall size,
+    ContainerAccessWithoutRangeCheck::ContainerBeginCall begin
+  |
+    calc.getTarget().hasName("operator+") and
+    DataFlow::localFlow(DataFlow::exprNode(size), DataFlow::exprNode(calc.getAChild*())) and
+    DataFlow::localFlow(DataFlow::exprNode(begin), DataFlow::exprNode(calc.getAChild*())) and
+    //make sure its the same container providing its size as giving the begin
+    globalValueNumber(begin.getQualifier()) = globalValueNumber(size.getQualifier()) and
+    result = begin.getQualifier()
   )
+}
+
+Expr validEndCheck(FunctionCall end) {
+  end instanceof ContainerAccessWithoutRangeCheck::ContainerEndCall and
+  result = end.getQualifier()
+  or
+  result = calculatedEndCheck(end)
 }
 
 /**
@@ -35,19 +47,23 @@ predicate sizeCheckedAbove(ContainerIteratorAccess it, IteratorSource source) {
  */
 predicate validEndBoundCheck(ContainerIteratorAccess it, IteratorSource source) {
   exists(
-    ContainerAccessWithoutRangeCheck::ContainerEndCall end, BasicBlock b, GuardCondition l,
-    ContainerIteratorAccess otherAccess
+    FunctionCall end, BasicBlock b, GuardCondition l, ContainerIteratorAccess otherAccess,
+    Expr qualifierToCheck
   |
+    //sufficient end guard
+    qualifierToCheck = validEndCheck(end) and
     //guard controls the access
     l.controls(b, _) and
     b.contains(it) and
-    //guard is comprised of (anything flowing to) end check and an iterator access
+    //guard is comprised of end check and an iterator access
     DataFlow::localFlow(DataFlow::exprNode(end), DataFlow::exprNode(l.getChild(_))) and
     l.getChild(_) = otherAccess and
     //make sure its the same iterator being checked in the guard as accessed
     otherAccess.getOwningContainer() = it.getOwningContainer() and
-    //make sure its the same container providing its end as giving the iterator
-    globalValueNumber(end.getQualifier()) = globalValueNumber(source.getQualifier())
+    //if its the end call itself (or its parts), make sure its the same container providing its end as giving the iterator
+    globalValueNumber(qualifierToCheck) = globalValueNumber(source.getQualifier()) and
+    // and the guard call we match must be after the assignment call (to avoid valid guards protecting new iterator accesses further down)
+    source.getASuccessor*() = l
   )
 }
 
@@ -58,5 +74,5 @@ where
   not exists(RangeBasedForStmt fs | fs.getUpdate().getAChild*() = it) and
   source = it.getANearbyAssigningIteratorCall() and
   not validEndBoundCheck(it, source) and
-  not sizeCheckedAbove(it, source)
+  not sizeCompareBoundsChecked(source, it)
 select it, "Increment of iterator may overflow since its bounds are not checked."

--- a/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
+++ b/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
@@ -60,16 +60,19 @@ Expr getReferenceToOnePassedTheEndElement(Expr containerReference) {
  */
 predicate isUpperBoundEndCheckedIteratorAccess(IteratorSource source, ContainerIteratorAccess it) {
   exists(
-    Expr referenceToOnePassedTheEndElement, BasicBlock basicBlockOfIteratorAccess, GuardCondition upperBoundCheck,
-    ContainerIteratorAccess checkedIteratorAccess, Expr containerReferenceFromEndGuard
+    Expr referenceToOnePassedTheEndElement, BasicBlock basicBlockOfIteratorAccess,
+    GuardCondition upperBoundCheck, ContainerIteratorAccess checkedIteratorAccess,
+    Expr containerReferenceFromEndGuard
   |
     //sufficient end guard
-    referenceToOnePassedTheEndElement = getReferenceToOnePassedTheEndElement(containerReferenceFromEndGuard) and
+    referenceToOnePassedTheEndElement =
+      getReferenceToOnePassedTheEndElement(containerReferenceFromEndGuard) and
     //guard controls the access
     upperBoundCheck.controls(basicBlockOfIteratorAccess, _) and
     basicBlockOfIteratorAccess.contains(it) and
     //guard is comprised of end check and an iterator access
-    DataFlow::localFlow(DataFlow::exprNode(referenceToOnePassedTheEndElement), DataFlow::exprNode(upperBoundCheck.getChild(_))) and
+    DataFlow::localFlow(DataFlow::exprNode(referenceToOnePassedTheEndElement),
+      DataFlow::exprNode(upperBoundCheck.getChild(_))) and
     upperBoundCheck.getChild(_) = checkedIteratorAccess and
     //make sure its the same iterator being checked in the guard as accessed
     checkedIteratorAccess.getOwningContainer() = it.getOwningContainer() and

--- a/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
+++ b/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
@@ -15,23 +15,44 @@ import cpp
 import codingstandards.cpp.cert
 import codingstandards.cpp.Iterators
 
-from ContainerIteratorAccess it
+/**
+ * any `.size()` check above our access
+ */
+predicate size_checked_above(ContainerIteratorAccess it, IteratorSource source) {
+  exists(STLContainer c, FunctionCall guardCall |
+    c.getACallToSize() = guardCall and
+    guardCall = it.getAPredecessor*() and
+    //make sure its the same container providing its size as giving the iterator
+    globalValueNumber(guardCall.getQualifier()) = globalValueNumber(source.getQualifier()) and
+    // and the size call we match must be after the assignment call
+    source.getASuccessor*() = guardCall
+  )
+}
+
+/**
+ * some loop check exists like: `iterator != end`
+ * where a relevant`.end()` call flowed into end
+ */
+predicate valid_end_bound_check(ContainerIteratorAccess it, IteratorSource source) {
+  exists(STLContainer c, Loop l, ContainerIteratorAccess otherAccess, IteratorSource end |
+    end = c.getAnIteratorEndFunctionCall() and
+    //flow exists between end() and the loop condition
+    DataFlow::localFlow(DataFlow::exprNode(end), DataFlow::exprNode(l.getCondition().getAChild())) and
+    l.getCondition().getAChild() = otherAccess and
+    //make sure its the same iterator being checked as incremented
+    otherAccess.getOwningContainer() = it.getOwningContainer() and
+    //make sure its the same container providing its end as giving the iterator
+    globalValueNumber(end.getQualifier()) = globalValueNumber(source.getQualifier())
+  )
+}
+
+from ContainerIteratorAccess it, IteratorSource source
 where
   not isExcluded(it, IteratorsPackage::doNotUseAnAdditiveOperatorOnAnIteratorQuery()) and
   it.isAdditiveOperation() and
   not exists(RangeBasedForStmt fs | fs.getUpdate().getAChild*() = it) and
-  // we get the neraby assignment
-  not exists(STLContainer c, FunctionCall nearbyAssigningIteratorCall, FunctionCall guardCall |
-    nearbyAssigningIteratorCall = it.getANearbyAssigningIteratorCall() and
-    // we look for calls to size or end
-    (guardCall = c.getACallToSize() or guardCall = c.getAnIteratorEndFunctionCall()) and
-    // such that the call to size is before this
-    // access
-    guardCall = it.getAPredecessor*() and
-    // and it uses the same qualifier as the one we were just assigned
-    nearbyAssigningIteratorCall.getQualifier().(VariableAccess).getTarget() =
-      guardCall.getQualifier().(VariableAccess).getTarget() and
-    // and the size call we match must be after the assignment call
-    nearbyAssigningIteratorCall.getASuccessor*() = guardCall
-  )
+  source = it.getANearbyAssigningIteratorCall() and
+  not size_compare_bounds_checked(source, it) and
+  not valid_end_bound_check(it, source) and
+  not size_checked_above(it, source)
 select it, "Increment of iterator may overflow since its bounds are not checked."

--- a/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
+++ b/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
@@ -17,8 +17,9 @@ import codingstandards.cpp.Iterators
 import semmle.code.cpp.controlflow.Dominance
 
 /**
- * something like:
- * `end = begin() + size()`
+ *  Get a derived one passed the end element for `containerReference`.
+ *  An example derivation is:
+ *     `end = begin() + size()`
  */
 Expr calculatedEndCheck(AdditiveOperatorFunctionCall calc) {
   exists(

--- a/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
+++ b/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
@@ -17,54 +17,66 @@ import codingstandards.cpp.Iterators
 import semmle.code.cpp.controlflow.Dominance
 
 /**
- *  Get a derived one passed the end element for `containerReference`.
+ * Models a call to an iterator's `operator+`
+ */
+class AdditionOperatorFunctionCall extends AdditiveOperatorFunctionCall {
+  AdditionOperatorFunctionCall() { this.getTarget().hasName("operator+") }
+}
+
+/**
+ *  There exists a calculation for the reference one passed the end of some container
  *  An example derivation is:
  *     `end = begin() + size()`
  */
-Expr calculatedEndCheck(AdditiveOperatorFunctionCall calc) {
+Expr getDerivedReferenceToOnePassedTheEndElement(Expr containerReference) {
   exists(
     ContainerAccessWithoutRangeCheck::ContainerSizeCall size,
-    ContainerAccessWithoutRangeCheck::ContainerBeginCall begin
+    ContainerAccessWithoutRangeCheck::ContainerBeginCall begin, AdditionOperatorFunctionCall calc
   |
-    calc.getTarget().hasName("operator+") and
-    DataFlow::localFlow(DataFlow::exprNode(size), DataFlow::exprNode(calc.getAChild*())) and
-    DataFlow::localFlow(DataFlow::exprNode(begin), DataFlow::exprNode(calc.getAChild*())) and
+    result = calc
+  |
+    DataFlow::localFlow(DataFlow::exprNode(size), DataFlow::exprNode(calc.getAChild+())) and
+    DataFlow::localFlow(DataFlow::exprNode(begin), DataFlow::exprNode(calc.getAChild+())) and
     //make sure its the same container providing its size as giving the begin
     globalValueNumber(begin.getQualifier()) = globalValueNumber(size.getQualifier()) and
-    result = begin.getQualifier()
+    containerReference = begin.getQualifier()
   )
 }
 
-Expr validEndCheck(FunctionCall end) {
-  end instanceof ContainerAccessWithoutRangeCheck::ContainerEndCall and
-  result = end.getQualifier()
+/**
+ * a wrapper predicate for a couple of types of permitted end bounds checks
+ */
+Expr getReferenceToOnePassedTheEndElement(Expr containerReference) {
+  //a container end access - v.end()
+  result instanceof ContainerAccessWithoutRangeCheck::ContainerEndCall and
+  containerReference = result.(FunctionCall).getQualifier()
   or
-  result = calculatedEndCheck(end)
+  result = getDerivedReferenceToOnePassedTheEndElement(containerReference)
 }
 
 /**
  * some guard exists like: `iterator != end`
  * where a relevant`.end()` call flowed into end
  */
-predicate validEndBoundCheck(ContainerIteratorAccess it, IteratorSource source) {
+predicate isUpperBoundEndCheckedIteratorAccess(IteratorSource source, ContainerIteratorAccess it) {
   exists(
-    FunctionCall end, BasicBlock b, GuardCondition l, ContainerIteratorAccess otherAccess,
-    Expr qualifierToCheck
+    Expr referenceToOnePassedTheEndElement, BasicBlock basicBlockOfIteratorAccess, GuardCondition upperBoundCheck,
+    ContainerIteratorAccess checkedIteratorAccess, Expr containerReferenceFromEndGuard
   |
     //sufficient end guard
-    qualifierToCheck = validEndCheck(end) and
+    referenceToOnePassedTheEndElement = getReferenceToOnePassedTheEndElement(containerReferenceFromEndGuard) and
     //guard controls the access
-    l.controls(b, _) and
-    b.contains(it) and
+    upperBoundCheck.controls(basicBlockOfIteratorAccess, _) and
+    basicBlockOfIteratorAccess.contains(it) and
     //guard is comprised of end check and an iterator access
-    DataFlow::localFlow(DataFlow::exprNode(end), DataFlow::exprNode(l.getChild(_))) and
-    l.getChild(_) = otherAccess and
+    DataFlow::localFlow(DataFlow::exprNode(referenceToOnePassedTheEndElement), DataFlow::exprNode(upperBoundCheck.getChild(_))) and
+    upperBoundCheck.getChild(_) = checkedIteratorAccess and
     //make sure its the same iterator being checked in the guard as accessed
-    otherAccess.getOwningContainer() = it.getOwningContainer() and
+    checkedIteratorAccess.getOwningContainer() = it.getOwningContainer() and
     //if its the end call itself (or its parts), make sure its the same container providing its end as giving the iterator
-    globalValueNumber(qualifierToCheck) = globalValueNumber(source.getQualifier()) and
+    globalValueNumber(containerReferenceFromEndGuard) = globalValueNumber(source.getQualifier()) and
     // and the guard call we match must be after the assignment call (to avoid valid guards protecting new iterator accesses further down)
-    source.getASuccessor*() = l
+    source.getASuccessor*() = upperBoundCheck
   )
 }
 
@@ -74,6 +86,6 @@ where
   it.isAdditiveOperation() and
   not exists(RangeBasedForStmt fs | fs.getUpdate().getAChild*() = it) and
   source = it.getANearbyAssigningIteratorCall() and
-  not validEndBoundCheck(it, source) and
+  not isUpperBoundEndCheckedIteratorAccess(source, it) and
   not sizeCompareBoundsChecked(source, it)
 select it, "Increment of iterator may overflow since its bounds are not checked."

--- a/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
+++ b/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
@@ -57,7 +57,6 @@ where
   it.isAdditiveOperation() and
   not exists(RangeBasedForStmt fs | fs.getUpdate().getAChild*() = it) and
   source = it.getANearbyAssigningIteratorCall() and
-  not sizeCompareBoundsChecked(source, it) and
   not validEndBoundCheck(it, source) and
   not sizeCheckedAbove(it, source)
 select it, "Increment of iterator may overflow since its bounds are not checked."

--- a/cpp/cert/test/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.expected
+++ b/cpp/cert/test/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.expected
@@ -4,4 +4,4 @@
 | test.cpp:22:18:22:18 | i | Increment of iterator may overflow since its bounds are not checked. |
 | test.cpp:28:31:28:31 | i | Increment of iterator may overflow since its bounds are not checked. |
 | test.cpp:41:5:41:8 | end2 | Increment of iterator may overflow since its bounds are not checked. |
-| test.cpp:50:42:50:42 | i | Increment of iterator may overflow since its bounds are not checked. |
+| test.cpp:53:42:53:42 | i | Increment of iterator may overflow since its bounds are not checked. |

--- a/cpp/cert/test/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.expected
+++ b/cpp/cert/test/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.expected
@@ -5,3 +5,4 @@
 | test.cpp:28:31:28:31 | i | Increment of iterator may overflow since its bounds are not checked. |
 | test.cpp:41:5:41:8 | end2 | Increment of iterator may overflow since its bounds are not checked. |
 | test.cpp:53:42:53:42 | i | Increment of iterator may overflow since its bounds are not checked. |
+| test.cpp:64:15:64:15 | i | Increment of iterator may overflow since its bounds are not checked. |

--- a/cpp/cert/test/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.expected
+++ b/cpp/cert/test/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.expected
@@ -2,5 +2,5 @@
 | test.cpp:9:9:9:9 | i | Increment of iterator may overflow since its bounds are not checked. |
 | test.cpp:10:9:10:9 | i | Increment of iterator may overflow since its bounds are not checked. |
 | test.cpp:22:18:22:18 | i | Increment of iterator may overflow since its bounds are not checked. |
-| test.cpp:27:31:27:31 | i | Increment of iterator may overflow since its bounds are not checked. |
-| test.cpp:40:5:40:8 | end2 | Increment of iterator may overflow since its bounds are not checked. |
+| test.cpp:28:31:28:31 | i | Increment of iterator may overflow since its bounds are not checked. |
+| test.cpp:41:5:41:8 | end2 | Increment of iterator may overflow since its bounds are not checked. |

--- a/cpp/cert/test/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.expected
+++ b/cpp/cert/test/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.expected
@@ -1,4 +1,6 @@
 | test.cpp:8:7:8:7 | i | Increment of iterator may overflow since its bounds are not checked. |
 | test.cpp:9:9:9:9 | i | Increment of iterator may overflow since its bounds are not checked. |
 | test.cpp:10:9:10:9 | i | Increment of iterator may overflow since its bounds are not checked. |
+| test.cpp:22:18:22:18 | i | Increment of iterator may overflow since its bounds are not checked. |
 | test.cpp:27:31:27:31 | i | Increment of iterator may overflow since its bounds are not checked. |
+| test.cpp:40:5:40:8 | end2 | Increment of iterator may overflow since its bounds are not checked. |

--- a/cpp/cert/test/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.expected
+++ b/cpp/cert/test/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.expected
@@ -4,3 +4,4 @@
 | test.cpp:22:18:22:18 | i | Increment of iterator may overflow since its bounds are not checked. |
 | test.cpp:28:31:28:31 | i | Increment of iterator may overflow since its bounds are not checked. |
 | test.cpp:41:5:41:8 | end2 | Increment of iterator may overflow since its bounds are not checked. |
+| test.cpp:50:42:50:42 | i | Increment of iterator may overflow since its bounds are not checked. |

--- a/cpp/cert/test/rules/CTR55-CPP/test.cpp
+++ b/cpp/cert/test/rules/CTR55-CPP/test.cpp
@@ -38,8 +38,11 @@ void test_fp_reported_in_374(std::vector<int> &v) {
 
   {
     auto end2 = v.end();
-    end2++;                                    // NON_COMPLIANT
-    for (auto i = v.begin(); i != end2; ++i) { // NON_COMPLIANT[FALSE_NEGATIVE]
+    end2++; // NON_COMPLIANT
+    for (auto i = v.begin(); i != end2;
+         ++i) { // NON_COMPLIANT[FALSE_NEGATIVE] - case of invalidations to
+                // check before use expected to be less frequent, can model in
+                // future if need be
     }
   }
 }

--- a/cpp/cert/test/rules/CTR55-CPP/test.cpp
+++ b/cpp/cert/test/rules/CTR55-CPP/test.cpp
@@ -20,8 +20,9 @@ void f1(std::vector<int> &v) {
   }
   for (auto i = v.begin(),
             l = (i + std::min(static_cast<std::vector<int>::size_type>(10),
-                              v.size()));
-       i != l; ++i) { // COMPLIANT
+                              v.size())); // NON_COMPLIANT - technically in the
+                                          // calculation
+       i != l; ++i) {                     // COMPLIANT
   }
 
   for (auto i = v.begin();; ++i) { // NON_COMPLIANT
@@ -37,7 +38,7 @@ void test_fp_reported_in_374(std::vector<int> &v) {
 
   {
     auto end2 = v.end();
-    end2++;                                    // NON_COMPLIANT[FALSE_NEGATIVE]
+    end2++;                                    // NON_COMPLIANT
     for (auto i = v.begin(); i != end2; ++i) { // NON_COMPLIANT[FALSE_NEGATIVE]
     }
   }

--- a/cpp/cert/test/rules/CTR55-CPP/test.cpp
+++ b/cpp/cert/test/rules/CTR55-CPP/test.cpp
@@ -43,3 +43,11 @@ void test_fp_reported_in_374(std::vector<int> &v) {
     }
   }
 }
+
+void test(std::vector<int> &v, std::vector<int> &v2) {
+  {
+    auto end = v2.end();
+    for (auto i = v.begin(); i != end; ++i) { // NON_COMPLIANT - wrong check
+    }
+  }
+}

--- a/cpp/cert/test/rules/CTR55-CPP/test.cpp
+++ b/cpp/cert/test/rules/CTR55-CPP/test.cpp
@@ -54,3 +54,13 @@ void test(std::vector<int> &v, std::vector<int> &v2) {
     }
   }
 }
+
+void test2(std::vector<int> &v) {
+  auto i = v.begin();
+  while (1) {
+    auto i2 = ((i != v.end()) != 0);
+    if (!i2)
+      break;
+    (void)((++i)); // COMPLIANT[FALSE_POSITIVE]
+  }
+}

--- a/cpp/cert/test/rules/CTR55-CPP/test.cpp
+++ b/cpp/cert/test/rules/CTR55-CPP/test.cpp
@@ -27,3 +27,18 @@ void f1(std::vector<int> &v) {
   for (auto i = v.begin();; ++i) { // NON_COMPLIANT
   }
 }
+
+void test_fp_reported_in_374(std::vector<int> &v) {
+  {
+    auto end = v.end();
+    for (auto i = v.begin(); i != end; ++i) { // COMPLIANT
+    }
+  }
+
+  {
+    auto end2 = v.end();
+    end2++;                                    // NON_COMPLIANT[FALSE_NEGATIVE]
+    for (auto i = v.begin(); i != end2; ++i) { // NON_COMPLIANT[FALSE_NEGATIVE]
+    }
+  }
+}

--- a/cpp/common/src/codingstandards/cpp/Iterators.qll
+++ b/cpp/common/src/codingstandards/cpp/Iterators.qll
@@ -6,6 +6,10 @@ import cpp
 import codingstandards.cpp.dataflow.DataFlow
 import codingstandards.cpp.dataflow.TaintTracking
 import codingstandards.cpp.StdNamespace
+import codingstandards.cpp.rules.containeraccesswithoutrangecheck.ContainerAccessWithoutRangeCheck as ContainerAccessWithoutRangeCheck
+import semmle.code.cpp.controlflow.Guards
+import semmle.code.cpp.valuenumbering.GlobalValueNumbering
+import semmle.code.cpp.rangeanalysis.RangeAnalysisUtils
 
 abstract class ContainerAccess extends VariableAccess {
   abstract Variable getOwningContainer();
@@ -63,9 +67,11 @@ class ContainerIteratorAccess extends ContainerAccess {
     )
   }
 
-  // get a function call to cbegin/begin that
-  // assigns its value to the iterator represented by this
-  // access
+  /**
+   * gets a function call to cbegin/begin that
+   * assigns its value to the iterator represented by this
+   * access
+   */
   FunctionCall getANearbyAssigningIteratorCall() {
     // the underlying container for this variable is one wherein
     // there is an assigned value of cbegin/cend
@@ -460,5 +466,20 @@ ControlFlowNode getANonInvalidatedSuccessor(ContainerInvalidationOperation op) {
     mid = getANonInvalidatedSuccessor(op) and
     result = mid.getASuccessor() and
     not result instanceof ContainerInvalidationOperation
+  )
+}
+
+/**
+ * Guarded by a bounds check that ensures our destination is larger than "some" value
+ */
+predicate size_compare_bounds_checked(IteratorSource iteratorCreationCall, Expr guarded) {
+  exists(
+    GuardCondition guard, ContainerAccessWithoutRangeCheck::ContainerSizeCall sizeCall,
+    boolean branch
+  |
+    globalValueNumber(sizeCall.getQualifier()) =
+      globalValueNumber(iteratorCreationCall.getQualifier()) and
+    guard.controls(guarded.getBasicBlock(), branch) and
+    relOpWithSwapAndNegate(guard, sizeCall, _, Greater(), _, branch)
   )
 }

--- a/cpp/common/src/codingstandards/cpp/Iterators.qll
+++ b/cpp/common/src/codingstandards/cpp/Iterators.qll
@@ -472,7 +472,7 @@ ControlFlowNode getANonInvalidatedSuccessor(ContainerInvalidationOperation op) {
 /**
  * Guarded by a bounds check that ensures our destination is larger than "some" value
  */
-predicate size_compare_bounds_checked(IteratorSource iteratorCreationCall, Expr guarded) {
+predicate sizeCompareBoundsChecked(IteratorSource iteratorCreationCall, Expr guarded) {
   exists(
     GuardCondition guard, ContainerAccessWithoutRangeCheck::ContainerSizeCall sizeCall,
     boolean branch

--- a/cpp/common/src/codingstandards/cpp/rules/containeraccesswithoutrangecheck/ContainerAccessWithoutRangeCheck.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/containeraccesswithoutrangecheck/ContainerAccessWithoutRangeCheck.qll
@@ -86,6 +86,16 @@ class ContainerEmptyCall extends FunctionCall {
 }
 
 /**
+ * A call to either `begin()` on a container.
+ */
+class ContainerBeginCall extends FunctionCall {
+  ContainerBeginCall() {
+    getTarget().getDeclaringType() instanceof ContainerType and
+    getTarget().getName() = "begin"
+  }
+}
+
+/**
  * A call to either `end()` on a container.
  */
 class ContainerEndCall extends FunctionCall {

--- a/cpp/common/src/codingstandards/cpp/rules/containeraccesswithoutrangecheck/ContainerAccessWithoutRangeCheck.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/containeraccesswithoutrangecheck/ContainerAccessWithoutRangeCheck.qll
@@ -86,6 +86,16 @@ class ContainerEmptyCall extends FunctionCall {
 }
 
 /**
+ * A call to either `end()` on a container.
+ */
+class ContainerEndCall extends FunctionCall {
+  ContainerEndCall() {
+    getTarget().getDeclaringType() instanceof ContainerType and
+    getTarget().getName() = "end"
+  }
+}
+
+/**
  * A call to either `size()` or `length()` on a container.
  */
 class ContainerSizeCall extends FunctionCall {


### PR DESCRIPTION
## Description

fix #374 

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - CTR55-CPP
     - CTR52-CPP (just a refactor)
## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)