### PR TITLE
`RULE-12-2`: Address common false positives and improve description

### DIFF
--- a/c/misra/src/codingstandards/c/misra/EssentialTypes.qll
+++ b/c/misra/src/codingstandards/c/misra/EssentialTypes.qll
@@ -355,13 +355,17 @@ class EssentialLiteral extends EssentialExpr, Literal {
     else (
       if this.(CharLiteral).getCharacter().length() = 1
       then result instanceof PlainCharType
-      else (
-        getStandardType().(IntegralType).isSigned() and
-        result = stlr(this)
-        or
-        not getStandardType().(IntegralType).isSigned() and
-        result = utlr(this)
-      )
+      else
+        exists(Type underlyingStandardType |
+          underlyingStandardType = getStandardType().getUnderlyingType()
+        |
+          if underlyingStandardType instanceof IntType
+          then
+            if underlyingStandardType.(IntType).isSigned()
+            then result = stlr(this)
+            else result = utlr(this)
+          else result = underlyingStandardType
+        )
     )
   }
 }

--- a/c/misra/test/c/misra/EssentialTypes.expected
+++ b/c/misra/test/c/misra/EssentialTypes.expected
@@ -38,3 +38,6 @@
 | test.c:26:3:26:3 | f | float | float | essentially Floating type |
 | test.c:27:3:27:5 | f32 | float32_t | float32_t | essentially Floating type |
 | test.c:28:3:28:6 | cf32 | float | float | essentially Floating type |
+| test.c:32:3:32:3 | 1 | signed char | signed char | essentially Signed type |
+| test.c:33:3:33:4 | 1 | unsigned char | unsigned char | essentially Unsigned type |
+| test.c:34:3:34:5 | 1 | unsigned long | unsigned long | essentially Unsigned type |

--- a/c/misra/test/c/misra/test.c
+++ b/c/misra/test/c/misra/test.c
@@ -27,3 +27,9 @@ void testCategoriesForComplexTypes() {
   f32;  // Should be essentially Floating type
   cf32; // Should be essentially Floating type
 }
+
+void testConstants() {
+  1;   // Essentially signed char
+  1U;  // Essentially unsigned char
+  1UL; // Essentially unsigned long
+}

--- a/c/misra/test/rules/RULE-12-2/RightHandOperandOfAShiftRange.expected
+++ b/c/misra/test/rules/RULE-12-2/RightHandOperandOfAShiftRange.expected
@@ -8,3 +8,6 @@
 | test.c:25:10:25:10 | 8 | The right hand operand of the shift operator shall lie in the range 0 to 7. |
 | test.c:26:10:26:11 | 64 | The right hand operand of the shift operator shall lie in the range 0 to 7. |
 | test.c:30:16:30:17 | 64 | The right hand operand of the shift operator shall lie in the range 0 to 63. |
+| test.c:34:8:34:8 | y | The right hand operand of the shift operator shall lie in the range 0 to 31. |
+| test.c:40:8:40:8 | y | The right hand operand of the shift operator shall lie in the range 0 to 31. |
+| test.c:42:8:42:8 | y | The right hand operand of the shift operator shall lie in the range 0 to 31. |

