### PR TITLE
M9-3-3: exclude uninstantiated templates from static member function query

### DIFF
--- a/change_notes/2024-06-18-fix-fp-616-M9-3-3.md
+++ b/change_notes/2024-06-18-fix-fp-616-M9-3-3.md
@@ -1,0 +1,2 @@
+- `M9-3-3` - `MemberFunctionStaticIfPossible.ql`:
+  - Fixes #616. Exclude uninstantiated templates.

--- a/cpp/autosar/src/rules/M9-3-3/MemberFunctionStaticIfPossible.ql
+++ b/cpp/autosar/src/rules/M9-3-3/MemberFunctionStaticIfPossible.ql
@@ -31,7 +31,8 @@ class NonStaticMemberFunction extends MemberFunction {
     not this instanceof Constructor and
     not this instanceof Destructor and
     not this instanceof Operator and
-    this.hasDefinition()
+    this.hasDefinition() and
+    not this.isFromUninstantiatedTemplate(_)
   }
 }
 

--- a/cpp/autosar/test/rules/M9-3-3/test.cpp
+++ b/cpp/autosar/test/rules/M9-3-3/test.cpp
@@ -215,3 +215,10 @@ void fp_reported_in_381() {
   int i = z.front();
   z.fill(i);
 }
+
+class ZZ {
+public:
+  template <typename T>
+  void fp_616(const T &val) {
+  } // COMPLIANT - ignore uninstantiated templates for static also
+};


### PR DESCRIPTION
## Description

Fixes #616.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - M9-3-3

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)