### PR TITLE
`RULE-10-1`: Handle unary operators correctly

### DIFF
--- a/c/misra/src/codingstandards/c/misra/EssentialTypes.qll
+++ b/c/misra/src/codingstandards/c/misra/EssentialTypes.qll
@@ -179,6 +179,10 @@ class EssentialBinaryLogicalOperationExpr extends EssentialExpr, BinaryLogicalOp
   override Type getEssentialType() { result instanceof BoolType }
 }
 
+class EssentialUnaryLogicalOperationExpr extends EssentialExpr, UnaryLogicalOperation {
+  override Type getEssentialType() { result instanceof BoolType }
+}
+
 class EssentialEqualityOperationExpr extends EssentialExpr, EqualityOperation {
   override Type getEssentialType() { result instanceof BoolType }
 }

--- a/c/misra/src/rules/RULE-10-1/OperandsOfAnInappropriateEssentialType.ql
+++ b/c/misra/src/rules/RULE-10-1/OperandsOfAnInappropriateEssentialType.ql
@@ -178,7 +178,8 @@ predicate isInappropriateEssentialType(
     child =
       [
         operator.(BinaryBitwiseOperation).getAnOperand(),
-        operator.(Bitwise::AssignBitwiseOperation).getAnOperand()
+        operator.(Bitwise::AssignBitwiseOperation).getAnOperand(),
+        operator.(ComplementExpr).getAnOperand()
       ] and
     not operator instanceof LShiftExpr and
     not operator instanceof RShiftExpr and
@@ -240,7 +241,7 @@ string getRationaleMessage(int rationaleId, EssentialTypeCategory etc) {
   result = "Bitwise operator applied to operand of " + etc + " and not essentially unsigned."
   or
   rationaleId = 7 and
-  result = "Right hand operatand of shift operator is " + etc + " and not not essentially unsigned."
+  result = "Right hand operand of shift operator is " + etc + " and not not essentially unsigned."
   or
   rationaleId = 8 and
   result =
@@ -251,4 +252,4 @@ from Expr operator, Expr child, int rationaleId, EssentialTypeCategory etc
 where
   not isExcluded(operator, EssentialTypesPackage::operandsOfAnInappropriateEssentialTypeQuery()) and
   isInappropriateEssentialType(operator, child, etc, rationaleId)
-select operator, getRationaleMessage(rationaleId, etc)
+select child, getRationaleMessage(rationaleId, etc)

--- a/c/misra/test/c/misra/EssentialTypes.expected
+++ b/c/misra/test/c/misra/EssentialTypes.expected
@@ -41,3 +41,35 @@
 | test.c:32:3:32:3 | 1 | signed char | signed char | essentially Signed type |
 | test.c:33:3:33:4 | 1 | unsigned char | unsigned char | essentially Unsigned type |
 | test.c:34:3:34:5 | 1 | unsigned long | unsigned long | essentially Unsigned type |
+| test.c:38:13:38:16 | 1 | bool | bool | essentially Boolean type |
+| test.c:38:13:38:16 | (bool)... | bool | bool | essentially Boolean type |
+| test.c:39:20:39:20 | 1 | signed char | signed char | essentially Signed type |
+| test.c:39:20:39:20 | (unsigned int)... | unsigned int | unsigned int | essentially Unsigned type |
+| test.c:40:23:40:23 | 1 | signed char | signed char | essentially Signed type |
+| test.c:40:23:40:23 | (unsigned short)... | unsigned short | unsigned short | essentially Unsigned type |
+| test.c:41:17:41:18 | 1 | signed char | signed char | essentially Signed type |
+| test.c:42:21:42:21 | 1 | signed char | signed char | essentially Signed type |
+| test.c:42:21:42:21 | (signed short)... | signed short | signed short | essentially Signed type |
+| test.c:44:3:44:4 | ! ... | bool | bool | essentially Boolean type |
+| test.c:44:4:44:4 | b | bool | bool | essentially Boolean type |
+| test.c:45:3:45:4 | ! ... | bool | bool | essentially Boolean type |
+| test.c:45:4:45:4 | u | unsigned int | unsigned int | essentially Unsigned type |
+| test.c:46:3:46:5 | ! ... | bool | bool | essentially Boolean type |
+| test.c:46:4:46:5 | us | unsigned short | unsigned short | essentially Unsigned type |
+| test.c:47:3:47:4 | ! ... | bool | bool | essentially Boolean type |
+| test.c:47:4:47:4 | s | signed int | signed int | essentially Signed type |
+| test.c:48:3:48:5 | ! ... | bool | bool | essentially Boolean type |
+| test.c:48:4:48:5 | ss | signed short | signed short | essentially Signed type |
+| test.c:50:3:50:4 | ~ ... | int | int | essentially Signed type |
+| test.c:50:4:50:4 | (int)... | int | int | essentially Signed type |
+| test.c:50:4:50:4 | b | bool | bool | essentially Boolean type |
+| test.c:51:3:51:4 | ~ ... | unsigned int | unsigned int | essentially Unsigned type |
+| test.c:51:4:51:4 | u | unsigned int | unsigned int | essentially Unsigned type |
+| test.c:52:3:52:5 | ~ ... | unsigned short | unsigned short | essentially Unsigned type |
+| test.c:52:4:52:5 | (int)... | int | int | essentially Signed type |
+| test.c:52:4:52:5 | us | unsigned short | unsigned short | essentially Unsigned type |
+| test.c:53:3:53:4 | ~ ... | signed int | signed int | essentially Signed type |
+| test.c:53:4:53:4 | s | signed int | signed int | essentially Signed type |
+| test.c:54:3:54:5 | ~ ... | int | int | essentially Signed type |
+| test.c:54:4:54:5 | (int)... | int | int | essentially Signed type |
+| test.c:54:4:54:5 | ss | signed short | signed short | essentially Signed type |

--- a/c/misra/test/c/misra/test.c
+++ b/c/misra/test/c/misra/test.c
@@ -33,3 +33,23 @@ void testConstants() {
   1U;  // Essentially unsigned char
   1UL; // Essentially unsigned long
 }
+
+void testUnary() {
+  _Bool b = true;
+  unsigned int u = 1;
+  unsigned short us = 1;
+  signed int s = 1;
+  signed short ss = 1;
+
+  !b;  // Should be boolean
+  !u;  // Should be boolean
+  !us; // Should be boolean
+  !s;  // Should be boolean
+  !ss; // Should be boolean
+
+  ~b;  // Should be essentially signed
+  ~u;  // Should be essentially unsigned
+  ~us; // Should be essentially unsigned
+  ~s;  // Should be essentially signed
+  ~ss; // Should be essentially signed
+}

--- a/c/misra/test/rules/RULE-10-1/OperandsOfAnInappropriateEssentialType.expected
+++ b/c/misra/test/rules/RULE-10-1/OperandsOfAnInappropriateEssentialType.expected
@@ -1,187 +1,191 @@
-| test.c:13:3:13:6 | access to array | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:14:3:14:6 | access to array | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:20:3:20:4 | + ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:21:3:21:4 | + ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:22:3:22:5 | + ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:27:3:27:4 | - ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:28:3:28:4 | - ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:29:3:29:5 | - ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:31:3:31:4 | - ... | Operand of essentially Unsigned type will be converted to a signed type with the signedness dependent on the implemented size of int. |
-| test.c:34:3:34:7 | ... + ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:36:3:36:8 | ... + ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:41:3:41:7 | ... - ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:43:3:43:8 | ... - ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:48:3:48:7 | ... + ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:50:3:50:8 | ... + ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:55:3:55:7 | ... - ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:57:3:57:8 | ... - ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:62:3:62:5 | ... ++ | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:64:3:64:6 | ... ++ | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:69:3:69:5 | ... -- | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:71:3:71:6 | ... -- | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:76:3:76:5 | ++ ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:78:3:78:6 | ++ ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:83:3:83:5 | -- ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:85:3:85:6 | -- ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:90:3:90:7 | ... * ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:91:3:91:7 | ... * ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:92:3:92:8 | ... * ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:97:3:97:7 | ... / ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:98:3:98:7 | ... / ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:99:3:99:8 | ... / ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:104:3:104:7 | ... * ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:105:3:105:7 | ... * ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:106:3:106:8 | ... * ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:111:3:111:7 | ... / ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:112:3:112:7 | ... / ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:113:3:113:8 | ... / ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:118:3:118:7 | ... % ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:119:3:119:7 | ... % ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:120:3:120:8 | ... % ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:125:3:125:7 | ... % ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:126:3:126:7 | ... % ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:127:3:127:8 | ... % ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:132:3:132:7 | ... < ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:139:3:139:7 | ... > ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:146:3:146:8 | ... <= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:153:3:153:8 | ... >= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:160:3:160:7 | ... < ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:167:3:167:7 | ... > ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:174:3:174:8 | ... <= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:181:3:181:8 | ... >= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:217:3:217:4 | ! ... | Operand of essentially Character type type interpreted as a Boolean value. |
-| test.c:218:3:218:5 | ! ... | Operand of essentially Enum Type type interpreted as a Boolean value. |
-| test.c:219:3:219:4 | ! ... | Operand of essentially Signed type type interpreted as a Boolean value. |
-| test.c:220:3:220:4 | ! ... | Operand of essentially Unsigned type type interpreted as a Boolean value. |
-| test.c:221:3:221:4 | ! ... | Operand of essentially Floating type type interpreted as a Boolean value. |
-| test.c:224:3:224:11 | ... && ... | Operand of essentially Character type type interpreted as a Boolean value. |
-| test.c:225:3:225:12 | ... && ... | Operand of essentially Enum Type type interpreted as a Boolean value. |
-| test.c:226:3:226:11 | ... && ... | Operand of essentially Signed type type interpreted as a Boolean value. |
-| test.c:227:3:227:11 | ... && ... | Operand of essentially Unsigned type type interpreted as a Boolean value. |
-| test.c:228:3:228:11 | ... && ... | Operand of essentially Floating type type interpreted as a Boolean value. |
-| test.c:231:3:231:12 | ... \|\| ... | Operand of essentially Character type type interpreted as a Boolean value. |
-| test.c:232:3:232:13 | ... \|\| ... | Operand of essentially Enum Type type interpreted as a Boolean value. |
-| test.c:233:3:233:12 | ... \|\| ... | Operand of essentially Signed type type interpreted as a Boolean value. |
-| test.c:234:3:234:12 | ... \|\| ... | Operand of essentially Unsigned type type interpreted as a Boolean value. |
-| test.c:235:3:235:12 | ... \|\| ... | Operand of essentially Floating type type interpreted as a Boolean value. |
-| test.c:238:3:238:11 | ... && ... | Operand of essentially Character type type interpreted as a Boolean value. |
-| test.c:239:3:239:12 | ... && ... | Operand of essentially Enum Type type interpreted as a Boolean value. |
-| test.c:240:3:240:11 | ... && ... | Operand of essentially Signed type type interpreted as a Boolean value. |
-| test.c:241:3:241:11 | ... && ... | Operand of essentially Unsigned type type interpreted as a Boolean value. |
-| test.c:242:3:242:11 | ... && ... | Operand of essentially Floating type type interpreted as a Boolean value. |
-| test.c:245:3:245:12 | ... \|\| ... | Operand of essentially Character type type interpreted as a Boolean value. |
-| test.c:246:3:246:13 | ... \|\| ... | Operand of essentially Enum Type type interpreted as a Boolean value. |
-| test.c:247:3:247:12 | ... \|\| ... | Operand of essentially Signed type type interpreted as a Boolean value. |
-| test.c:248:3:248:12 | ... \|\| ... | Operand of essentially Unsigned type type interpreted as a Boolean value. |
-| test.c:249:3:249:12 | ... \|\| ... | Operand of essentially Floating type type interpreted as a Boolean value. |
-| test.c:251:3:251:8 | ... << ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:252:3:252:8 | ... << ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:253:3:253:9 | ... << ... | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
-| test.c:254:3:254:8 | ... << ... | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
-| test.c:258:3:258:8 | ... >> ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:259:3:259:8 | ... >> ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:260:3:260:9 | ... >> ... | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
-| test.c:261:3:261:8 | ... >> ... | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
-| test.c:265:3:265:8 | ... << ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:266:3:266:8 | ... << ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:267:3:267:9 | ... << ... | Right hand operatand of shift operator is essentially Enum Type and not not essentially unsigned. |
-| test.c:268:3:268:8 | ... << ... | Right hand operatand of shift operator is essentially Signed type and not not essentially unsigned. |
-| test.c:272:3:272:8 | ... >> ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:273:3:273:8 | ... >> ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:274:3:274:9 | ... >> ... | Right hand operatand of shift operator is essentially Enum Type and not not essentially unsigned. |
-| test.c:275:3:275:8 | ... >> ... | Right hand operatand of shift operator is essentially Signed type and not not essentially unsigned. |
-| test.c:279:3:279:6 | ... & ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:280:3:280:6 | ... & ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:281:3:281:7 | ... & ... | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
-| test.c:282:3:282:6 | ... & ... | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
-| test.c:286:3:286:7 | ... \| ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:287:3:287:7 | ... \| ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:288:3:288:8 | ... \| ... | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
-| test.c:289:3:289:7 | ... \| ... | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
-| test.c:293:3:293:7 | ... ^ ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:294:3:294:7 | ... ^ ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:295:3:295:8 | ... ^ ... | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
-| test.c:296:3:296:7 | ... ^ ... | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
-| test.c:300:3:300:6 | ... & ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:301:3:301:6 | ... & ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:302:3:302:7 | ... & ... | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
-| test.c:303:3:303:6 | ... & ... | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
-| test.c:307:3:307:7 | ... \| ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:308:3:308:7 | ... \| ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:309:3:309:8 | ... \| ... | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
-| test.c:310:3:310:7 | ... \| ... | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
-| test.c:314:3:314:7 | ... ^ ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:315:3:315:7 | ... ^ ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:316:3:316:8 | ... ^ ... | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
-| test.c:317:3:317:7 | ... ^ ... | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
-| test.c:329:3:329:11 | ... ? ... : ... | Operand of essentially Character type type interpreted as a Boolean value. |
-| test.c:330:3:330:12 | ... ? ... : ... | Operand of essentially Enum Type type interpreted as a Boolean value. |
-| test.c:331:3:331:11 | ... ? ... : ... | Operand of essentially Signed type type interpreted as a Boolean value. |
-| test.c:332:3:332:11 | ... ? ... : ... | Operand of essentially Unsigned type type interpreted as a Boolean value. |
-| test.c:333:3:333:11 | ... ? ... : ... | Operand of essentially Floating type type interpreted as a Boolean value. |
-| test.c:342:3:342:8 | ... += ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:344:3:344:9 | ... += ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:349:3:349:8 | ... -= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:351:3:351:9 | ... -= ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:356:3:356:8 | ... += ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:358:3:358:9 | ... += ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:363:3:363:8 | ... -= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:365:3:365:9 | ... -= ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:370:3:370:8 | ... *= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:371:3:371:8 | ... *= ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:372:3:372:9 | ... *= ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:377:3:377:8 | ... /= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:378:3:378:8 | ... /= ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:379:3:379:9 | ... /= ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:384:3:384:8 | ... *= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:385:3:385:8 | ... *= ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:386:3:386:9 | ... *= ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:391:3:391:8 | ... /= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:392:3:392:8 | ... /= ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:393:3:393:9 | ... /= ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:398:3:398:8 | ... %= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:399:3:399:8 | ... %= ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:400:3:400:9 | ... %= ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:405:3:405:8 | ... %= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:406:3:406:8 | ... %= ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:407:3:407:9 | ... %= ... | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
-| test.c:412:3:412:9 | ... <<= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:413:3:413:9 | ... <<= ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:414:3:414:10 | ... <<= ... | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
-| test.c:415:3:415:9 | ... <<= ... | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
-| test.c:419:3:419:9 | ... >>= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:420:3:420:9 | ... >>= ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:421:3:421:10 | ... >>= ... | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
-| test.c:422:3:422:9 | ... >>= ... | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
-| test.c:426:3:426:9 | ... <<= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:427:3:427:9 | ... <<= ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:428:3:428:10 | ... <<= ... | Right hand operatand of shift operator is essentially Enum Type and not not essentially unsigned. |
-| test.c:429:3:429:9 | ... <<= ... | Right hand operatand of shift operator is essentially Signed type and not not essentially unsigned. |
-| test.c:433:3:433:9 | ... >>= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:434:3:434:9 | ... >>= ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:435:3:435:10 | ... >>= ... | Right hand operatand of shift operator is essentially Enum Type and not not essentially unsigned. |
-| test.c:436:3:436:9 | ... >>= ... | Right hand operatand of shift operator is essentially Signed type and not not essentially unsigned. |
-| test.c:440:3:440:8 | ... &= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:441:3:441:8 | ... &= ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:442:3:442:9 | ... &= ... | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
-| test.c:443:3:443:8 | ... &= ... | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
-| test.c:447:3:447:8 | ... ^= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:448:3:448:8 | ... ^= ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:449:3:449:9 | ... ^= ... | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
-| test.c:450:3:450:8 | ... ^= ... | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
-| test.c:454:3:454:8 | ... \|= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:455:3:455:8 | ... \|= ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:456:3:456:9 | ... \|= ... | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
-| test.c:457:3:457:8 | ... \|= ... | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
-| test.c:461:3:461:8 | ... &= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:462:3:462:8 | ... &= ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:463:3:463:9 | ... &= ... | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
-| test.c:464:3:464:8 | ... &= ... | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
-| test.c:468:3:468:8 | ... ^= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:469:3:469:8 | ... ^= ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:470:3:470:9 | ... ^= ... | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
-| test.c:471:3:471:8 | ... ^= ... | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
-| test.c:475:3:475:8 | ... \|= ... | Operand of essentially Boolean type interpreted as a numeric value. |
-| test.c:476:3:476:8 | ... \|= ... | Operand of essentially Charater type interpreted as a numeric value. |
-| test.c:477:3:477:9 | ... \|= ... | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
-| test.c:478:3:478:8 | ... \|= ... | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
+| test.c:13:5:13:5 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:14:5:14:5 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:20:4:20:4 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:21:4:21:4 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:22:4:22:5 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:27:4:27:4 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:28:4:28:4 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:29:4:29:5 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:31:4:31:4 | u | Operand of essentially Unsigned type will be converted to a signed type with the signedness dependent on the implemented size of int. |
+| test.c:34:7:34:7 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:36:7:36:8 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:41:7:41:7 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:43:7:43:8 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:48:3:48:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:50:3:50:4 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:55:3:55:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:57:3:57:4 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:62:3:62:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:64:3:64:4 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:69:3:69:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:71:3:71:4 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:76:5:76:5 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:78:5:78:6 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:83:5:83:5 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:85:5:85:6 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:90:7:90:7 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:91:7:91:7 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:92:7:92:8 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:97:7:97:7 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:98:7:98:7 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:99:7:99:8 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:104:3:104:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:105:3:105:3 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:106:3:106:4 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:111:3:111:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:112:3:112:3 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:113:3:113:4 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:118:3:118:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:119:3:119:3 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:120:3:120:4 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:125:7:125:7 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:126:7:126:7 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:127:7:127:8 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:132:7:132:7 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:139:7:139:7 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:146:8:146:8 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:153:8:153:8 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:160:3:160:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:167:3:167:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:174:3:174:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:181:3:181:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:217:4:217:4 | c | Operand of essentially Character type type interpreted as a Boolean value. |
+| test.c:218:4:218:5 | e1 | Operand of essentially Enum Type type interpreted as a Boolean value. |
+| test.c:219:4:219:4 | s | Operand of essentially Signed type type interpreted as a Boolean value. |
+| test.c:220:4:220:4 | u | Operand of essentially Unsigned type type interpreted as a Boolean value. |
+| test.c:221:4:221:4 | f | Operand of essentially Floating type type interpreted as a Boolean value. |
+| test.c:224:3:224:3 | c | Operand of essentially Character type type interpreted as a Boolean value. |
+| test.c:225:3:225:4 | e1 | Operand of essentially Enum Type type interpreted as a Boolean value. |
+| test.c:226:3:226:3 | s | Operand of essentially Signed type type interpreted as a Boolean value. |
+| test.c:227:3:227:3 | u | Operand of essentially Unsigned type type interpreted as a Boolean value. |
+| test.c:228:3:228:3 | f | Operand of essentially Floating type type interpreted as a Boolean value. |
+| test.c:231:3:231:3 | c | Operand of essentially Character type type interpreted as a Boolean value. |
+| test.c:232:3:232:4 | e1 | Operand of essentially Enum Type type interpreted as a Boolean value. |
+| test.c:233:3:233:3 | s | Operand of essentially Signed type type interpreted as a Boolean value. |
+| test.c:234:3:234:3 | u | Operand of essentially Unsigned type type interpreted as a Boolean value. |
+| test.c:235:3:235:3 | f | Operand of essentially Floating type type interpreted as a Boolean value. |
+| test.c:238:11:238:11 | c | Operand of essentially Character type type interpreted as a Boolean value. |
+| test.c:239:11:239:12 | e1 | Operand of essentially Enum Type type interpreted as a Boolean value. |
+| test.c:240:11:240:11 | s | Operand of essentially Signed type type interpreted as a Boolean value. |
+| test.c:241:11:241:11 | u | Operand of essentially Unsigned type type interpreted as a Boolean value. |
+| test.c:242:11:242:11 | f | Operand of essentially Floating type type interpreted as a Boolean value. |
+| test.c:245:12:245:12 | c | Operand of essentially Character type type interpreted as a Boolean value. |
+| test.c:246:12:246:13 | e1 | Operand of essentially Enum Type type interpreted as a Boolean value. |
+| test.c:247:12:247:12 | s | Operand of essentially Signed type type interpreted as a Boolean value. |
+| test.c:248:12:248:12 | u | Operand of essentially Unsigned type type interpreted as a Boolean value. |
+| test.c:249:12:249:12 | f | Operand of essentially Floating type type interpreted as a Boolean value. |
+| test.c:251:3:251:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:252:3:252:3 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:253:3:253:4 | e1 | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
+| test.c:254:3:254:3 | s | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
+| test.c:258:3:258:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:259:3:259:3 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:260:3:260:4 | e1 | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
+| test.c:261:3:261:3 | s | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
+| test.c:265:8:265:8 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:266:8:266:8 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:267:8:267:9 | e1 | Right hand operand of shift operator is essentially Enum Type and not not essentially unsigned. |
+| test.c:268:8:268:8 | s | Right hand operand of shift operator is essentially Signed type and not not essentially unsigned. |
+| test.c:272:8:272:8 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:273:8:273:8 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:274:8:274:9 | e1 | Right hand operand of shift operator is essentially Enum Type and not not essentially unsigned. |
+| test.c:275:8:275:8 | s | Right hand operand of shift operator is essentially Signed type and not not essentially unsigned. |
+| test.c:279:3:279:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:280:3:280:3 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:281:3:281:4 | e1 | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
+| test.c:282:3:282:3 | s | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
+| test.c:286:3:286:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:287:3:287:3 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:288:3:288:4 | e1 | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
+| test.c:289:3:289:3 | s | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
+| test.c:293:3:293:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:294:3:294:3 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:295:3:295:4 | e1 | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
+| test.c:296:3:296:3 | s | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
+| test.c:300:6:300:6 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:301:6:301:6 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:302:6:302:7 | e1 | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
+| test.c:303:6:303:6 | s | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
+| test.c:307:7:307:7 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:308:7:308:7 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:309:7:309:8 | e1 | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
+| test.c:310:7:310:7 | s | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
+| test.c:314:7:314:7 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:315:7:315:7 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:316:7:316:8 | e1 | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
+| test.c:317:7:317:7 | s | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
+| test.c:321:4:321:4 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:322:4:322:4 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:323:4:323:5 | e1 | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
+| test.c:324:4:324:4 | s | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
+| test.c:329:3:329:3 | c | Operand of essentially Character type type interpreted as a Boolean value. |
+| test.c:330:3:330:4 | e1 | Operand of essentially Enum Type type interpreted as a Boolean value. |
+| test.c:331:3:331:3 | s | Operand of essentially Signed type type interpreted as a Boolean value. |
+| test.c:332:3:332:3 | u | Operand of essentially Unsigned type type interpreted as a Boolean value. |
+| test.c:333:3:333:3 | f | Operand of essentially Floating type type interpreted as a Boolean value. |
+| test.c:342:3:342:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:344:3:344:4 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:349:3:349:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:351:3:351:4 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:356:8:356:8 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:358:8:358:9 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:363:8:363:8 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:365:8:365:9 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:370:3:370:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:371:3:371:3 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:372:3:372:4 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:377:3:377:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:378:3:378:3 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:379:3:379:4 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:384:8:384:8 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:385:8:385:8 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:386:8:386:9 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:391:8:391:8 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:392:8:392:8 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:393:8:393:9 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:398:3:398:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:399:3:399:3 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:400:3:400:4 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:405:8:405:8 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:406:8:406:8 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:407:8:407:9 | e1 | Operand of essentially Enum type used in arithmetic operation, but has an implementation defined integer type. |
+| test.c:412:3:412:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:413:3:413:3 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:414:3:414:4 | e1 | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
+| test.c:415:3:415:3 | s | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
+| test.c:419:3:419:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:420:3:420:3 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:421:3:421:4 | e1 | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
+| test.c:422:3:422:3 | s | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
+| test.c:426:9:426:9 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:427:9:427:9 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:428:9:428:10 | e1 | Right hand operand of shift operator is essentially Enum Type and not not essentially unsigned. |
+| test.c:429:9:429:9 | s | Right hand operand of shift operator is essentially Signed type and not not essentially unsigned. |
+| test.c:433:9:433:9 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:434:9:434:9 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:435:9:435:10 | e1 | Right hand operand of shift operator is essentially Enum Type and not not essentially unsigned. |
+| test.c:436:9:436:9 | s | Right hand operand of shift operator is essentially Signed type and not not essentially unsigned. |
+| test.c:440:3:440:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:441:3:441:3 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:442:3:442:4 | e1 | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
+| test.c:443:3:443:3 | s | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
+| test.c:447:3:447:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:448:3:448:3 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:449:3:449:4 | e1 | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
+| test.c:450:3:450:3 | s | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
+| test.c:454:3:454:3 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:455:3:455:3 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:456:3:456:4 | e1 | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
+| test.c:457:3:457:3 | s | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
+| test.c:461:8:461:8 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:462:8:462:8 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:463:8:463:9 | e1 | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
+| test.c:464:8:464:8 | s | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
+| test.c:468:8:468:8 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:469:8:469:8 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:470:8:470:9 | e1 | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
+| test.c:471:8:471:8 | s | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |
+| test.c:475:8:475:8 | b | Operand of essentially Boolean type interpreted as a numeric value. |
+| test.c:476:8:476:8 | c | Operand of essentially Charater type interpreted as a numeric value. |
+| test.c:477:8:477:9 | e1 | Bitwise operator applied to operand of essentially Enum Type and not essentially unsigned. |
+| test.c:478:8:478:8 | s | Bitwise operator applied to operand of essentially Signed type and not essentially unsigned. |

--- a/change_notes/2024-09-17-essential-types-unary.md
+++ b/change_notes/2024-09-17-essential-types-unary.md
@@ -1,0 +1,4 @@
+ - `RULE-10-1` - `OperandsOfAnInappropriateEssentialType.ql`
+   - Reduce false negatives by supporting operands to the `~` operator with the incorrect essential type.
+   - Reduce false positives by identifying the essential type of `!<expr>` as essentially boolean type.
+   - Improve clarity reporting by reporting the violating operand, instead of the operator, and addressing message typos.


### PR DESCRIPTION
## Description

Fixes #691 - handling of unary operators `~` and `!`.

This also improves the reporting of the query, by reporting the operand, not the operator.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
 - [x] Queries have been modified for the following rules:
     - `RULE-10-1`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)