### PR TITLE
`RULE-11-*`: Improve detection of const void pointers

### DIFF
--- a/c/misra/src/rules/RULE-11-5/ConversionFromPointerToVoidIntoPointerToObject.ql
+++ b/c/misra/src/rules/RULE-11-5/ConversionFromPointerToVoidIntoPointerToObject.ql
@@ -19,7 +19,7 @@ import codingstandards.cpp.Pointers
 from Cast cast, VoidPointerType type, PointerToObjectType newType
 where
   not isExcluded(cast, Pointers1Package::conversionFromPointerToVoidIntoPointerToObjectQuery()) and
-  type = cast.getExpr().getUnderlyingType() and
+  type = cast.getExpr().getUnspecifiedType() and
   newType = cast.getUnderlyingType() and
   not isNullPointerConstant(cast.getExpr())
 select cast,

--- a/c/misra/test/rules/RULE-11-3/CastBetweenObjectPointerAndDifferentObjectType.expected
+++ b/c/misra/test/rules/RULE-11-3/CastBetweenObjectPointerAndDifferentObjectType.expected
@@ -2,3 +2,7 @@
 | test.c:14:8:14:9 | (int *)... | Cast performed between a pointer to object type (char) and a pointer to a different object type (int). |
 | test.c:15:8:15:25 | (int *)... | Cast performed between a pointer to object type (short) and a pointer to a different object type (int). |
 | test.c:15:15:15:25 | (short *)... | Cast performed between a pointer to object type (char) and a pointer to a different object type (short). |
+| test.c:20:3:20:17 | (const int *)... | Cast performed between a pointer to object type (char) and a pointer to a different object type (const int). |
+| test.c:21:3:21:16 | (int *)... | Cast performed between a pointer to object type (char) and a pointer to a different object type (int). |
+| test.c:22:20:22:21 | (int *)... | Cast performed between a pointer to object type (char) and a pointer to a different object type (int). |
+| test.c:23:3:23:18 | (long long *)... | Cast performed between a pointer to object type (int) and a pointer to a different object type (long long). |

--- a/c/misra/test/rules/RULE-11-3/test.c
+++ b/c/misra/test/rules/RULE-11-3/test.c
@@ -13,4 +13,8 @@ void f1(void) {
   int *v8 = (int *)0;         // COMPLIANT
   v8 = v2;                    // NON_COMPLIANT
   v8 = (int *)(short *)v2;    // NON_COMPLIANT
+  (const void *)v1;           // COMPLIANT
+  const void *v9 = v1;        // COMPLIANT
+  (int *)v9;                  // COMPLIANT - cast from void*
+  (const void *)v2;           // COMPLIANT
 }

--- a/c/misra/test/rules/RULE-11-3/test.c
+++ b/c/misra/test/rules/RULE-11-3/test.c
@@ -17,4 +17,8 @@ void f1(void) {
   const void *v9 = v1;        // COMPLIANT
   (int *)v9;                  // COMPLIANT - cast from void*
   (const void *)v2;           // COMPLIANT
+  (const int *)v2;            // NON_COMPLIANT
+  (int *const)v2;             // NON_COMPLIANT
+  int *const v10 = v2;        // NON_COMPLIANT
+  (long long *)v10;           // NON_COMPLIANT
 }

--- a/c/misra/test/rules/RULE-11-4/ConversionBetweenPointerToObjectAndIntegerType.expected
+++ b/c/misra/test/rules/RULE-11-4/ConversionBetweenPointerToObjectAndIntegerType.expected
@@ -1,6 +1,6 @@
 | test.c:6:21:6:37 | (unsigned int)... | Cast from pointer to object type 'unsigned int *' to integer type 'unsigned int'. | test.c:6:21:6:37 | (unsigned int)... |  |
 | test.c:8:8:8:24 | (unsigned int)... | Cast from pointer to object type 'unsigned int *' to integer type 'unsigned int'. | test.c:8:8:8:24 | (unsigned int)... |  |
 | test.c:12:22:12:39 | (unsigned int *)... | Cast from integer type 'unsigned int' to pointer to object type 'unsigned int *'. | test.c:12:22:12:39 | (unsigned int *)... |  |
