### PR TITLE
A7-1-7: exclusions

### DIFF
--- a/change_notes/2024-07-05-fix-fp628-630.md
+++ b/change_notes/2024-07-05-fix-fp628-630.md
@@ -1,0 +1,3 @@
+- `A7-1-7` - `IdentifierDeclarationAndInitializationNotOnSeparateLines.ql`:
+  - Fixes #628. Excludes Functions.
+  - Fixes #630. Excludes struct identifiers and variables on the same line when a typedef is used.

--- a/cpp/autosar/src/rules/A7-1-7/IdentifierDeclarationAndInitializationNotOnSeparateLines.ql
+++ b/cpp/autosar/src/rules/A7-1-7/IdentifierDeclarationAndInitializationNotOnSeparateLines.ql
@@ -23,12 +23,10 @@ class UniqueLineStmt extends Locatable {
       this = d.getADeclarationEntry() and
       not d instanceof Parameter and
       not d instanceof TemplateParameter and
-      not d instanceof FunctionTemplateSpecialization and
       // TODO - Needs to be enhanced to solve issues with
       // templated inner classes.
-      not d instanceof MemberFunction and
+      not d instanceof Function and
       not d.isFromTemplateInstantiation(_) and
-      not d.(Function).isCompilerGenerated() and
       not d.(Variable).isCompilerGenerated() and
       not exists(RangeBasedForStmt f | f.getADeclaration() = d) and
       not exists(DeclStmt declStmt, ForStmt f |
@@ -52,6 +50,9 @@ where
     DeclarationsPackage::identifierDeclarationAndInitializationNotOnSeparateLinesQuery()) and
   not e1 = e2 and
   not e1.(DeclarationEntry) = e2 and
+  //omit the cases where there is one struct identifier on a struct var line used with typedef
+  not exists(Struct s | s.getADeclarationEntry() = e1 and e1 instanceof TypeDeclarationEntry) and
+  not exists(Struct s | s.getATypeNameUse() = e1 and e1 instanceof TypeDeclarationEntry) and
   exists(Location l1, Location l2 |
     e1.getLocation() = l1 and
     e2.getLocation() = l2 and

--- a/cpp/autosar/test/rules/A7-1-7/IdentifierDeclarationAndInitializationNotOnSeparateLines.expected
+++ b/cpp/autosar/test/rules/A7-1-7/IdentifierDeclarationAndInitializationNotOnSeparateLines.expected
@@ -26,3 +26,4 @@
 | test.cpp:66:12:66:12 | definition of g | Expression statement and identifier are on the same line. |
 | test.cpp:82:7:82:10 | definition of S3_a | Expression statement and identifier are on the same line. |
 | test.cpp:82:17:82:20 | definition of S3_b | Expression statement and identifier are on the same line. |
+| test.cpp:154:24:154:24 | definition of y | Expression statement and identifier are on the same line. |

--- a/cpp/autosar/test/rules/A7-1-7/test.cpp
+++ b/cpp/autosar/test/rules/A7-1-7/test.cpp
@@ -147,3 +147,9 @@ struct s_357 {
     // clang-format on
   }
 };
+
+void example_function() { f1(); } // COMPLIANT
+
+// clang-format off
+typedef struct x { int y; } z; //COMPLIANT - for struct typedef and struct var //NON_COMPLIANT - for struct all on one line
+// clang-format on


### PR DESCRIPTION
exclude functions
exclude struct identifiers and variables
when used with typedefs

## Description

Fixes #628. Fixes #630.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - A7-1-7

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)