### PR TITLE
A3-1-5: change definition of trivial length

### DIFF
--- a/change_notes/2024-07-03-fix-fp-611-A3-1-5.md
+++ b/change_notes/2024-07-03-fix-fp-611-A3-1-5.md
@@ -1,0 +1,2 @@
+- `A3-1-5` - `NonTrivialNonTemplateFunctionDefinedInsideClassDefinition.ql`, `TrivialOrTemplateFunctionDefinedOutsideClassDefinition.ql`:
+  - Fixes #611. Relax definition of trivial length of trivial member function to 10 LOC.

--- a/cpp/autosar/test/rules/A3-1-5/NonTrivialNonTemplateFunctionDefinedInsideClassDefinition.expected
+++ b/cpp/autosar/test/rules/A3-1-5/NonTrivialNonTemplateFunctionDefinedInsideClassDefinition.expected
@@ -1,2 +1,1 @@
-| test.cpp:12:7:12:13 | trivial | Non-Trivial or non-template function trivial is defined in the class body of $@. | test.cpp:2:7:2:7 | A | A |
 | test.cpp:26:7:26:9 | gcd | Non-Trivial or non-template function gcd is defined in the class body of $@. | test.cpp:2:7:2:7 | A | A |

--- a/cpp/autosar/test/rules/A3-1-5/TrivialOrTemplateFunctionDefinedOutsideClassDefinition.expected
+++ b/cpp/autosar/test/rules/A3-1-5/TrivialOrTemplateFunctionDefinedOutsideClassDefinition.expected
@@ -1,7 +1,7 @@
-| test.cpp:58:5:58:11 | getB | The trivial member function getB is not defined in the class body of $@. | test.cpp:2:7:2:7 | A | A |
-| test.cpp:60:25:60:28 | d | The template member function d is not defined in the class body of $@. | test.cpp:2:7:2:7 | A | A |
-| test.cpp:62:5:62:8 | b | The trivial member function b is not defined in the class body of $@. | test.cpp:2:7:2:7 | A | A |
-| test.cpp:81:34:81:57 | complexCalculation | The template member function complexCalculation is not defined in the class body of $@. | test.cpp:64:29:64:29 | B<C> | B<C> |
-| test.cpp:97:47:97:53 | d | The template member function d is not defined in the class body of $@. | test.cpp:64:29:64:29 | B<C> | B<C> |
-| test.cpp:101:27:101:33 | b | The template member function b is not defined in the class body of $@. | test.cpp:64:29:64:29 | B<C> | B<C> |
-| test.cpp:106:27:106:36 | getB | The template member function getB is not defined in the class body of $@. | test.cpp:64:29:64:29 | B<C> | B<C> |
+| test.cpp:65:5:65:11 | getB | The trivial member function getB is not defined in the class body of $@. | test.cpp:2:7:2:7 | A | A |
+| test.cpp:67:25:67:28 | d | The template member function d is not defined in the class body of $@. | test.cpp:2:7:2:7 | A | A |
+| test.cpp:69:5:69:8 | b | The trivial member function b is not defined in the class body of $@. | test.cpp:2:7:2:7 | A | A |
+| test.cpp:88:34:88:57 | complexCalculation | The template member function complexCalculation is not defined in the class body of $@. | test.cpp:71:29:71:29 | B<C> | B<C> |
+| test.cpp:104:47:104:53 | d | The template member function d is not defined in the class body of $@. | test.cpp:71:29:71:29 | B<C> | B<C> |
+| test.cpp:108:27:108:33 | b | The template member function b is not defined in the class body of $@. | test.cpp:71:29:71:29 | B<C> | B<C> |
+| test.cpp:113:27:113:36 | getB | The template member function getB is not defined in the class body of $@. | test.cpp:71:29:71:29 | B<C> | B<C> |

--- a/cpp/autosar/test/rules/A3-1-5/test.cpp
+++ b/cpp/autosar/test/rules/A3-1-5/test.cpp
@@ -9,7 +9,7 @@ public:
 
   int getABar() { return 9; }
 
-  int trivial() { // NON_COMPLIANT
+  int not_trivial() { // COMPLIANT - with threshold of 10 loc
     ;
     ;
     ;

--- a/cpp/autosar/test/rules/A3-1-5/test.cpp
+++ b/cpp/autosar/test/rules/A3-1-5/test.cpp
@@ -28,6 +28,13 @@ public:
       return a;
     int result = gcd(b, (a % b));
     ;
+    ;
+    ;
+    ;
+    ;
+    ;
+    ;
+    ;
     return result;
   }
 
@@ -130,6 +137,13 @@ int FooBar::f1(int a, int b) { // COMPLIANT not a trivial function
     if (b == 0)
       return a;
     int result = FooBar::f1(b, (a % b));
+    ;
+    ;
+    ;
+    ;
+    ;
+    ;
+    ;
     ;
   }
 }

--- a/cpp/common/src/codingstandards/cpp/Class.qll
+++ b/cpp/common/src/codingstandards/cpp/Class.qll
@@ -149,7 +149,8 @@ class IntrospectedMemberFunction extends MemberFunction {
   }
 
   predicate hasTrivialLength() {
-    this.getBlock().getNumStmt() <= 3 and
+    this.getBlock().getLastStmt().getLocation().getStartLine() -
+      this.getBlock().getStmt(0).getLocation().getStartLine() <= 10 and
     not exists(this.getBlock().getStmt(_).getChildStmt())
   }
 

--- a/cpp/common/src/codingstandards/cpp/Class.qll
+++ b/cpp/common/src/codingstandards/cpp/Class.qll
@@ -149,9 +149,7 @@ class IntrospectedMemberFunction extends MemberFunction {
   }
 
   predicate hasTrivialLength() {
-    this.getBlock().getLastStmt().getLocation().getStartLine() -
-      this.getBlock().getStmt(0).getLocation().getStartLine() <= 10 and
-    not exists(this.getBlock().getStmt(_).getChildStmt())
+    this.getBlock().getLocation().getEndLine() - this.getBlock().getLocation().getStartLine() <= 10
   }
 
   predicate isSetter() {


### PR DESCRIPTION
## Description

fixes #611 
relaxed definition of trivial length of trivial member function to 10LOC

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - A3-1-5

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)