-| test.c:15:1:15:24 | #define FOO (int *)0x200 | Cast from integer type 'int' to pointer to object type 'int *'. | test.c:15:1:15:24 | #define FOO (int *)0x200 |  |
-| test.c:23:3:23:22 | (int *)... | Cast from integer type 'int' to pointer to object type 'int *' from expansion of macro $@. | test.c:17:1:17:34 | #define FOO_FUNCTIONAL(x) (int *)x | FOO_FUNCTIONAL |
-| test.c:24:14:24:25 | (int *)... | Cast from integer type 'int' to pointer to object type 'int *' from expansion of macro $@. | test.c:18:1:18:23 | #define FOO_INSERT(x) x | FOO_INSERT |
+| test.c:18:1:18:24 | #define FOO (int *)0x200 | Cast from integer type 'int' to pointer to object type 'int *'. | test.c:18:1:18:24 | #define FOO (int *)0x200 |  |
+| test.c:26:3:26:22 | (int *)... | Cast from integer type 'int' to pointer to object type 'int *' from expansion of macro $@. | test.c:20:1:20:34 | #define FOO_FUNCTIONAL(x) (int *)x | FOO_FUNCTIONAL |
+| test.c:27:14:27:25 | (int *)... | Cast from integer type 'int' to pointer to object type 'int *' from expansion of macro $@. | test.c:21:1:21:23 | #define FOO_INSERT(x) x | FOO_INSERT |

--- a/c/misra/test/rules/RULE-11-4/test.c
+++ b/c/misra/test/rules/RULE-11-4/test.c
@@ -10,6 +10,9 @@ void f1(void) {
   unsigned int *v4 = 0;                      // COMPLIANT
   unsigned int *v5 = NULL;                   // COMPLIANT
   unsigned int *v6 = (unsigned int *)v2;     // NON_COMPLIANT
+  const void *v7 = 0;
+  (unsigned int)v7; // COMPLIANT - cast const void to int
+  (const void *)v1; // COMPLIANT - casting int to const void
 }
 
 #define FOO (int *)0x200 // NON_COMPLIANT

--- a/c/misra/test/rules/RULE-11-5/ConversionFromPointerToVoidIntoPointerToObject.expected
+++ b/c/misra/test/rules/RULE-11-5/ConversionFromPointerToVoidIntoPointerToObject.expected
@@ -1,1 +1,2 @@
 | test.c:6:13:6:21 | (int *)... | Cast performed from a void pointer into a pointer to an object (int *). |
+| test.c:11:3:11:11 | (int *)... | Cast performed from a void pointer into a pointer to an object (int *). |

--- a/c/misra/test/rules/RULE-11-5/test.c
+++ b/c/misra/test/rules/RULE-11-5/test.c
@@ -8,7 +8,7 @@ void f1(void) {
   void *v3 = (void *)v1; // COMPLIANT
   v3 = (void *)v2;       // COMPLIANT
   const void *v4 = 0;
-  (int *)v4; // NON_COMPLIANT[FALSE_NEGATIVE] - const in type is irrelevant
+  (int *)v4;        // NON_COMPLIANT - const in type is irrelevant
   (const void *)v1; // COMPLIANT - casting is from void to void, const addition
                     // should be irrelevant
 }

--- a/c/misra/test/rules/RULE-11-5/test.c
+++ b/c/misra/test/rules/RULE-11-5/test.c
@@ -7,4 +7,8 @@ void f1(void) {
   v2 = NULL;             // COMPLIANT
   void *v3 = (void *)v1; // COMPLIANT
   v3 = (void *)v2;       // COMPLIANT
+  const void *v4 = 0;
+  (int *)v4; // NON_COMPLIANT[FALSE_NEGATIVE] - const in type is irrelevant
+  (const void *)v1; // COMPLIANT - casting is from void to void, const addition
+                    // should be irrelevant
 }

--- a/c/misra/test/rules/RULE-11-7/test.c
+++ b/c/misra/test/rules/RULE-11-7/test.c
@@ -7,4 +7,12 @@ void f1(void) {
   float v4 = (float)(bool)v1; // NON_COMPLIANT
   v1 = (int *)v2;             // NON_COMPLIANT
   v4 = (float)v3;             // COMPLIANT
+  void *v5 = 0;
+  const void *v6 = 0;
+  // void pointers (regardless of specifier) are not pointers to object, so all
+  // these examples are compliant according to this rule
+  (bool)v5;         // COMPLIANT
+  (bool)v6;         // COMPLIANT
+  (void *)v2;       // COMPLIANT
+  (const void *)v2; // COMPLIANT
 }

