### PR TITLE
Fix #1869 Compiler Compatability for clang for CERT-C++ rule DCL51-CPP

### DIFF
--- a/cpp/cert/test/rules/DCL51-CPP/FunctionReusesReservedName.expected
+++ b/cpp/cert/test/rules/DCL51-CPP/FunctionReusesReservedName.expected
@@ -1,1 +1,1 @@
-| test.cpp:20:6:20:8 | min | The function $@ reuses a reserved standard library name. | test.cpp:20:6:20:8 | min | min |
+| test.cpp:22:6:22:8 | min | The function $@ reuses a reserved standard library name. | test.cpp:22:6:22:8 | min | min |

--- a/cpp/cert/test/rules/DCL51-CPP/ObjectReusesReservedName.expected
+++ b/cpp/cert/test/rules/DCL51-CPP/ObjectReusesReservedName.expected
@@ -1,1 +1,1 @@
-| test.cpp:18:7:18:12 | tzname | The variable $@ reuses a reserved standard library name. | test.cpp:18:7:18:12 | tzname | tzname |
+| test.cpp:18:20:18:25 | tzname | The variable $@ reuses a reserved standard library name. | test.cpp:18:20:18:25 | tzname | tzname |

--- a/cpp/cert/test/rules/DCL51-CPP/ObjectReusesReservedName.expected
+++ b/cpp/cert/test/rules/DCL51-CPP/ObjectReusesReservedName.expected
@@ -1,1 +1,1 @@
-| test.cpp:18:20:18:25 | tzname | The variable $@ reuses a reserved standard library name. | test.cpp:18:20:18:25 | tzname | tzname |
+| test.cpp:19:5:19:10 | tzname | The variable $@ reuses a reserved standard library name. | test.cpp:19:5:19:10 | tzname | tzname |

--- a/cpp/cert/test/rules/DCL51-CPP/ObjectReusesReservedName.expected
+++ b/cpp/cert/test/rules/DCL51-CPP/ObjectReusesReservedName.expected
@@ -1,1 +1,1 @@
-| test.cpp:18:5:18:10 | tzname | The variable $@ reuses a reserved standard library name. | test.cpp:18:5:18:10 | tzname | tzname |
+| test.cpp:18:7:18:12 | tzname | The variable $@ reuses a reserved standard library name. | test.cpp:18:7:18:12 | tzname | tzname |

--- a/cpp/cert/test/rules/DCL51-CPP/RedefiningOfStandardLibraryName.expected
+++ b/cpp/cert/test/rules/DCL51-CPP/RedefiningOfStandardLibraryName.expected
@@ -1,3 +1,3 @@
 | test.cpp:6:1:6:14 | #undef INT_MAX | Redefinition of INT_MAX declared in a standard library header. |
 | test.cpp:7:1:7:20 | #define SIZE_MAX 256 | Redefinition of SIZE_MAX declared in a standard library header. |
-| test.cpp:37:1:38:9 | #define FD_SET(X) int _ ## X | Redefinition of FD_SET declared in a standard library header. |
+| test.cpp:39:1:40:9 | #define FD_SET(X) int _ ## X | Redefinition of FD_SET declared in a standard library header. |

--- a/cpp/cert/test/rules/DCL51-CPP/UseOfDoubleUnderscoreReservedPrefix.expected
+++ b/cpp/cert/test/rules/DCL51-CPP/UseOfDoubleUnderscoreReservedPrefix.expected
@@ -1,2 +1,2 @@
-| test.cpp:25:5:25:7 | __x | Name $@ uses the reserved prefix '__'. | test.cpp:25:5:25:7 | __x | __x |
-| test.cpp:30:5:30:7 | __x | Name $@ uses the reserved prefix '__'. | test.cpp:30:5:30:7 | __x | __x |
+| test.cpp:27:5:27:7 | __x | Name $@ uses the reserved prefix '__'. | test.cpp:27:5:27:7 | __x | __x |
+| test.cpp:32:5:32:7 | __x | Name $@ uses the reserved prefix '__'. | test.cpp:32:5:32:7 | __x | __x |

