### PR TITLE
A18-5-8: address fp report 

### DIFF
--- a/change_notes/2024-05-22-fix-fp-rule-A18-5-8.md
+++ b/change_notes/2024-05-22-fix-fp-rule-A18-5-8.md
@@ -1,0 +1,2 @@
+- `A18-5-8` - `UnnecessaryUseOfDynamicStorage.ql`:
+  - Address FP reported in #20. Add model of flow from MakeSharedOrUnique to return expression to capture copy/move elision case NRVO.

--- a/cpp/autosar/src/rules/A18-5-8/UnnecessaryUseOfDynamicStorage.ql
+++ b/cpp/autosar/src/rules/A18-5-8/UnnecessaryUseOfDynamicStorage.ql
@@ -53,6 +53,9 @@ class MakeSharedOrUnique extends FunctionCall, CandidateFunctionLocalHeapAllocat
     // This includes the case where a result of `make_shared` or `make_unique` is return by a function
     // because the compiler will call the appropriate constructor.
     not exists(FunctionCall fc | DataFlow::localExprFlow(this, fc.getAnArgument())) and
+    // The flow to a return statement is explicitly modelled for the case where
+    // the copy/move constructor is elided and therefore there is no actual function call in the database
+    not exists(ReturnStmt ret | DataFlow::localExprFlow(this, ret.getExpr())) and
     // Not assigned to a field
     not exists(Field f | DataFlow::localExprFlow(this, f.getAnAssignedValue()))
   }

--- a/cpp/autosar/test/rules/A18-5-8/test.cpp
+++ b/cpp/autosar/test/rules/A18-5-8/test.cpp
@@ -69,3 +69,12 @@ StructA *test_failure() {
   }
   return a;
 }
+
+#include <string>
+std::unique_ptr<StructA>
+test_for_fp_reported_in_20(const std::string &s) noexcept {
+  // make_unique performs heap allocation
+  // but this outlives the function due to copy elision
+  // (specifically NRVO)
+  return std::make_unique<StructA>(s); // COMPLIANT
+}


### PR DESCRIPTION
## Description

fixes #20, add return expression flow for [NRVO elision](https://en.cppreference.com/w/cpp/language/copy_elision)

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - A18-5-8

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)