--- a/change_notes/2024-10-11-specifiers-rule-11-misra-c.md
+++ b/change_notes/2024-10-11-specifiers-rule-11-misra-c.md
@@ -1,2 +1,4 @@
 - `RULE-11-3`, `RULE-11-4`, `RULE-11-5`, `RULE-11-7` - `CastBetweenObjectPointerAndDifferentObjectType.ql`, `ConversionBetweenPointerToObjectAndIntegerType.ql`, `ConversionFromPointerToVoidIntoPointerToObject.ql`, `CastBetweenPointerToObjectAndNonIntArithmeticType.ql`:
-  - Removed false positives where casts involved a specified void type pointer, e.g. `const void*`, which should not be considered as a pointer to object, but should be considered a pointer-to-void.
+  - Removed false positives where casts involved a specified void type pointer, e.g. `const void*`, which should not be considered as a pointer to object.
+- `RULE-11-5` - `ConversionFromPointerToVoidIntoPointerToObject.ql`:
+  - Addressed false negatives where the pointer-to-void was specified.

--- a/change_notes/2024-10-11-specifiers-rule-11-misra-c.md
+++ b/change_notes/2024-10-11-specifiers-rule-11-misra-c.md
@@ -1,0 +1,2 @@
+- `RULE-11-3`, `RULE-11-4`, `RULE-11-5`, `RULE-11-7` - `CastBetweenObjectPointerAndDifferentObjectType.ql`, `ConversionBetweenPointerToObjectAndIntegerType.ql`, `ConversionFromPointerToVoidIntoPointerToObject.ql`, `CastBetweenPointerToObjectAndNonIntArithmeticType.ql`:
+  - Removed false positives where casts involved a specified void type pointer, e.g. `const void*`, which should not be considered as a pointer to object.

--- a/change_notes/2024-10-11-specifiers-rule-11-misra-c.md
+++ b/change_notes/2024-10-11-specifiers-rule-11-misra-c.md
@@ -1,2 +1,2 @@
 - `RULE-11-3`, `RULE-11-4`, `RULE-11-5`, `RULE-11-7` - `CastBetweenObjectPointerAndDifferentObjectType.ql`, `ConversionBetweenPointerToObjectAndIntegerType.ql`, `ConversionFromPointerToVoidIntoPointerToObject.ql`, `CastBetweenPointerToObjectAndNonIntArithmeticType.ql`:
-  - Removed false positives where casts involved a specified void type pointer, e.g. `const void*`, which should not be considered as a pointer to object.
+  - Removed false positives where casts involved a specified void type pointer, e.g. `const void*`, which should not be considered as a pointer to object, but should be considered a pointer-to-void.

--- a/cpp/common/src/codingstandards/cpp/Pointers.qll
+++ b/cpp/common/src/codingstandards/cpp/Pointers.qll
@@ -80,9 +80,9 @@ predicate isCastNullPointerConstant(Cast c) {
 class PointerToObjectType extends PointerType {
   PointerToObjectType() {
     not (
-      this.getUnderlyingType() instanceof FunctionPointerType or
-      this.getUnderlyingType() instanceof VoidPointerType or
-      this.getBaseType().getUnderlyingType() instanceof IncompleteType
+      this.getUnspecifiedType() instanceof FunctionPointerType or
+      this.getUnspecifiedType() instanceof VoidPointerType or
+      this.getBaseType().getUnspecifiedType() instanceof IncompleteType
     )
   }
 }


### PR DESCRIPTION
## Description

Fixes https://github.com/github/codeql-coding-standards/issues/317.

The definition of `PointerToObjectType` has been updated to exclude _specified_ void pointer types, such as `const void *`.

In addition, `RULE-11-5` has been updated to detect specified void pointer types, therefore reducing false negatives.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `RULE-11-3`
     - `RULE-11-4`
     - `RULE-11-5`
     - `RULE-11-7`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)