### PR TITLE
`RULE-10-4`: Improve essential type detection

### DIFF
--- a/c/misra/src/codingstandards/c/misra/EssentialTypes.qll
+++ b/c/misra/src/codingstandards/c/misra/EssentialTypes.qll
@@ -130,12 +130,17 @@ EssentialTypeCategory getEssentialTypeCategory(Type type) {
     essentialType.(IntegralType).isSigned() and
     not essentialType instanceof PlainCharType
     or
+    // Anonymous enums are considered to be signed
+    result = EssentiallySignedType() and
+    essentialType instanceof AnonymousEnumType and
+    not essentialType instanceof MisraBoolType
+    or
     result = EssentiallyUnsignedType() and
     essentialType.(IntegralType).isUnsigned() and
     not essentialType instanceof PlainCharType
     or
     result = EssentiallyEnumType() and
-    essentialType instanceof Enum and
+    essentialType instanceof NamedEnumType and
     not essentialType instanceof MisraBoolType
     or
     result = EssentiallyFloatingType() and
@@ -348,8 +353,41 @@ class EssentialBinaryArithmeticExpr extends EssentialExpr, BinaryArithmeticOpera
   }
 }
 
+/**
+ * A named Enum type, as per D.5.
+ */
+class NamedEnumType extends Enum {
+  NamedEnumType() {
+    not isAnonymous()
+    or
+    exists(Type useOfEnum | this = useOfEnum.stripType() |
+      exists(TypedefType t | t.getBaseType() = useOfEnum)
+      or
+      exists(Function f | f.getType() = useOfEnum or f.getAParameter().getType() = useOfEnum)
+      or
+      exists(Struct s | s.getAField().getType() = useOfEnum)
+      or
+      exists(Variable v | v.getType() = useOfEnum)
+    )
+  }
+}
+
+/**
+ * An anonymous Enum type, as per D.5.
+ */
+class AnonymousEnumType extends Enum {
+  AnonymousEnumType() { not this instanceof NamedEnumType }
+}
+
+/**
+ * The EssentialType of an EnumConstantAccess, which may be essentially enum or essentially signed.
+ */
 class EssentialEnumConstantAccess extends EssentialExpr, EnumConstantAccess {
-  override Type getEssentialType() { result = getTarget().getDeclaringEnum() }
+  override Type getEssentialType() {
+    exists(Enum e | e = getTarget().getDeclaringEnum() |
+      if e instanceof NamedEnumType then result = e else result = stlr(this)
+    )
+  }
 }
 
 class EssentialLiteral extends EssentialExpr, Literal {

--- a/c/misra/src/codingstandards/c/misra/EssentialTypes.qll
+++ b/c/misra/src/codingstandards/c/misra/EssentialTypes.qll
@@ -393,9 +393,11 @@ class EssentialEnumConstantAccess extends EssentialExpr, EnumConstantAccess {
 class EssentialLiteral extends EssentialExpr, Literal {
   override Type getEssentialType() {
     if this instanceof BooleanLiteral
-    then result instanceof MisraBoolType
+    then
+      // This returns a multitude of types - not sure if we really want that
+      result instanceof MisraBoolType
     else (
-      if this.(CharLiteral).getCharacter().length() = 1
+      if this instanceof CharLiteral
       then result instanceof PlainCharType
       else
         exists(Type underlyingStandardType |

--- a/c/misra/src/rules/RULE-10-4/OperandsWithMismatchedEssentialTypeCategory.ql
+++ b/c/misra/src/rules/RULE-10-4/OperandsWithMismatchedEssentialTypeCategory.ql
@@ -38,7 +38,7 @@ where
     // be reported as non-compliant.
     leftOpTypeCategory = EssentiallyEnumType() and
     rightOpTypeCategory = EssentiallyEnumType() and
-    not leftOpEssentialType = rightOpEssentialType and
+    not leftOpEssentialType.getUnspecifiedType() = rightOpEssentialType.getUnspecifiedType() and
     message =
       "The operands of this operator with usual arithmetic conversions have mismatched essentially Enum types (left operand: "
         + leftOpEssentialType + ", right operand: " + rightOpEssentialType + ")."

--- a/c/misra/test/c/misra/EssentialTypes.expected
+++ b/c/misra/test/c/misra/EssentialTypes.expected
@@ -87,3 +87,6 @@
 | test.c:73:3:73:5 | EC4 | (unnamed enum) | (unnamed enum) | essentially Enum Type |
 | test.c:74:3:74:5 | EC5 | (unnamed enum) | (unnamed enum) | essentially Enum Type |
 | test.c:75:3:75:5 | EC6 | (unnamed enum) | (unnamed enum) | essentially Enum Type |
+| test.c:79:3:79:5 | 97 | char | char | essentially Character type |
+| test.c:80:3:80:6 | 10 | char | char | essentially Character type |
+| test.c:81:3:81:6 | 0 | char | char | essentially Character type |

--- a/c/misra/test/c/misra/EssentialTypes.expected
+++ b/c/misra/test/c/misra/EssentialTypes.expected
@@ -1,3 +1,9 @@
+| file://:0:0:0:0 | 0 | signed char | signed char | essentially Signed type |
+| file://:0:0:0:0 | 0 | signed char | signed char | essentially Signed type |
+| file://:0:0:0:0 | 0 | signed char | signed char | essentially Signed type |
+| file://:0:0:0:0 | 0 | signed char | signed char | essentially Signed type |
+| file://:0:0:0:0 | 0 | signed char | signed char | essentially Signed type |
+| file://:0:0:0:0 | 0 | signed char | signed char | essentially Signed type |
 | test.c:4:20:4:20 | 1 | signed char | signed char | essentially Signed type |
 | test.c:4:20:4:20 | (unsigned int)... | unsigned int | unsigned int | essentially Unsigned type |
 | test.c:5:23:5:23 | 1 | signed char | signed char | essentially Signed type |
@@ -73,3 +79,11 @@
 | test.c:54:3:54:5 | ~ ... | int | int | essentially Signed type |
 | test.c:54:4:54:5 | (int)... | int | int | essentially Signed type |
 | test.c:54:4:54:5 | ss | signed short | signed short | essentially Signed type |
+| test.c:63:30:63:32 | ((unnamed enum))... | (unnamed enum) | (unnamed enum) | essentially Enum Type |
+| test.c:63:30:63:32 | EC5 | (unnamed enum) | (unnamed enum) | essentially Enum Type |
+| test.c:70:3:70:5 | EC1 | signed char | signed char | essentially Signed type |
+| test.c:71:3:71:5 | EC2 | E1 | E1 | essentially Enum Type |
+| test.c:72:3:72:5 | EC3 | (unnamed enum) | (unnamed enum) | essentially Enum Type |
+| test.c:73:3:73:5 | EC4 | (unnamed enum) | (unnamed enum) | essentially Enum Type |
+| test.c:74:3:74:5 | EC5 | (unnamed enum) | (unnamed enum) | essentially Enum Type |
+| test.c:75:3:75:5 | EC6 | (unnamed enum) | (unnamed enum) | essentially Enum Type |

--- a/c/misra/test/c/misra/test.c
+++ b/c/misra/test/c/misra/test.c
@@ -53,3 +53,24 @@ void testUnary() {
   ~s;  // Should be essentially signed
   ~ss; // Should be essentially signed
 }
+
+enum { EC1 };
+enum E1 { EC2 };
+typedef enum { EC3 } E2;
+
+enum { EC4 } g;
+
+enum { EC5 } test() { return EC5; }
+
+struct S1 {
+  enum { EC6 } m;
+};
+
+void testEnums() {
+  EC1; // Should be essentially signed
+  EC2; // Should be essentially enum
+  EC3; // Should be essentially enum
+  EC4; // Should be essentially enum
+  EC5; // Should be essentially enum
+  EC6; // Should be essentially enum
+}

--- a/c/misra/test/c/misra/test.c
+++ b/c/misra/test/c/misra/test.c
@@ -74,3 +74,9 @@ void testEnums() {
   EC5; // Should be essentially enum
   EC6; // Should be essentially enum
 }
+
+void testControlChar() {
+  'a';  // Essentially char
+  '\n'; // Essentially char
+  '\0'; // Essentially char
+}

--- a/c/misra/test/rules/RULE-10-4/test.c
+++ b/c/misra/test/rules/RULE-10-4/test.c
@@ -37,4 +37,9 @@ void testOps() {
   enum { G };
   s32 + G;   // COMPLIANT
   c == '\n'; // COMPLIANT
+
+  typedef enum { H } E3;
+
+  E3 e3a = H;
+  e3a < H; // COMPLIANT
 }

--- a/c/misra/test/rules/RULE-10-4/test.c
+++ b/c/misra/test/rules/RULE-10-4/test.c
@@ -33,4 +33,8 @@ void testOps() {
   A < A;     // COMPLIANT
   e1a < e2a; // NON_COMPLIANT
   A < D;     // NON_COMPLIANT
+
+  enum { G };
+  s32 + G;   // COMPLIANT
+  c == '\n'; // COMPLIANT
 }

--- a/change_notes/2024-10-15-lits-and-constants-10-4.md
+++ b/change_notes/2024-10-15-lits-and-constants-10-4.md
@@ -1,0 +1,5 @@
+ - `RULE-10-4` - `OperandswithMismatchedEssentialTypeCategory.ql`:
+   - Removed false positives where a specified or typedef'd enum type was compared to an enum constant type.
+ - `EssentialType` - for all queries related to essential types:
+   - `\n` and other control characters are now correctly deduced as essentially char type, instead of an essentially integer type.
+   - Enum constants for anonymous enums are now correctly deduced as an essentially signed integer type instead of essentially enum.


### PR DESCRIPTION
## Description

Fixes https://github.com/github/codeql-coding-standards/issues/747.

 - `RULE-10-4` - `OperandswithMismatchedEssentialTypeCategory.ql`:
   - Removed false positives where a specified or typedef'd enum type was compared to an enum constant type.
 - `EssentialType` - for all queries related to essential types:
   - `\n` and other control characters are now correctly deduced as essentially char type, instead of an essentially integer type.
   - Enum constants for anonymous enums are now correctly deduced as an essentially signed integer type instead of essentially enum.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `RULE-10-4`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)