--- a/c/misra/test/rules/RULE-12-2/RightHandOperandOfAShiftRange.expected
+++ b/c/misra/test/rules/RULE-12-2/RightHandOperandOfAShiftRange.expected
@@ -1,13 +1,12 @@
-| test.c:8:10:8:10 | 8 | The right hand operand of the shift operator shall lie in the range 0 to 7. |
-| test.c:9:10:9:11 | - ... | The right hand operand of the shift operator shall lie in the range 0 to 7. |
-| test.c:10:10:10:14 | ... + ... | The right hand operand of the shift operator shall lie in the range 0 to 7. |
-| test.c:11:10:11:14 | ... + ... | The right hand operand of the shift operator shall lie in the range 0 to 7. |
-| test.c:13:21:13:22 | 16 | The right hand operand of the shift operator shall lie in the range 0 to 15. |
-| test.c:16:9:16:9 | 8 | The right hand operand of the shift operator shall lie in the range 0 to 7. |
-| test.c:21:9:21:10 | 64 | The right hand operand of the shift operator shall lie in the range 0 to 63. |
-| test.c:25:10:25:10 | 8 | The right hand operand of the shift operator shall lie in the range 0 to 7. |
-| test.c:26:10:26:11 | 64 | The right hand operand of the shift operator shall lie in the range 0 to 7. |
-| test.c:30:16:30:17 | 64 | The right hand operand of the shift operator shall lie in the range 0 to 63. |
-| test.c:34:8:34:8 | y | The right hand operand of the shift operator shall lie in the range 0 to 31. |
-| test.c:40:8:40:8 | y | The right hand operand of the shift operator shall lie in the range 0 to 31. |
-| test.c:42:8:42:8 | y | The right hand operand of the shift operator shall lie in the range 0 to 31. |
+| test.c:8:10:8:10 | 8 | The possible range of the right operand of the shift operator (8..8) is outside the the valid shift range (0..7) for the essential type of the left operand (uint8_t). | test.c:8:3:8:10 | ... >> ... |  |
+| test.c:9:10:9:11 | - ... | The possible range of the right operand of the shift operator (-1..-1) is outside the the valid shift range (0..7) for the essential type of the left operand (uint8_t). | test.c:9:3:9:11 | ... >> ... |  |
+| test.c:10:10:10:14 | ... + ... | The possible range of the right operand of the shift operator (8..8) is outside the the valid shift range (0..7) for the essential type of the left operand (uint8_t). | test.c:10:3:10:14 | ... >> ... |  |
+| test.c:11:10:11:14 | ... + ... | The possible range of the right operand of the shift operator (8..8) is outside the the valid shift range (0..7) for the essential type of the left operand (uint8_t). | test.c:11:3:11:14 | ... << ... |  |
+| test.c:13:21:13:22 | 16 | The possible range of the right operand of the shift operator (16..16) is outside the the valid shift range (0..15) for the essential type of the left operand (uint16_t). | test.c:13:3:13:22 | ... << ... |  |
+| test.c:16:9:16:9 | 8 | The possible range of the right operand of the shift operator (8..8) is outside the the valid shift range (0..7) for the essential type of the left operand (unsigned char). | test.c:16:3:16:9 | ... << ... |  |
+| test.c:21:9:21:10 | 64 | The possible range of the right operand of the shift operator (64..64) is outside the the valid shift range (0..63) for the essential type of the left operand (unsigned long). | test.c:21:3:21:10 | ... << ... |  |
+| test.c:26:10:26:11 | 64 | The possible range of the right operand of the shift operator (64..64) is outside the the valid shift range (0..63) for the essential type of the left operand (unsigned long). | test.c:26:3:26:11 | ... << ... |  |
+| test.c:30:16:30:17 | 64 | The possible range of the right operand of the shift operator (64..64) is outside the the valid shift range (0..63) for the essential type of the left operand (unsigned long). | test.c:30:3:30:17 | ... << ... |  |
+| test.c:34:8:34:8 | y | The possible range of the right operand of the shift operator (0..4294967295) is outside the the valid shift range (0..31) for the essential type of the left operand (unsigned int). | test.c:34:3:34:8 | ... >> ... |  |
+| test.c:40:8:40:8 | y | The possible range of the right operand of the shift operator (-2147483648..2147483647) is outside the the valid shift range (0..31) for the essential type of the left operand (signed int). | test.c:40:3:40:8 | ... >> ... |  |
+| test.c:42:8:42:8 | y | The possible range of the right operand of the shift operator (-31..31) is outside the the valid shift range (0..31) for the essential type of the left operand (signed int). | test.c:42:3:42:8 | ... >> ... |  |

--- a/c/misra/test/rules/RULE-12-2/test.c
+++ b/c/misra/test/rules/RULE-12-2/test.c
@@ -29,3 +29,15 @@ void f1() {
   ULONG_MAX << 8;  // COMPLIANT
   ULONG_MAX << 64; // NON_COMPLIANT
 }
+
+void unsignedRemAssign(unsigned int y, unsigned int x) {
+  x >> y; // NON_COMPLIANT
+  y %= 32;
+  x >> y; // COMPLIANT
+}
+
+void signedRemAssign(signed int y, signed int x) {
+  x >> y; // NON_COMPLIANT
+  y %= 32;
+  x >> y; // NON_COMPLIANT - may be negative
+}