--- a/cpp/cert/test/rules/DCL51-CPP/UseOfReservedLiteralSuffixIdentifier.expected
+++ b/cpp/cert/test/rules/DCL51-CPP/UseOfReservedLiteralSuffixIdentifier.expected
@@ -1,1 +1,1 @@
-| test.cpp:22:6:22:17 | operator ""x | Literal suffix identifier $@ does not start with an underscore. | test.cpp:22:6:22:17 | operator ""x | operator ""x |
+| test.cpp:24:6:24:17 | operator ""x | Literal suffix identifier $@ does not start with an underscore. | test.cpp:24:6:24:17 | operator ""x | operator ""x |

--- a/cpp/cert/test/rules/DCL51-CPP/UseOfSingleUnderscoreReservedPrefix.expected
+++ b/cpp/cert/test/rules/DCL51-CPP/UseOfSingleUnderscoreReservedPrefix.expected
@@ -1,5 +1,5 @@
-| test.cpp:26:5:26:6 | _X | Name $@ uses the reserved prefix '_'. | test.cpp:26:5:26:6 | _X | _X |
-| test.cpp:27:5:27:6 | _x | Name $@ uses the reserved prefix '_'. | test.cpp:27:5:27:6 | _x | _x |
-| test.cpp:31:5:31:6 | _X | Name $@ uses the reserved prefix '_'. | test.cpp:31:5:31:6 | _X | _X |
-| test.cpp:35:1:35:3 | _i | Name $@ uses the reserved prefix '_'. | test.cpp:35:1:35:3 | _i | _i |
+| test.cpp:28:5:28:6 | _X | Name $@ uses the reserved prefix '_'. | test.cpp:28:5:28:6 | _X | _X |
+| test.cpp:29:5:29:6 | _x | Name $@ uses the reserved prefix '_'. | test.cpp:29:5:29:6 | _x | _x |
+| test.cpp:33:5:33:6 | _X | Name $@ uses the reserved prefix '_'. | test.cpp:33:5:33:6 | _X | _X |
+| test.cpp:37:1:37:3 | _i | Name $@ uses the reserved prefix '_'. | test.cpp:37:1:37:3 | _i | _i |
 | test.h:2:1:2:15 | #define _TEST_H | Name $@ uses the reserved prefix '_'. | test.h:2:1:2:15 | #define _TEST_H | _TEST_H |

--- a/cpp/cert/test/rules/DCL51-CPP/test.cpp
+++ b/cpp/cert/test/rules/DCL51-CPP/test.cpp
@@ -15,7 +15,7 @@ enum {
 
 // int NULL = 0; // NON_COMPLIANT, but not supported by compilers in practice
 
-char *tzname[2]; // NON_COMPLIANT
+namespace ns { int tzname = 0; } // NON_COMPLIANT
 
 void min() {} // NON_COMPLIANT
 

--- a/cpp/cert/test/rules/DCL51-CPP/test.cpp
+++ b/cpp/cert/test/rules/DCL51-CPP/test.cpp
@@ -15,7 +15,9 @@ enum {
 
 // int NULL = 0; // NON_COMPLIANT, but not supported by compilers in practice
 
-namespace ns { int tzname = 0; } // NON_COMPLIANT
+namespace ns {
+int tzname = 0; // NON_COMPLIANT
+}
 
 void min() {} // NON_COMPLIANT
 

--- a/cpp/cert/test/rules/DCL51-CPP/test.cpp
+++ b/cpp/cert/test/rules/DCL51-CPP/test.cpp
@@ -15,7 +15,7 @@ enum {
 
 // int NULL = 0; // NON_COMPLIANT, but not supported by compilers in practice
 
-int tzname = 0; // NON_COMPLIANT
+char* tzname[2]; // NON_COMPLIANT
 
 void min() {} // NON_COMPLIANT
 

--- a/cpp/cert/test/rules/DCL51-CPP/test.cpp
+++ b/cpp/cert/test/rules/DCL51-CPP/test.cpp
@@ -15,7 +15,7 @@ enum {
 
 // int NULL = 0; // NON_COMPLIANT, but not supported by compilers in practice
 
-char* tzname[2]; // NON_COMPLIANT
+char *tzname[2]; // NON_COMPLIANT
 
 void min() {} // NON_COMPLIANT
 


### PR DESCRIPTION
tzname is char*[2] in the standard libraries of both clang and gcc. This will allow the test code to compile, and still triggers a non-compliance query result.

## Description

Change test code from `int tzname` to be of type `char*[2]`, to be compatible with clang std time.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)