### PR TITLE
`A7-1-3`:  Remove false positives where the typedef type is referenced in the initializer

### DIFF
--- a/change_notes/2024-10-15-a7-1-3-multi-refs.md
+++ b/change_notes/2024-10-15-a7-1-3-multi-refs.md
@@ -1,0 +1,2 @@
+- `A7-1-3` - `CvQualifiersNotPlacedOnTheRightHandSide.ql`:
+  - Removed false positives where a correctly CV-qualified typedef variable type was also referenced in the initializer.

--- a/cpp/autosar/src/rules/A7-1-3/CvQualifiersNotPlacedOnTheRightHandSide.ql
+++ b/cpp/autosar/src/rules/A7-1-3/CvQualifiersNotPlacedOnTheRightHandSide.ql
@@ -20,14 +20,12 @@ import cpp
 import codingstandards.cpp.autosar
 
 /**
- * Holds if declaration `e` using a `TypedefType` is CV-qualified
- *
- * For example, given `using intconstptr = int * const`:
- * the predicate holds for `const/volatile intconstptr ptr1`, but not for `intconstptr ptr2`
+ * Unwrap layers of indirection that occur on the right side of the type.
  */
-predicate containsExtraSpecifiers(VariableDeclarationEntry e) {
-  e.getType().toString().matches("const %") or
-  e.getType().toString().matches("volatile %")
+Type unwrapIndirection(Type type) {
+  if type instanceof DerivedType and not type instanceof SpecifiedType
+  then result = unwrapIndirection(type.(DerivedType).getBaseType())
+  else result = type
 }
 
 // DeclStmts that have a TypedefType name use (ie TypeMention) in them
@@ -36,19 +34,19 @@ predicate containsExtraSpecifiers(VariableDeclarationEntry e) {
 from VariableDeclarationEntry e, TypedefType t, TypeMention tm
 where
   not isExcluded(e, ConstPackage::cvQualifiersNotPlacedOnTheRightHandSideQuery()) and
-  containsExtraSpecifiers(e) and
+  // Variable type is specified, and has the typedef type as a base type
+  unwrapIndirection(e.getType()).(SpecifiedType).getBaseType() = t and
   exists(string filepath, int startline |
     e.getLocation().hasLocationInfo(filepath, startline, _, _, _) and
     tm.getLocation().hasLocationInfo(filepath, startline, _, _, _) and
     e = t.getATypeNameUse() and
     tm.getMentionedType() = t and
+    // TypeMention occurs before the variable declaration
+    tm.getLocation().getStartColumn() < e.getLocation().getStartColumn() and
     exists(DeclStmt s |
       s.getDeclarationEntry(_) = e and
-      //const could fit in there
+      // TypeMention occurs after the start of the StmtDecl, with enough space for const/volatile
       tm.getLocation().getStartColumn() - s.getLocation().getStartColumn() > 5
-      //volatile could fit in there
-      //but the above condition subsumes this one
-      //l.getStartColumn() - tm.getLocation().getStartColumn() > 8
     )
   )
 select e,

--- a/cpp/autosar/test/rules/A7-1-3/CvQualifiersNotPlacedOnTheRightHandSide.expected
+++ b/cpp/autosar/test/rules/A7-1-3/CvQualifiersNotPlacedOnTheRightHandSide.expected
@@ -1,3 +1,4 @@
 | test.cpp:9:16:9:19 | definition of ptr1 | There is possibly a const or volatile specifier on the left hand side of typedef name $@. | test.cpp:1:7:1:12 | intptr | intptr |
 | test.cpp:10:19:10:22 | definition of ptr2 | There is possibly a const or volatile specifier on the left hand side of typedef name $@. | test.cpp:1:7:1:12 | intptr | intptr |
 | test.cpp:19:21:19:24 | definition of ptr8 | There is possibly a const or volatile specifier on the left hand side of typedef name $@. | test.cpp:3:7:3:17 | constintptr | constintptr |
+| test.cpp:32:23:32:26 | definition of u32d | There is possibly a const or volatile specifier on the left hand side of typedef name $@. | file:///Users/luke/git/codeql-coding-standards/cpp/common/test/includes/standard-library/cstdint.h:9:22:9:29 | uint32_t | uint32_t |

--- a/cpp/autosar/test/rules/A7-1-3/CvQualifiersNotPlacedOnTheRightHandSide.expected
+++ b/cpp/autosar/test/rules/A7-1-3/CvQualifiersNotPlacedOnTheRightHandSide.expected
@@ -1,4 +1,4 @@
 | test.cpp:9:16:9:19 | definition of ptr1 | There is possibly a const or volatile specifier on the left hand side of typedef name $@. | test.cpp:1:7:1:12 | intptr | intptr |
 | test.cpp:10:19:10:22 | definition of ptr2 | There is possibly a const or volatile specifier on the left hand side of typedef name $@. | test.cpp:1:7:1:12 | intptr | intptr |
 | test.cpp:19:21:19:24 | definition of ptr8 | There is possibly a const or volatile specifier on the left hand side of typedef name $@. | test.cpp:3:7:3:17 | constintptr | constintptr |
-| test.cpp:32:23:32:26 | definition of u32d | There is possibly a const or volatile specifier on the left hand side of typedef name $@. | file:///Users/luke/git/codeql-coding-standards/cpp/common/test/includes/standard-library/cstdint.h:9:22:9:29 | uint32_t | uint32_t |
+| test.cpp:32:23:32:26 | definition of u32d | There is possibly a const or volatile specifier on the left hand side of typedef name uint32_t. | test.cpp:32:23:32:26 | definition of u32d |  |

--- a/cpp/autosar/test/rules/A7-1-3/test.cpp
+++ b/cpp/autosar/test/rules/A7-1-3/test.cpp
@@ -19,3 +19,15 @@ void f() {
   const constintptr ptr8 = &l; // NON_COMPLIANT
   inttypedef ptr9 = l;         // COMPLIANT
 }
+
+#include <cstdint>
+
+void false_positive() {
+  std::uint8_t u8{0};
+
+  auto const u32 = static_cast<std::uint32_t>(u8); // COMPLIANT - auto ignored
+  std::uint32_t const u32b = static_cast<std::uint32_t>(u8); // COMPLIANT
+
+  const auto u32c = static_cast<std::uint32_t>(u8); // COMPLIANT - auto ignored
+  const std::uint32_t u32d = static_cast<std::uint32_t>(u8); // NON_COMPLIANT
+}


### PR DESCRIPTION
## Description

Fixes #601.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `A7-1-3`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)