### PR TITLE
RULE-5-8: Only consider declarations conflicting if they occur in the same link target

### DIFF
--- a/change_notes/2024-09-16-rule-5-8-consider-linkage.md
+++ b/change_notes/2024-09-16-rule-5-8-consider-linkage.md
@@ -1,0 +1,2 @@
+ - `RULE-5-8` - `IdentifiersWithExternalLinkageNotUnique.ql`
+   - Remove false positives where conflicting declarations do not appear in the same link target.


### PR DESCRIPTION
## Description

Fixes #685.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `RULE-5-8`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)