--- a/change_notes/2024-09-11-rule-12-2-improvements.md
+++ b/change_notes/2024-09-11-rule-12-2-improvements.md
@@ -1,0 +1,6 @@
+- `RULE-12-2` - `RightHandOperandOfAShiftRange.ql`:
+  - Reduce false positives related to ranges determined by `%=`.
+  - Reduce false positives for integer constants with explicit size suffix were incorrectly identified as smaller types.
+  - Improve explanation of results, providing additional information on types and size ranges.
+  - Combine results stemming from the expansion of a macro, where the result is not dependent on the context.
+  

--- a/cpp/common/src/codingstandards/cpp/SimpleRangeAnalysisCustomizations.qll
+++ b/cpp/common/src/codingstandards/cpp/SimpleRangeAnalysisCustomizations.qll
@@ -161,7 +161,7 @@ private class RemAssignSimpleRange extends SimpleRangeAnalysisExpr, AssignRemExp
       maxDivisorNegated = (getFullyConvertedUpperBounds(getRValue()).abs() - 1) * -1 and
       // Find the lower bounds of the dividend
       dividendLowerBounds = getFullyConvertedLowerBounds(getLValue()) and
-      // The lower bound is caluclated in two steps:
+      // The lower bound is calculated in two steps:
       // 1. Determine the maximum of the dividend lower bound and maxDivisorNegated.
       //    When the dividend is negative this will result in a negative result
       // 2. Find the minimum with 0. If the divided is always >0 this will produce 0
@@ -172,7 +172,6 @@ private class RemAssignSimpleRange extends SimpleRangeAnalysisExpr, AssignRemExp
   }
 
   override float getUpperBounds() {
-    // TODO rem zero?
     exists(float maxDivisor, float maxDividend |
       // The maximum divisor value is the absolute value of the divisor minus 1
       maxDivisor = getFullyConvertedUpperBounds(getRValue()).abs() - 1 and

--- a/cpp/common/src/codingstandards/cpp/SimpleRangeAnalysisCustomizations.qll
+++ b/cpp/common/src/codingstandards/cpp/SimpleRangeAnalysisCustomizations.qll
@@ -152,6 +152,41 @@ private class CastEnumToIntegerSimpleRange extends SimpleRangeAnalysisExpr, Cast
 }
 
 /**
+ * A range analysis extension that supports `%=`.
+ */
+private class RemAssignSimpleRange extends SimpleRangeAnalysisExpr, AssignRemExpr {
+  override float getLowerBounds() {
+    exists(float maxDivisorNegated, float dividendLowerBounds |
+      // Find the max divisor, negated e.g. `%= 32` would be  `-31`
+      maxDivisorNegated = (getFullyConvertedUpperBounds(getRValue()).abs() - 1) * -1 and
+      // Find the lower bounds of the dividend
+      dividendLowerBounds = getFullyConvertedLowerBounds(getLValue()) and
+      // The lower bound is caluclated in two steps:
+      // 1. Determine the maximum of the dividend lower bound and maxDivisorNegated.
+      //    When the dividend is negative this will result in a negative result
+      // 2. Find the minimum with 0. If the divided is always >0 this will produce 0
+      //    otherwise it will produce the lowest negative number that can be held
+      //    after the modulo.
+      result = 0.minimum(dividendLowerBounds.maximum(maxDivisorNegated))
+    )
+  }
+
+  override float getUpperBounds() {
+    // TODO rem zero?
+    exists(float maxDivisor, float maxDividend |
+      // The maximum divisor value is the absolute value of the divisor minus 1
+      maxDivisor = getFullyConvertedUpperBounds(getRValue()).abs() - 1 and
+      // value if > 0 otherwise 0
+      maxDividend = getFullyConvertedUpperBounds(getLValue()).maximum(0) and
+      // In the case the numerator is definitely less than zero, the result could be negative
+      result = maxDividend.minimum(maxDivisor)
+    )
+  }
+
+  override predicate dependsOnChild(Expr expr) { expr = getAChild() }
+}
+
+/**
  * <stdio.h> functions that read a character from the STDIN,
  * or return EOF if it fails to do so.
  * Their return type is `int` by their signatures, but


### PR DESCRIPTION
## Description

 - Fixes #682 - handle `%=` when considering the range of expressions.
 - Fixes #683 - correctly identify the essential type of integer constants with size suffixes.
 - Improve reporting by compressing results caused by a macro expansion (which is not context dependent)
 - Improve reporting by providing more size and type information.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `RULE-12-2`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)