### PR TITLE
C++: Accept test changes from #16969

### DIFF
--- a/cpp/common/test/rules/validcontainerelementaccess/ValidContainerElementAccess.expected
+++ b/cpp/common/test/rules/validcontainerelementaccess/ValidContainerElementAccess.expected
@@ -7,4 +7,6 @@
 | test.cpp:89:15:89:16 | it | Elements of $@ not accessed with valid reference, pointer, or iterator because of a prior $@. | test.cpp:86:20:86:20 | d | container | test.cpp:92:7:92:12 | call to insert | invalidation |
 | test.cpp:91:9:91:10 | it | Elements of $@ not accessed with valid reference, pointer, or iterator because of a prior $@. | test.cpp:86:20:86:20 | d | container | test.cpp:92:7:92:12 | call to insert | invalidation |
 | test.cpp:98:56:98:58 | loc | Elements of $@ not accessed with valid reference, pointer, or iterator because of a prior $@. | test.cpp:96:44:96:46 | str | container | test.cpp:99:9:99:14 | call to insert | invalidation |
+| test.cpp:99:5:99:7 | str | Elements of $@ not accessed with valid reference, pointer, or iterator because of a prior $@. | test.cpp:96:44:96:46 | str | container | test.cpp:99:9:99:14 | call to insert | invalidation |
 | test.cpp:99:16:99:18 | loc | Elements of $@ not accessed with valid reference, pointer, or iterator because of a prior $@. | test.cpp:96:44:96:46 | str | container | test.cpp:99:9:99:14 | call to insert | invalidation |
+| test.cpp:106:11:106:13 | str | Elements of $@ not accessed with valid reference, pointer, or iterator because of a prior $@. | test.cpp:103:45:103:47 | str | container | test.cpp:106:15:106:20 | call to insert | invalidation |

--- a/cpp/common/test/rules/validcontainerelementaccess/test.cpp
+++ b/cpp/common/test/rules/validcontainerelementaccess/test.cpp
@@ -96,14 +96,14 @@ void f8(const int *ar) {
 void f9(const std::string &s, std::string &str) {
   std::string::iterator loc = str.begin();
   for (auto i = s.begin(), e = s.end(); i != e; ++i, ++loc) { // NON_COMPLIANT
-    str.insert(loc, 'c');                                     // NON_COMPLIANT
+    str.insert(loc, 'c');                                     // NON_COMPLIANT[FALSE POSITIVE for str]
   }
 }
 
 void f10(const std::string &s, std::string &str) {
   std::string::iterator loc = str.begin();
   for (auto i = s.begin(), e = s.end(); i != e; ++i, ++loc) { // COMPLIANT
-    loc = str.insert(loc, 'c');                               // COMPLIANT
+    loc = str.insert(loc, 'c');                               // COMPLIANT[FALSE POSITIVE]
   }
 }
 

--- a/cpp/common/test/rules/validcontainerelementaccess/test.cpp
+++ b/cpp/common/test/rules/validcontainerelementaccess/test.cpp
@@ -96,14 +96,14 @@ void f8(const int *ar) {
 void f9(const std::string &s, std::string &str) {
   std::string::iterator loc = str.begin();
   for (auto i = s.begin(), e = s.end(); i != e; ++i, ++loc) { // NON_COMPLIANT
-    str.insert(loc, 'c');                                     // NON_COMPLIANT[FALSE POSITIVE for str]
+    str.insert(loc, 'c'); // NON_COMPLIANT[FALSE POSITIVE for str]
   }
 }
 
 void f10(const std::string &s, std::string &str) {
   std::string::iterator loc = str.begin();
   for (auto i = s.begin(), e = s.end(); i != e; ++i, ++loc) { // COMPLIANT
-    loc = str.insert(loc, 'c');                               // COMPLIANT[FALSE POSITIVE]
+    loc = str.insert(loc, 'c'); // COMPLIANT[FALSE POSITIVE]
   }
 }
 


### PR DESCRIPTION
## Description

In https://github.com/github/codeql/pull/16969 we fix a problem where string taint functions didn't recognize iterator parameters hidden behind typedefs and/or specifiers. Once we did this, we saw a couple of test changes on the Coding Standards repo (which is accepted in this PR). We also tried to make the above PR more robust by allowing both specifiers and unspecified types to be recognized as iterators, but this didn't fix the regression. So for now we're just accepting the new FPs if that's okay with you folks.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)