### PR TITLE
Rule 8.3: Remove false positives for declarations that don't share a link target

### DIFF
--- a/c/misra/src/rules/RULE-8-3/DeclarationsOfAnObjectSameNameAndType.ql
+++ b/c/misra/src/rules/RULE-8-3/DeclarationsOfAnObjectSameNameAndType.ql
@@ -21,7 +21,19 @@ where
   not isExcluded(decl2, Declarations4Package::declarationsOfAnObjectSameNameAndTypeQuery()) and
   not decl1 = decl2 and
   not decl1.getVariable().getDeclaringType().isAnonymous() and
+  // Declarations are for the same qualified name
+  // Note: decl1.getVariable() = decl2.getVariable() does not work for common cases where an aliased
+  //       type is used.
   decl1.getVariable().getQualifiedName() = decl2.getVariable().getQualifiedName() and
+  // As we use qualified name, require that they share a common link target to ensure they are
+  // for the same object
+  (
+    decl1.getVariable().(GlobalVariable).getALinkTarget() =
+      decl2.getVariable().(GlobalVariable).getALinkTarget()
+    or
+    decl1.getVariable().(Field).getDeclaringType().(Class).getALinkTarget() =
+      decl2.getVariable().(Field).getDeclaringType().(Class).getALinkTarget()
+  ) and
   not typesCompatible(decl1.getType(), decl2.getType())
 select decl1,
   "The object $@ of type " + decl1.getType().toString() +

--- a/change_notes/2024-09-17-rule-8-3-linker-aware.md
+++ b/change_notes/2024-09-17-rule-8-3-linker-aware.md
@@ -1,0 +1,2 @@
+ - `RULE-8-3` - `DeclarationsOfAnObjectSameNameAndType.ql`
+   - Remove false positives where two conflicting declarations are never linked together.


### PR DESCRIPTION
## Description

Fixes https://github.com/github/codeql-coding-standards/issues/694.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
 - [x] Queries have been modified for the following rules:
     - `RULE-8-3`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)