### PR TITLE
A7-1-1: improve template handling

### DIFF
--- a/change_notes/2024-07-05-fix-fp-621-A7-1-1.md
+++ b/change_notes/2024-07-05-fix-fp-621-A7-1-1.md
@@ -1,0 +1,2 @@
+- `A7-1-1` - `DeclarationUnmodifiedObjectMissingConstSpecifier.ql`:
+  - Fixes #621. Exclude template instantiations that come from constexpr templates.

--- a/cpp/autosar/src/rules/A7-1-1/DeclarationUnmodifiedObjectMissingConstSpecifier.ql
+++ b/cpp/autosar/src/rules/A7-1-1/DeclarationUnmodifiedObjectMissingConstSpecifier.ql
@@ -37,5 +37,7 @@ where
   ) and
   not exists(LambdaExpression lc | lc.getACapture().getField() = v) and
   not v.isFromUninstantiatedTemplate(_) and
-  not v.isCompilerGenerated()
+  not v.isCompilerGenerated() and
+  //if the instantiation is not constexpr but the template is, still exclude it as a candidate
+  not exists(TemplateVariable b | b.getAnInstantiation() = v and b.isConstexpr())
 select v, "Non-constant variable " + v.getName() + cond + " and is not modified."

--- a/cpp/autosar/test/rules/A7-1-1/test.cpp
+++ b/cpp/autosar/test/rules/A7-1-1/test.cpp
@@ -77,3 +77,10 @@ int main(int, char **) noexcept {
 
   (new Issue18)->F(0);
 }
+
+template <bool... Args> extern constexpr bool recurse_var = true; // COMPLIANT
+
+template <bool B1, bool... Args>
+extern constexpr bool recurse_var<B1, Args...> = B1 &&recurse_var<Args...>;
+
+void fp_621() { recurse_var<true, true, true>; }


### PR DESCRIPTION
## Description

Fixes #621 

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - A7-1-1

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)