### PR TITLE
A12-8-6: Update tests around unused template special members.

### DIFF
--- a/cpp/autosar/test/rules/A12-8-6/CopyAndMoveNotDeclaredProtected.expected
+++ b/cpp/autosar/test/rules/A12-8-6/CopyAndMoveNotDeclaredProtected.expected
@@ -20,7 +20,3 @@
 | test.cpp:109:3:109:12 | declaration of BaseClass8 | Move constructor for base class 'BaseClass8' is not declared protected. |
 | test.cpp:110:15:110:23 | declaration of operator= | Copy assignment operator for base class 'BaseClass8' is not declared protected. |
 | test.cpp:111:15:111:23 | declaration of operator= | Move assignment operator for base class 'BaseClass8' is not declared protected. |
-| test.cpp:124:26:124:26 | declaration of BaseClass9 | Implicit copy constructor for base class 'BaseClass9<int>' is not declared deleted. |
-| test.cpp:124:26:124:26 | declaration of BaseClass9 | Implicit move constructor for base class 'BaseClass9<int>' is not declared deleted. |
-| test.cpp:124:26:124:26 | declaration of operator= | Implicit copy assignment operator for base class 'BaseClass9<int>' is not declared deleted. |
-| test.cpp:124:26:124:26 | declaration of operator= | Implicit move assignment operator for base class 'BaseClass9<int>' is not declared deleted. |


### PR DESCRIPTION
We have recently fixed a bug in database creation where compiler-generated special members of template classes were unconditionally included in the database. They are now only included when used, consistently with other member functions and with the C++ Standard. This PR updates the tests to reflect this change.