### PR TITLE
A8-4-7: fix type size rounding error

### DIFF
--- a/change_notes/2024-03-22-fix-fp-89-a8-4-7.md
+++ b/change_notes/2024-03-22-fix-fp-89-a8-4-7.md
@@ -1,0 +1,2 @@
+- `A8-4-7` - `InParametersForCheapToCopyTypesNotPassedByValue.ql`, `InParametersForCheapToCopyTypesNotPassedByReference.ql`:
+  - Fixes #89. Accidental floor rounding was applying to type size calculations.

--- a/cpp/autosar/src/rules/A8-4-7/TriviallyCopyableSmallType.qll
+++ b/cpp/autosar/src/rules/A8-4-7/TriviallyCopyableSmallType.qll
@@ -12,7 +12,7 @@ int wordSize() { result = max(VoidPointerType v | | v.getSize()) }
  * Converts bytes to words
  */
 bindingset[bytes]
-int bytesToWords(int bytes) { result = bytes / wordSize() }
+float bytesToWords(float bytes) { result = bytes / wordSize() }
 
 class TriviallyCopyableSmallType extends Type {
   TriviallyCopyableSmallType() {

--- a/cpp/autosar/src/rules/A8-4-7/TriviallyCopyableSmallType.qll
+++ b/cpp/autosar/src/rules/A8-4-7/TriviallyCopyableSmallType.qll
@@ -12,11 +12,11 @@ int wordSize() { result = max(VoidPointerType v | | v.getSize()) }
  * Converts bytes to words
  */
 bindingset[bytes]
-int minWordsRequiredToRepresentBytes(int bytes) { result = (1.0*bytes / wordSize()).ceil() }
+int minWordsRequiredToRepresentBytes(int bytes) { result = (1.0 * bytes / wordSize()).ceil() }
 
 class TriviallyCopyableSmallType extends Type {
   TriviallyCopyableSmallType() {
     isTriviallyCopyableType(this) and
-    exists(int size | size = this.getSize() | bytesToWords(size) <= 2)
+    exists(int size | size = this.getSize() | minWordsRequiredToRepresentBytes(size) <= 2)
   }
 }

--- a/cpp/autosar/src/rules/A8-4-7/TriviallyCopyableSmallType.qll
+++ b/cpp/autosar/src/rules/A8-4-7/TriviallyCopyableSmallType.qll
@@ -12,7 +12,7 @@ int wordSize() { result = max(VoidPointerType v | | v.getSize()) }
  * Converts bytes to words
  */
 bindingset[bytes]
-float bytesToWords(float bytes) { result = bytes / wordSize() }
+int minWordsRequiredToRepresentBytes(int bytes) { result = (1.0*bytes / wordSize()).ceil() }
 
 class TriviallyCopyableSmallType extends Type {
   TriviallyCopyableSmallType() {

--- a/cpp/autosar/test/rules/A8-4-7/test.cpp
+++ b/cpp/autosar/test/rules/A8-4-7/test.cpp
@@ -69,3 +69,13 @@ struct S5 {
 void f15(S3 f15a) {} // COMPLIANT
 void f17(S4 f17a) {} // NON_COMPLIANT (S4 has a non-trivial destructor)
 void f18(S5 f18a) {} // COMPLIANT
+
+#include <iostream>
+class A8_4_7 {
+public:
+  std::array<char, 20UL> values;
+};
+void fp_reported_in_82(
+    const A8_4_7 &a847) noexcept { // COMPLIANT - larger than 2 words
+  std::cout << a847.values[0] << std::endl;
+}


### PR DESCRIPTION
## Description

fixes #82 

many points are discussed in the issue, the incorrect definition of trivially copyable was already addressed in another FP report however.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - A8-4-7

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)