### PR TITLE
Expand integer constant testing, and extend C++ queries to support binary literals

### DIFF
--- a/c/misra/test/rules/RULE-7-2/UOrUSuffixRepresentedInUnsignedType.expected
+++ b/c/misra/test/rules/RULE-7-2/UOrUSuffixRepresentedInUnsignedType.expected
@@ -8,5 +8,5 @@
 | test.c:232:3:232:25 | 9223372036854775808 | Unsigned literal 01000000000000000000000 does not explicitly express sign with a 'U' or 'u' suffix. |
 | test.c:249:3:249:26 | 9223372036854775808 | Unsigned literal 01000000000000000000000l does not explicitly express sign with a 'U' or 'u' suffix. |
 | test.c:266:3:266:26 | 9223372036854775808 | Unsigned literal 01000000000000000000000L does not explicitly express sign with a 'U' or 'u' suffix. |
-| test.c:283:3:283:26 | 9223372036854775808 | Unsigned literal 01000000000000000000000l does not explicitly express sign with a 'U' or 'u' suffix. |
-| test.c:300:3:300:26 | 9223372036854775808 | Unsigned literal 01000000000000000000000L does not explicitly express sign with a 'U' or 'u' suffix. |
+| test.c:283:3:283:27 | 9223372036854775808 | Unsigned literal 01000000000000000000000ll does not explicitly express sign with a 'U' or 'u' suffix. |
+| test.c:300:3:300:27 | 9223372036854775808 | Unsigned literal 01000000000000000000000LL does not explicitly express sign with a 'U' or 'u' suffix. |

--- a/c/misra/test/rules/RULE-7-2/UOrUSuffixRepresentedInUnsignedType.expected
+++ b/c/misra/test/rules/RULE-7-2/UOrUSuffixRepresentedInUnsignedType.expected
@@ -4,3 +4,9 @@
 | test.c:162:3:162:21 | 9223372036854775808 | Unsigned literal 0x8000000000000000L does not explicitly express sign with a 'U' or 'u' suffix. |
 | test.c:185:3:185:22 | 9223372036854775808 | Unsigned literal 0x8000000000000000ll does not explicitly express sign with a 'U' or 'u' suffix. |
 | test.c:208:3:208:22 | 9223372036854775808 | Unsigned literal 0x8000000000000000LL does not explicitly express sign with a 'U' or 'u' suffix. |
+| test.c:227:3:227:14 | 2147483648 | Unsigned literal 020000000000 does not explicitly express sign with a 'U' or 'u' suffix. |
+| test.c:232:3:232:25 | 9223372036854775808 | Unsigned literal 01000000000000000000000 does not explicitly express sign with a 'U' or 'u' suffix. |
+| test.c:249:3:249:26 | 9223372036854775808 | Unsigned literal 01000000000000000000000l does not explicitly express sign with a 'U' or 'u' suffix. |
+| test.c:266:3:266:26 | 9223372036854775808 | Unsigned literal 01000000000000000000000L does not explicitly express sign with a 'U' or 'u' suffix. |
+| test.c:283:3:283:26 | 9223372036854775808 | Unsigned literal 01000000000000000000000l does not explicitly express sign with a 'U' or 'u' suffix. |
+| test.c:300:3:300:26 | 9223372036854775808 | Unsigned literal 01000000000000000000000L does not explicitly express sign with a 'U' or 'u' suffix. |

--- a/c/misra/test/rules/RULE-7-2/test.c
+++ b/c/misra/test/rules/RULE-7-2/test.c
@@ -275,38 +275,38 @@ void test_octal_constants() {
                              // correctly
 
   // Use of the `ll` suffix
-  00ll;                     // COMPLIANT - uses signed long long
-  017777777777l;            // COMPLIANT - uses signed long long
-  020000000000l;            // COMPLIANT - uses signed long long
-  040000000000l;            // COMPLIANT - uses signed long long
-  0777777777777777777777l;  // COMPLIANT - max long int
-  01000000000000000000000l; // NON_COMPLIANT - larger than long int, so will be
-                            // unsigned long int
-  00Ul;           // COMPLIANT - unsigned, but uses the suffix correctly
-  017777777777Ul; // COMPLIANT - unsigned, but uses the suffix correctly
-  020000000000Ul; // COMPLIANT - unsigned, but uses the suffix correctly
-  040000000000Ul; // COMPLIANT - unsigned, but uses the suffix correctly
-  0777777777777777777777Ul;  // COMPLIANT - unsigned, but uses the suffix
-                             // correctly
-  01000000000000000000000Ul; // COMPLIANT - unsigned, but uses the suffix
-                             // correctly
+  00ll;                      // COMPLIANT - uses signed long long
+  017777777777ll;            // COMPLIANT - uses signed long long
+  020000000000ll;            // COMPLIANT - uses signed long long
+  040000000000ll;            // COMPLIANT - uses signed long long
+  0777777777777777777777ll;  // COMPLIANT - max long int
+  01000000000000000000000ll; // NON_COMPLIANT - larger than long int, so will be
+                             // unsigned long int
+  00Ull;           // COMPLIANT - unsigned, but uses the suffix correctly
+  017777777777Ull; // COMPLIANT - unsigned, but uses the suffix correctly
+  020000000000Ull; // COMPLIANT - unsigned, but uses the suffix correctly
+  040000000000Ull; // COMPLIANT - unsigned, but uses the suffix correctly
+  0777777777777777777777Ull;  // COMPLIANT - unsigned, but uses the suffix
+                              // correctly
+  01000000000000000000000Ull; // COMPLIANT - unsigned, but uses the suffix
+                              // correctly
 
   // Use of the `LL` suffix
-  00L;                      // COMPLIANT - uses signed long long
-  017777777777L;            // COMPLIANT - uses signed long long
-  020000000000L;            // COMPLIANT - uses signed long long
-  040000000000L;            // COMPLIANT - uses signed long long
-  0777777777777777777777L;  // COMPLIANT - max long int
-  01000000000000000000000L; // NON_COMPLIANT - larger than long int, so will be
-                            // unsigned long int
-  00UL;           // COMPLIANT - unsigned, but uses the suffix correctly
-  017777777777UL; // COMPLIANT - unsigned, but uses the suffix correctly
-  020000000000UL; // COMPLIANT - unsigned, but uses the suffix correctly
-  040000000000UL; // COMPLIANT - unsigned, but uses the suffix correctly
-  0777777777777777777777UL;  // COMPLIANT - unsigned, but uses the suffix
-                             // correctly
-  01000000000000000000000UL; // COMPLIANT - unsigned, but uses the suffix
-                             // correctly
+  00LL;                      // COMPLIANT - uses signed long long
+  017777777777LL;            // COMPLIANT - uses signed long long
+  020000000000LL;            // COMPLIANT - uses signed long long
+  040000000000LL;            // COMPLIANT - uses signed long long
+  0777777777777777777777LL;  // COMPLIANT - max long int
+  01000000000000000000000LL; // NON_COMPLIANT - larger than long int, so will be
+                             // unsigned long int
+  00ULL;           // COMPLIANT - unsigned, but uses the suffix correctly
+  017777777777ULL; // COMPLIANT - unsigned, but uses the suffix correctly
+  020000000000ULL; // COMPLIANT - unsigned, but uses the suffix correctly
+  040000000000ULL; // COMPLIANT - unsigned, but uses the suffix correctly
+  0777777777777777777777ULL;  // COMPLIANT - unsigned, but uses the suffix
+                              // correctly
+  01000000000000000000000ULL; // COMPLIANT - unsigned, but uses the suffix
+                              // correctly
 }
 
 #define COMPLIANT_VAL 0x80000000U

--- a/c/misra/test/rules/RULE-7-2/test.c
+++ b/c/misra/test/rules/RULE-7-2/test.c
@@ -221,6 +221,94 @@ void test_hexadecimal_constants() {
   0x8000000000000000LLu; // COMPLIANT - unsigned, but uses the suffix correctly
 }
 
+void test_octal_constants() {
+  00;           // COMPLIANT - uses signed int
+  017777777777; // COMPLIANT - max value held by signed int
+  020000000000; // NON_COMPLIANT - larger than max signed int, so will be
+                // unsigned int
+  040000000000; // COMPLIANT - larger than unsigned int, but smaller than long
+                // int
+  0777777777777777777777;  // COMPLIANT - max long int
+  01000000000000000000000; // NON_COMPLIANT - larger than long int, so will be
+                           // unsigned long int
+  00U;           // COMPLIANT - unsigned, but uses the suffix correctly
+  017777777777U; // COMPLIANT - unsigned, but uses the suffix correctly
+  020000000000U; // COMPLIANT - unsigned, but uses the suffix correctly
+  040000000000U; // COMPLIANT - unsigned, but uses the suffix correctly
+  0777777777777777777777U;  // COMPLIANT - unsigned, but uses the suffix
+                            // correctly
+  01000000000000000000000U; // COMPLIANT - unsigned, but uses the suffix
+                            // correctly
+
+  // Use of the `l` suffix
+  00l;                      // COMPLIANT - uses signed long
+  017777777777l;            // COMPLIANT - uses signed long
+  020000000000l;            // COMPLIANT - uses signed long
+  040000000000l;            // COMPLIANT - uses signed long
+  0777777777777777777777l;  // COMPLIANT - max long int
+  01000000000000000000000l; // NON_COMPLIANT - larger than long int, so will be
+                            // unsigned long int
+  00Ul;           // COMPLIANT - unsigned, but uses the suffix correctly
+  017777777777Ul; // COMPLIANT - unsigned, but uses the suffix correctly
+  020000000000Ul; // COMPLIANT - unsigned, but uses the suffix correctly
+  040000000000Ul; // COMPLIANT - unsigned, but uses the suffix correctly
+  0777777777777777777777Ul;  // COMPLIANT - unsigned, but uses the suffix
+                             // correctly
+  01000000000000000000000Ul; // COMPLIANT - unsigned, but uses the suffix
+                             // correctly
+
+  // Use of the `L` suffix
+  00L;                      // COMPLIANT - uses signed long
+  017777777777L;            // COMPLIANT - uses signed long
+  020000000000L;            // COMPLIANT - uses signed long
+  040000000000L;            // COMPLIANT - uses signed long
+  0777777777777777777777L;  // COMPLIANT - COMPLIANT - uses signed long
+  01000000000000000000000L; // NON_COMPLIANT - larger than long int, so will be
+                            // unsigned long int
+  00UL;           // COMPLIANT - unsigned, but uses the suffix correctly
+  017777777777UL; // COMPLIANT - unsigned, but uses the suffix correctly
+  020000000000UL; // COMPLIANT - unsigned, but uses the suffix correctly
+  040000000000UL; // COMPLIANT - unsigned, but uses the suffix correctly
+  0777777777777777777777UL;  // COMPLIANT - unsigned, but uses the suffix
+                             // correctly
+  01000000000000000000000UL; // COMPLIANT - unsigned, but uses the suffix
+                             // correctly
+
+  // Use of the `ll` suffix
+  00ll;                     // COMPLIANT - uses signed long long
+  017777777777l;            // COMPLIANT - uses signed long long
+  020000000000l;            // COMPLIANT - uses signed long long
+  040000000000l;            // COMPLIANT - uses signed long long
+  0777777777777777777777l;  // COMPLIANT - max long int
+  01000000000000000000000l; // NON_COMPLIANT - larger than long int, so will be
+                            // unsigned long int
+  00Ul;           // COMPLIANT - unsigned, but uses the suffix correctly
+  017777777777Ul; // COMPLIANT - unsigned, but uses the suffix correctly
+  020000000000Ul; // COMPLIANT - unsigned, but uses the suffix correctly
+  040000000000Ul; // COMPLIANT - unsigned, but uses the suffix correctly
+  0777777777777777777777Ul;  // COMPLIANT - unsigned, but uses the suffix
+                             // correctly
+  01000000000000000000000Ul; // COMPLIANT - unsigned, but uses the suffix
+                             // correctly
+
+  // Use of the `LL` suffix
+  00L;                      // COMPLIANT - uses signed long long
+  017777777777L;            // COMPLIANT - uses signed long long
+  020000000000L;            // COMPLIANT - uses signed long long
+  040000000000L;            // COMPLIANT - uses signed long long
+  0777777777777777777777L;  // COMPLIANT - max long int
+  01000000000000000000000L; // NON_COMPLIANT - larger than long int, so will be
+                            // unsigned long int
+  00UL;           // COMPLIANT - unsigned, but uses the suffix correctly
+  017777777777UL; // COMPLIANT - unsigned, but uses the suffix correctly
+  020000000000UL; // COMPLIANT - unsigned, but uses the suffix correctly
+  040000000000UL; // COMPLIANT - unsigned, but uses the suffix correctly
+  0777777777777777777777UL;  // COMPLIANT - unsigned, but uses the suffix
+                             // correctly
+  01000000000000000000000UL; // COMPLIANT - unsigned, but uses the suffix
+                             // correctly
+}
+
 #define COMPLIANT_VAL 0x80000000U
 #define NON_COMPLIANT_VAL 0x80000000
 

--- a/change_notes/2024-10-17-suffixes.md
+++ b/change_notes/2024-10-17-suffixes.md
@@ -1,0 +1,4 @@
+ - `5.13.4` - `UnsignedLiteralsNotAppropriatelySuffixed.ql`:
+   - Expand detection to binary literals.
+ - `M2-13-3` - `MissingUSuffix.ql`:
+   - Expand detection to binary literals.

--- a/cpp/common/src/codingstandards/cpp/rules/unsignedintegerliteralsnotappropriatelysuffixed/UnsignedIntegerLiteralsNotAppropriatelySuffixed.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/unsignedintegerliteralsnotappropriatelysuffixed/UnsignedIntegerLiteralsNotAppropriatelySuffixed.qll
@@ -19,6 +19,8 @@ query predicate problems(Cpp14Literal::NumericLiteral nl, string message) {
       nl instanceof Cpp14Literal::OctalLiteral and literalKind = "Octal"
       or
       nl instanceof Cpp14Literal::HexLiteral and literalKind = "Hex"
+      or
+      nl instanceof Cpp14Literal::BinaryLiteral and literalKind = "Binary"
     ) and
     // This either directly has an unsigned integer type, or it is converted to an unsigned integer type
     nl.getType().getUnspecifiedType().(IntegralType).isUnsigned() and

--- a/cpp/common/test/rules/unsignedintegerliteralsnotappropriatelysuffixed/UnsignedIntegerLiteralsNotAppropriatelySuffixed.expected
+++ b/cpp/common/test/rules/unsignedintegerliteralsnotappropriatelysuffixed/UnsignedIntegerLiteralsNotAppropriatelySuffixed.expected
@@ -8,5 +8,5 @@
 | test.cpp:232:3:232:25 | 9223372036854775808 | Octal literal is an unsigned integer but does not include a 'U' suffix. |
 | test.cpp:249:3:249:26 | 9223372036854775808 | Octal literal is an unsigned integer but does not include a 'U' suffix. |
 | test.cpp:266:3:266:26 | 9223372036854775808 | Octal literal is an unsigned integer but does not include a 'U' suffix. |
-| test.cpp:283:3:283:26 | 9223372036854775808 | Octal literal is an unsigned integer but does not include a 'U' suffix. |
-| test.cpp:300:3:300:26 | 9223372036854775808 | Octal literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:283:3:283:27 | 9223372036854775808 | Octal literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:300:3:300:27 | 9223372036854775808 | Octal literal is an unsigned integer but does not include a 'U' suffix. |

--- a/cpp/common/test/rules/unsignedintegerliteralsnotappropriatelysuffixed/UnsignedIntegerLiteralsNotAppropriatelySuffixed.expected
+++ b/cpp/common/test/rules/unsignedintegerliteralsnotappropriatelysuffixed/UnsignedIntegerLiteralsNotAppropriatelySuffixed.expected
@@ -10,3 +10,9 @@
 | test.cpp:266:3:266:26 | 9223372036854775808 | Octal literal is an unsigned integer but does not include a 'U' suffix. |
 | test.cpp:283:3:283:27 | 9223372036854775808 | Octal literal is an unsigned integer but does not include a 'U' suffix. |
 | test.cpp:300:3:300:27 | 9223372036854775808 | Octal literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:315:3:315:36 | 2147483648 | Binary literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:322:3:322:68 | 9223372036854775808 | Binary literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:365:3:365:69 | 9223372036854775808 | Binary literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:412:3:412:69 | 9223372036854775808 | Binary literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:457:3:457:70 | 9223372036854775808 | Binary literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:502:3:502:70 | 9223372036854775808 | Binary literal is an unsigned integer but does not include a 'U' suffix. |

--- a/cpp/common/test/rules/unsignedintegerliteralsnotappropriatelysuffixed/UnsignedIntegerLiteralsNotAppropriatelySuffixed.expected
+++ b/cpp/common/test/rules/unsignedintegerliteralsnotappropriatelysuffixed/UnsignedIntegerLiteralsNotAppropriatelySuffixed.expected
@@ -1,1 +1,12 @@
-| test.cpp:3:3:3:12 | 4294967295 | Hex literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:111:3:111:12 | 2147483648 | Hex literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:116:3:116:20 | 9223372036854775808 | Hex literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:139:3:139:21 | 9223372036854775808 | Hex literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:162:3:162:21 | 9223372036854775808 | Hex literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:185:3:185:22 | 9223372036854775808 | Hex literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:208:3:208:22 | 9223372036854775808 | Hex literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:227:3:227:14 | 2147483648 | Octal literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:232:3:232:25 | 9223372036854775808 | Octal literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:249:3:249:26 | 9223372036854775808 | Octal literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:266:3:266:26 | 9223372036854775808 | Octal literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:283:3:283:26 | 9223372036854775808 | Octal literal is an unsigned integer but does not include a 'U' suffix. |
+| test.cpp:300:3:300:26 | 9223372036854775808 | Octal literal is an unsigned integer but does not include a 'U' suffix. |

--- a/cpp/common/test/rules/unsignedintegerliteralsnotappropriatelysuffixed/test.cpp
+++ b/cpp/common/test/rules/unsignedintegerliteralsnotappropriatelysuffixed/test.cpp
@@ -275,38 +275,38 @@ void test_octal_constants() {
                              // correctly
 
   // Use of the `ll` suffix
-  00ll;                     // COMPLIANT - uses signed long long
-  017777777777l;            // COMPLIANT - uses signed long long
-  020000000000l;            // COMPLIANT - uses signed long long
-  040000000000l;            // COMPLIANT - uses signed long long
-  0777777777777777777777l;  // COMPLIANT - max long int
-  01000000000000000000000l; // NON_COMPLIANT - larger than long int, so will be
-                            // unsigned long int
-  00Ul;           // COMPLIANT - unsigned, but uses the suffix correctly
-  017777777777Ul; // COMPLIANT - unsigned, but uses the suffix correctly
-  020000000000Ul; // COMPLIANT - unsigned, but uses the suffix correctly
-  040000000000Ul; // COMPLIANT - unsigned, but uses the suffix correctly
-  0777777777777777777777Ul;  // COMPLIANT - unsigned, but uses the suffix
-                             // correctly
-  01000000000000000000000Ul; // COMPLIANT - unsigned, but uses the suffix
-                             // correctly
+  00ll;                      // COMPLIANT - uses signed long long
+  017777777777ll;            // COMPLIANT - uses signed long long
+  020000000000ll;            // COMPLIANT - uses signed long long
+  040000000000ll;            // COMPLIANT - uses signed long long
+  0777777777777777777777ll;  // COMPLIANT - max long int
+  01000000000000000000000ll; // NON_COMPLIANT - larger than long int, so will be
+                             // unsigned long int
+  00Ull;           // COMPLIANT - unsigned, but uses the suffix correctly
+  017777777777Ull; // COMPLIANT - unsigned, but uses the suffix correctly
+  020000000000Ull; // COMPLIANT - unsigned, but uses the suffix correctly
+  040000000000Ull; // COMPLIANT - unsigned, but uses the suffix correctly
+  0777777777777777777777Ull;  // COMPLIANT - unsigned, but uses the suffix
+                              // correctly
+  01000000000000000000000Ull; // COMPLIANT - unsigned, but uses the suffix
+                              // correctly
 
   // Use of the `LL` suffix
-  00L;                      // COMPLIANT - uses signed long long
-  017777777777L;            // COMPLIANT - uses signed long long
-  020000000000L;            // COMPLIANT - uses signed long long
-  040000000000L;            // COMPLIANT - uses signed long long
-  0777777777777777777777L;  // COMPLIANT - max long int
-  01000000000000000000000L; // NON_COMPLIANT - larger than long int, so will be
-                            // unsigned long int
-  00UL;           // COMPLIANT - unsigned, but uses the suffix correctly
-  017777777777UL; // COMPLIANT - unsigned, but uses the suffix correctly
-  020000000000UL; // COMPLIANT - unsigned, but uses the suffix correctly
-  040000000000UL; // COMPLIANT - unsigned, but uses the suffix correctly
-  0777777777777777777777UL;  // COMPLIANT - unsigned, but uses the suffix
-                             // correctly
-  01000000000000000000000UL; // COMPLIANT - unsigned, but uses the suffix
-                             // correctly
+  00LL;                      // COMPLIANT - uses signed long long
+  017777777777LL;            // COMPLIANT - uses signed long long
+  020000000000LL;            // COMPLIANT - uses signed long long
+  040000000000LL;            // COMPLIANT - uses signed long long
+  0777777777777777777777LL;  // COMPLIANT - max long int
+  01000000000000000000000LL; // NON_COMPLIANT - larger than long int, so will be
+                             // unsigned long int
+  00ULL;           // COMPLIANT - unsigned, but uses the suffix correctly
+  017777777777ULL; // COMPLIANT - unsigned, but uses the suffix correctly
+  020000000000ULL; // COMPLIANT - unsigned, but uses the suffix correctly
+  040000000000ULL; // COMPLIANT - unsigned, but uses the suffix correctly
+  0777777777777777777777ULL;  // COMPLIANT - unsigned, but uses the suffix
+                              // correctly
+  01000000000000000000000ULL; // COMPLIANT - unsigned, but uses the suffix
+                              // correctly
 }
 
 #define COMPLIANT_VAL 0x80000000U

--- a/cpp/common/test/rules/unsignedintegerliteralsnotappropriatelysuffixed/test.cpp
+++ b/cpp/common/test/rules/unsignedintegerliteralsnotappropriatelysuffixed/test.cpp
@@ -309,6 +309,233 @@ void test_octal_constants() {
                               // correctly
 }
 
+void test_binary_constants() {
+  0b0;                               // COMPLIANT - uses signed int
+  0b1111111111111111111111111111111; // COMPLIANT - max value held by signed int
+  0b10000000000000000000000000000000;  // NON_COMPLIANT - larger than max signed
+                                       // int, so will be unsigned int
+  0b100000000000000000000000000000000; // COMPLIANT - larger than unsigned int,
+                                       // but smaller than long int
+  0b111111111111111111111111111111111111111111111111111111111111111; // COMPLIANT
+                                                                     // - max
+                                                                     // long int
+  0b1000000000000000000000000000000000000000000000000000000000000000; // NON_COMPLIANT
+                                                                      // -
+                                                                      // larger
+                                                                      // than
+                                                                      // long
+                                                                      // int, so
+                                                                      // will be
+                                                                      // unsigned
+                                                                      // long
+                                                                      // int
+  0b0U; // COMPLIANT - unsigned, but uses the suffix correctly
+  0b1111111111111111111111111111111U;   // COMPLIANT - unsigned, but uses the
+                                        // suffix correctly
+  0b10000000000000000000000000000000U;  // COMPLIANT - unsigned, but uses the
+                                        // suffix correctly
+  0b100000000000000000000000000000000U; // COMPLIANT - unsigned, but uses the
+                                        // suffix correctly
+  0b111111111111111111111111111111111111111111111111111111111111111U; // COMPLIANT
+                                                                      // -
+                                                                      // unsigned,
+                                                                      // but
+                                                                      // uses
+                                                                      // the
+                                                                      // suffix
+                                                                      // correctly
+  0b1000000000000000000000000000000000000000000000000000000000000000U; // COMPLIANT
+                                                                       // -
+                                                                       // unsigned,
+                                                                       // but
+                                                                       // uses
+                                                                       // the
+                                                                       // suffix
+                                                                       // correctly
+
+  // Use of the `l` suffix
+  0b0l;                                 // COMPLIANT - uses signed long
+  0b1111111111111111111111111111111l;   // COMPLIANT - uses signed long
+  0b10000000000000000000000000000000l;  // COMPLIANT - uses signed long
+  0b100000000000000000000000000000000l; // COMPLIANT - uses signed long
+  0b111111111111111111111111111111111111111111111111111111111111111l; // COMPLIANT
+                                                                      // - max
+                                                                      // long
+                                                                      // int
+  0b1000000000000000000000000000000000000000000000000000000000000000l; // NON_COMPLIANT
+                                                                       // -
+                                                                       // larger
+                                                                       // than
+                                                                       // long
+                                                                       // int,
+                                                                       // so
+                                                                       // will
+                                                                       // be
+                                                                       // unsigned
+                                                                       // long
+                                                                       // int
+  0b0Ul; // COMPLIANT - unsigned, but uses the suffix correctly
+  0b1111111111111111111111111111111Ul;   // COMPLIANT - unsigned, but uses the
+                                         // suffix correctly
+  0b10000000000000000000000000000000Ul;  // COMPLIANT - unsigned, but uses the
+                                         // suffix correctly
+  0b100000000000000000000000000000000Ul; // COMPLIANT - unsigned, but uses the
+                                         // suffix correctly
+  0b111111111111111111111111111111111111111111111111111111111111111Ul; // COMPLIANT
+                                                                       // -
+                                                                       // unsigned,
+                                                                       // but
+                                                                       // uses
+                                                                       // the
+                                                                       // suffix
+                                                                       // correctly
+  0b1000000000000000000000000000000000000000000000000000000000000000Ul; // COMPLIANT
+                                                                        // -
+                                                                        // unsigned,
+                                                                        // but
+                                                                        // uses
+                                                                        // the
+                                                                        // suffix
+                                                                        // correctly
+
+  // Use of the `L` suffix
+  0b0L;                                 // COMPLIANT - uses signed long
+  0b1111111111111111111111111111111L;   // COMPLIANT - uses signed long
+  0b10000000000000000000000000000000L;  // COMPLIANT - uses signed long
+  0b100000000000000000000000000000000L; // COMPLIANT - uses signed long
+  0b111111111111111111111111111111111111111111111111111111111111111L; // COMPLIANT
+                                                                      // -
+                                                                      // COMPLIANT
+                                                                      // - uses
+                                                                      // signed
+                                                                      // long
+  0b1000000000000000000000000000000000000000000000000000000000000000L; // NON_COMPLIANT
+                                                                       // -
+                                                                       // larger
+                                                                       // than
+                                                                       // long
+                                                                       // int,
+                                                                       // so
+                                                                       // will
+                                                                       // be
+                                                                       // unsigned
+                                                                       // long
+                                                                       // int
+  0b0UL; // COMPLIANT - unsigned, but uses the suffix correctly
+  0b1111111111111111111111111111111UL;   // COMPLIANT - unsigned, but uses the
+                                         // suffix correctly
+  0b10000000000000000000000000000000UL;  // COMPLIANT - unsigned, but uses the
+                                         // suffix correctly
+  0b100000000000000000000000000000000UL; // COMPLIANT - unsigned, but uses the
+                                         // suffix correctly
+  0b111111111111111111111111111111111111111111111111111111111111111UL; // COMPLIANT
+                                                                       // -
+                                                                       // unsigned,
+                                                                       // but
+                                                                       // uses
+                                                                       // the
+                                                                       // suffix
+                                                                       // correctly
+  0b1000000000000000000000000000000000000000000000000000000000000000UL; // COMPLIANT
+                                                                        // -
+                                                                        // unsigned,
+                                                                        // but
+                                                                        // uses
+                                                                        // the
+                                                                        // suffix
+                                                                        // correctly
+
+  // Use of the `ll` suffix
+  0b0ll;                                 // COMPLIANT - uses signed long long
+  0b1111111111111111111111111111111ll;   // COMPLIANT - uses signed long long
+  0b10000000000000000000000000000000ll;  // COMPLIANT - uses signed long long
+  0b100000000000000000000000000000000ll; // COMPLIANT - uses signed long long
+  0b111111111111111111111111111111111111111111111111111111111111111ll; // COMPLIANT
+                                                                       // - max
+                                                                       // long
+                                                                       // int
+  0b1000000000000000000000000000000000000000000000000000000000000000ll; // NON_COMPLIANT
+                                                                        // -
+                                                                        // larger
+                                                                        // than
+                                                                        // long
+                                                                        // int,
+                                                                        // so
+                                                                        // will
+                                                                        // be
+                                                                        // unsigned
+                                                                        // long
+                                                                        // int
+  0b0Ull; // COMPLIANT - unsigned, but uses the suffix correctly
+  0b1111111111111111111111111111111Ull;   // COMPLIANT - unsigned, but uses the
+                                          // suffix correctly
+  0b10000000000000000000000000000000Ull;  // COMPLIANT - unsigned, but uses the
+                                          // suffix correctly
+  0b100000000000000000000000000000000Ull; // COMPLIANT - unsigned, but uses the
+                                          // suffix correctly
+  0b111111111111111111111111111111111111111111111111111111111111111Ull; // COMPLIANT
+                                                                        // -
+                                                                        // unsigned,
+                                                                        // but
+                                                                        // uses
+                                                                        // the
+                                                                        // suffix
+                                                                        // correctly
+  0b1000000000000000000000000000000000000000000000000000000000000000Ull; // COMPLIANT
+                                                                         // -
+                                                                         // unsigned,
+                                                                         // but
+                                                                         // uses
+                                                                         // the
+                                                                         // suffix
+                                                                         // correctly
+
+  // Use of the `LL` suffix
+  00LL;                                  // COMPLIANT - uses signed long long
+  0b1111111111111111111111111111111LL;   // COMPLIANT - uses signed long long
+  0b10000000000000000000000000000000LL;  // COMPLIANT - uses signed long long
+  0b100000000000000000000000000000000LL; // COMPLIANT - uses signed long long
+  0b111111111111111111111111111111111111111111111111111111111111111LL; // COMPLIANT
+                                                                       // - max
+                                                                       // long
+                                                                       // int
+  0b1000000000000000000000000000000000000000000000000000000000000000LL; // NON_COMPLIANT
+                                                                        // -
+                                                                        // larger
+                                                                        // than
+                                                                        // long
+                                                                        // int,
+                                                                        // so
+                                                                        // will
+                                                                        // be
+                                                                        // unsigned
+                                                                        // long
+                                                                        // int
+  00ULL; // COMPLIANT - unsigned, but uses the suffix correctly
+  0b1111111111111111111111111111111ULL;   // COMPLIANT - unsigned, but uses the
+                                          // suffix correctly
+  0b10000000000000000000000000000000ULL;  // COMPLIANT - unsigned, but uses the
+                                          // suffix correctly
+  0b100000000000000000000000000000000ULL; // COMPLIANT - unsigned, but uses the
+                                          // suffix correctly
+  0b111111111111111111111111111111111111111111111111111111111111111ULL; // COMPLIANT
+                                                                        // -
+                                                                        // unsigned,
+                                                                        // but
+                                                                        // uses
+                                                                        // the
+                                                                        // suffix
+                                                                        // correctly
+  0b1000000000000000000000000000000000000000000000000000000000000000ULL; // COMPLIANT
+                                                                         // -
+                                                                         // unsigned,
+                                                                         // but
+                                                                         // uses
+                                                                         // the
+                                                                         // suffix
+                                                                         // correctly
+}
+
 #define COMPLIANT_VAL 0x80000000U
 #define NON_COMPLIANT_VAL 0x80000000
 

--- a/cpp/common/test/rules/unsignedintegerliteralsnotappropriatelysuffixed/test.cpp
+++ b/cpp/common/test/rules/unsignedintegerliteralsnotappropriatelysuffixed/test.cpp
@@ -1,5 +1,319 @@
-void test_unsigned_literals_without_suffix() {
-  0xFFFFFFFFU; // COMPLIANT - literal explicitly marked as unsigned
-  0xFFFFFFFF;  // NON_COMPLIANT - literal is too large for a signed int, so has
-               // type unsigned int
+// Assumed platform in qltest is linux_x86_64, so
+// int, long, long long sizes are assumed to be 32, 64, 64 bits respectively
+
+// The type of an integer constant is determined by "6.4.4.1 Integer constants"
+// in the C11 Standard. The principle is that any decimal integer constant will
+// be signed, unless it has the `U` or `u` suffix. Any hexadecimal integer will
+// depend on whether it is larger than the maximum value of the smallest signed
+// integer value that can hold the value. So the signedness depends on the
+// magnitude of the constant.
+
+void test_decimal_constants() {
+  0;          // COMPLIANT
+  2147483648; // COMPLIANT - larger than int, but decimal constants never use
+              // unsigned without the suffix, so will be `long`
+  4294967296; // COMPLIANT - larger than unsigned int, still `long`
+  9223372036854775807; // COMPLIANT - max long int
+  // 9223372036854775808; Not a valid integer constant, out of signed range
+  0U;                   // COMPLIANT - unsigned, but uses the suffix correctly
+  2147483648U;          // COMPLIANT - unsigned, but uses the suffix correctly
+  4294967296U;          // COMPLIANT - unsigned, but uses the suffix correctly
+  9223372036854775807U; // COMPLIANT - max long int
+  9223372036854775808U; // COMPLIANT - explicitly unsigned, so can go large than
+                        // max long int
+  0u;                   // COMPLIANT - unsigned, but uses the suffix correctly
+  2147483648u;          // COMPLIANT - unsigned, but uses the suffix correctly
+  4294967296u;          // COMPLIANT - unsigned, but uses the suffix correctly
+  9223372036854775807u; // COMPLIANT - max long int
+  9223372036854775808u; // COMPLIANT - explicitly unsigned, so can go large than
+                        // max long int
+
+  // l suffix
+  0l;                   // COMPLIANT
+  2147483648l;          // COMPLIANT - within the range of long int
+  4294967296l;          // COMPLIANT - within the range of long int
+  9223372036854775807l; // COMPLIANT - max long int
+  // 9223372036854775808l; Not a valid integer constant, out of signed range
+  0lU;                   // COMPLIANT - unsigned, but uses the suffix correctly
+  2147483648lU;          // COMPLIANT - unsigned, but uses the suffix correctly
+  4294967296lU;          // COMPLIANT - unsigned, but uses the suffix correctly
+  9223372036854775807lU; // COMPLIANT - max long int
+  9223372036854775808lU; // COMPLIANT - explicitly unsigned, so can go large
+                         // than max long int
+  0lu;                   // COMPLIANT - unsigned, but uses the suffix correctly
+  2147483648lu;          // COMPLIANT - unsigned, but uses the suffix correctly
+  4294967296lu;          // COMPLIANT - unsigned, but uses the suffix correctly
+  9223372036854775807lu; // COMPLIANT - max long int
+  9223372036854775808lu; // COMPLIANT - explicitly unsigned, so can go large
+                         // than max long int
+
+  // L suffix
+  0L;                   // COMPLIANT
+  2147483648L;          // COMPLIANT - within the range of long int
+  4294967296L;          // COMPLIANT - within the range of long int
+  9223372036854775807L; // COMPLIANT - max long int
+  // 9223372036854775808L; Not a valid integer constant, out of signed range
+  0LU;                   // COMPLIANT - unsigned, but uses the suffix correctly
+  2147483648LU;          // COMPLIANT - unsigned, but uses the suffix correctly
+  4294967296LU;          // COMPLIANT - unsigned, but uses the suffix correctly
+  9223372036854775807LU; // COMPLIANT - max long int
+  9223372036854775808LU; // COMPLIANT - explicitly unsigned, so can go large
+                         // than max long int
+  0Lu;                   // COMPLIANT - unsigned, but uses the suffix correctly
+  2147483648Lu;          // COMPLIANT - unsigned, but uses the suffix correctly
+  4294967296Lu;          // COMPLIANT - unsigned, but uses the suffix correctly
+  9223372036854775807Lu; // COMPLIANT - max long int
+  9223372036854775808Lu; // COMPLIANT - explicitly unsigned, so can go large
+                         // than max long int
+
+  // ll suffix
+  0ll;                   // COMPLIANT
+  2147483648ll;          // COMPLIANT - within the range of long long int
+  4294967296ll;          // COMPLIANT - within the range of long long int
+  9223372036854775807ll; // COMPLIANT - max long long int
+  // 9223372036854775808ll; Not a valid integer constant, out of signed range
+  0llU;                   // COMPLIANT - unsigned, but uses the suffix correctly
+  2147483648llU;          // COMPLIANT - unsigned, but uses the suffix correctly
+  4294967296llU;          // COMPLIANT - unsigned, but uses the suffix correctly
+  9223372036854775807llU; // COMPLIANT - max long long int
+  9223372036854775808llU; // COMPLIANT - explicitly unsigned, so can go large
+                          // than max long long int
+  0llu;                   // COMPLIANT - unsigned, but uses the suffix correctly
+  2147483648llu;          // COMPLIANT - unsigned, but uses the suffix correctly
+  4294967296llu;          // COMPLIANT - unsigned, but uses the suffix correctly
+  9223372036854775807llu; // COMPLIANT - max long long int
+  9223372036854775808llu; // COMPLIANT - explicitly unsigned, so can go large
+                          // than max long long int
+
+  // LL suffix
+  0LL;                   // COMPLIANT
+  2147483648LL;          // COMPLIANT - within the range of long long int
+  4294967296LL;          // COMPLIANT - within the range of long long int
+  9223372036854775807LL; // COMPLIANT - max long long int
+  // 9223372036854775808LL; Not a valid integer constant, out of signed range
+  0LLU;                   // COMPLIANT - unsigned, but uses the suffix correctly
+  2147483648LLU;          // COMPLIANT - unsigned, but uses the suffix correctly
+  4294967296LLU;          // COMPLIANT - unsigned, but uses the suffix correctly
+  9223372036854775807LLU; // COMPLIANT - max long long int
+  9223372036854775808LLU; // COMPLIANT - explicitly unsigned, so can go large
+                          // than max long long int
+  0LLu;                   // COMPLIANT - unsigned, but uses the suffix correctly
+  2147483648LLu;          // COMPLIANT - unsigned, but uses the suffix correctly
+  4294967296LLu;          // COMPLIANT - unsigned, but uses the suffix correctly
+  9223372036854775807LLu; // COMPLIANT - max long long int
+  9223372036854775808LLu; // COMPLIANT - explicitly unsigned, so can go large
+                          // than max long long int
+}
+
+void test_hexadecimal_constants() {
+  0x0;        // COMPLIANT - uses signed int
+  0x7FFFFFFF; // COMPLIANT - max value held by signed int
+  0x80000000; // NON_COMPLIANT - larger than max signed int, so will be unsigned
+              // int
+  0x100000000; // COMPLIANT - larger than unsigned int, but smaller than long
+               // int
+  0x7FFFFFFFFFFFFFFF;  // COMPLIANT - max long int
+  0x8000000000000000;  // NON_COMPLIANT - larger than long int, so will be
+                       // unsigned long int
+  0x0U;                // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFU;         // COMPLIANT - unsigned, but uses the suffix correctly
+  0x80000000U;         // COMPLIANT - unsigned, but uses the suffix correctly
+  0x100000000U;        // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFFFFFFFFFU; // COMPLIANT - unsigned, but uses the suffix correctly
+  0x8000000000000000U; // COMPLIANT - unsigned, but uses the suffix correctly
+  0x0u;                // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFu;         // COMPLIANT - unsigned, but uses the suffix correctly
+  0x80000000u;         // COMPLIANT - unsigned, but uses the suffix correctly
+  0x100000000u;        // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFFFFFFFFFu; // COMPLIANT - unsigned, but uses the suffix correctly
+  0x8000000000000000u; // COMPLIANT - unsigned, but uses the suffix correctly
+
+  // Use of the `l` suffix
+  0x0l;         // COMPLIANT - uses signed int
+  0x7FFFFFFFl;  // COMPLIANT - max value held by signed int
+  0x80000000l;  // COMPLIANT - larger than max signed int, but smaller than long
+                // int
+  0x100000000l; // COMPLIANT - larger than unsigned int, but smaller than long
+                // int
+  0x7FFFFFFFFFFFFFFFl;  // COMPLIANT - max long int
+  0x8000000000000000l;  // NON_COMPLIANT - larger than long int, so will be
+                        // unsigned long int
+  0x0lU;                // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFlU;         // COMPLIANT - unsigned, but uses the suffix correctly
+  0x80000000lU;         // COMPLIANT - unsigned, but uses the suffix correctly
+  0x100000000lU;        // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFFFFFFFFFlU; // COMPLIANT - unsigned, but uses the suffix correctly
+  0x8000000000000000lU; // COMPLIANT - unsigned, but uses the suffix correctly
+  0x0lu;                // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFlu;         // COMPLIANT - unsigned, but uses the suffix correctly
+  0x80000000lu;         // COMPLIANT - unsigned, but uses the suffix correctly
+  0x100000000lu;        // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFFFFFFFFFlu; // COMPLIANT - unsigned, but uses the suffix correctly
+  0x8000000000000000lu; // COMPLIANT - unsigned, but uses the suffix correctly
+
+  // Use of the `L` suffix
+  0x0L;         // COMPLIANT - uses signed int
+  0x7FFFFFFFL;  // COMPLIANT - max value held by signed int
+  0x80000000L;  // COMPLIANT - larger than max signed int, but smaller than long
+                // int
+  0x100000000L; // COMPLIANT - larger than unsigned int, but smaller than long
+                // int
+  0x7FFFFFFFFFFFFFFFL;  // COMPLIANT - max long int
+  0x8000000000000000L;  // NON_COMPLIANT - larger than long int, so will be
+                        // unsigned long int
+  0x0LU;                // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFLU;         // COMPLIANT - unsigned, but uses the suffix correctly
+  0x80000000LU;         // COMPLIANT - unsigned, but uses the suffix correctly
+  0x100000000LU;        // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFFFFFFFFFLU; // COMPLIANT - unsigned, but uses the suffix correctly
+  0x8000000000000000LU; // COMPLIANT - unsigned, but uses the suffix correctly
+  0x0Lu;                // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFLu;         // COMPLIANT - unsigned, but uses the suffix correctly
+  0x80000000Lu;         // COMPLIANT - unsigned, but uses the suffix correctly
+  0x100000000Lu;        // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFFFFFFFFFLu; // COMPLIANT - unsigned, but uses the suffix correctly
+  0x8000000000000000Lu; // COMPLIANT - unsigned, but uses the suffix correctly
+
+  // Use of the `ll` suffix
+  0x0ll;        // COMPLIANT - uses signed int
+  0x7FFFFFFFll; // COMPLIANT - max value held by signed int
+  0x80000000ll; // COMPLIANT - larger than max signed int, but smaller than long
+                // long int
+  0x100000000ll; // COMPLIANT - larger than unsigned int, but smaller than long
+                 // long int
+  0x7FFFFFFFFFFFFFFFll; // COMPLIANT - max long long int
+  0x8000000000000000ll; // NON_COMPLIANT - larger than long long int, so will be
+                        // unsigned long long int
+  0x0llU;               // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFllU;        // COMPLIANT - unsigned, but uses the suffix correctly
+  0x80000000llU;        // COMPLIANT - unsigned, but uses the suffix correctly
+  0x100000000llU;       // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFFFFFFFFFllU; // COMPLIANT - unsigned, but uses the suffix correctly
+  0x8000000000000000llU; // COMPLIANT - unsigned, but uses the suffix correctly
+  0x0llu;                // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFllu;         // COMPLIANT - unsigned, but uses the suffix correctly
+  0x80000000llu;         // COMPLIANT - unsigned, but uses the suffix correctly
+  0x100000000llu;        // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFFFFFFFFFllu; // COMPLIANT - unsigned, but uses the suffix correctly
+  0x8000000000000000llu; // COMPLIANT - unsigned, but uses the suffix correctly
+
+  // Use of the `LL` suffix
+  0x0LL;        // COMPLIANT - uses signed int
+  0x7FFFFFFFLL; // COMPLIANT - max value held by signed int
+  0x80000000LL; // COMPLIANT - larger than max signed int, but smaller than long
+                // long int
+  0x100000000LL; // COMPLIANT - larger than unsigned int, but smaller than long
+                 // long int
+  0x7FFFFFFFFFFFFFFFLL; // COMPLIANT - max long long int
+  0x8000000000000000LL; // NON_COMPLIANT - larger than long long int, so will be
+                        // unsigned long long int
+  0x0LLU;               // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFLLU;        // COMPLIANT - unsigned, but uses the suffix correctly
+  0x80000000LLU;        // COMPLIANT - unsigned, but uses the suffix correctly
+  0x100000000LLU;       // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFFFFFFFFFLLU; // COMPLIANT - unsigned, but uses the suffix correctly
+  0x8000000000000000LLU; // COMPLIANT - unsigned, but uses the suffix correctly
+  0x0LLu;                // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFLLu;         // COMPLIANT - unsigned, but uses the suffix correctly
+  0x80000000LLu;         // COMPLIANT - unsigned, but uses the suffix correctly
+  0x100000000LLu;        // COMPLIANT - unsigned, but uses the suffix correctly
+  0x7FFFFFFFFFFFFFFFLLu; // COMPLIANT - unsigned, but uses the suffix correctly
+  0x8000000000000000LLu; // COMPLIANT - unsigned, but uses the suffix correctly
+}
+
+void test_octal_constants() {
+  00;           // COMPLIANT - uses signed int
+  017777777777; // COMPLIANT - max value held by signed int
+  020000000000; // NON_COMPLIANT - larger than max signed int, so will be
+                // unsigned int
+  040000000000; // COMPLIANT - larger than unsigned int, but smaller than long
+                // int
+  0777777777777777777777;  // COMPLIANT - max long int
+  01000000000000000000000; // NON_COMPLIANT - larger than long int, so will be
+                           // unsigned long int
+  00U;           // COMPLIANT - unsigned, but uses the suffix correctly
+  017777777777U; // COMPLIANT - unsigned, but uses the suffix correctly
+  020000000000U; // COMPLIANT - unsigned, but uses the suffix correctly
+  040000000000U; // COMPLIANT - unsigned, but uses the suffix correctly
+  0777777777777777777777U;  // COMPLIANT - unsigned, but uses the suffix
+                            // correctly
+  01000000000000000000000U; // COMPLIANT - unsigned, but uses the suffix
+                            // correctly
+
+  // Use of the `l` suffix
+  00l;                      // COMPLIANT - uses signed long
+  017777777777l;            // COMPLIANT - uses signed long
+  020000000000l;            // COMPLIANT - uses signed long
+  040000000000l;            // COMPLIANT - uses signed long
+  0777777777777777777777l;  // COMPLIANT - max long int
+  01000000000000000000000l; // NON_COMPLIANT - larger than long int, so will be
+                            // unsigned long int
+  00Ul;           // COMPLIANT - unsigned, but uses the suffix correctly
+  017777777777Ul; // COMPLIANT - unsigned, but uses the suffix correctly
+  020000000000Ul; // COMPLIANT - unsigned, but uses the suffix correctly
+  040000000000Ul; // COMPLIANT - unsigned, but uses the suffix correctly
+  0777777777777777777777Ul;  // COMPLIANT - unsigned, but uses the suffix
+                             // correctly
+  01000000000000000000000Ul; // COMPLIANT - unsigned, but uses the suffix
+                             // correctly
+
+  // Use of the `L` suffix
+  00L;                      // COMPLIANT - uses signed long
+  017777777777L;            // COMPLIANT - uses signed long
+  020000000000L;            // COMPLIANT - uses signed long
+  040000000000L;            // COMPLIANT - uses signed long
+  0777777777777777777777L;  // COMPLIANT - COMPLIANT - uses signed long
+  01000000000000000000000L; // NON_COMPLIANT - larger than long int, so will be
+                            // unsigned long int
+  00UL;           // COMPLIANT - unsigned, but uses the suffix correctly
+  017777777777UL; // COMPLIANT - unsigned, but uses the suffix correctly
+  020000000000UL; // COMPLIANT - unsigned, but uses the suffix correctly
+  040000000000UL; // COMPLIANT - unsigned, but uses the suffix correctly
+  0777777777777777777777UL;  // COMPLIANT - unsigned, but uses the suffix
+                             // correctly
+  01000000000000000000000UL; // COMPLIANT - unsigned, but uses the suffix
+                             // correctly
+
+  // Use of the `ll` suffix
+  00ll;                     // COMPLIANT - uses signed long long
+  017777777777l;            // COMPLIANT - uses signed long long
+  020000000000l;            // COMPLIANT - uses signed long long
+  040000000000l;            // COMPLIANT - uses signed long long
+  0777777777777777777777l;  // COMPLIANT - max long int
+  01000000000000000000000l; // NON_COMPLIANT - larger than long int, so will be
+                            // unsigned long int
+  00Ul;           // COMPLIANT - unsigned, but uses the suffix correctly
+  017777777777Ul; // COMPLIANT - unsigned, but uses the suffix correctly
+  020000000000Ul; // COMPLIANT - unsigned, but uses the suffix correctly
+  040000000000Ul; // COMPLIANT - unsigned, but uses the suffix correctly
+  0777777777777777777777Ul;  // COMPLIANT - unsigned, but uses the suffix
+                             // correctly
+  01000000000000000000000Ul; // COMPLIANT - unsigned, but uses the suffix
+                             // correctly
+
+  // Use of the `LL` suffix
+  00L;                      // COMPLIANT - uses signed long long
+  017777777777L;            // COMPLIANT - uses signed long long
+  020000000000L;            // COMPLIANT - uses signed long long
+  040000000000L;            // COMPLIANT - uses signed long long
+  0777777777777777777777L;  // COMPLIANT - max long int
+  01000000000000000000000L; // NON_COMPLIANT - larger than long int, so will be
+                            // unsigned long int
+  00UL;           // COMPLIANT - unsigned, but uses the suffix correctly
+  017777777777UL; // COMPLIANT - unsigned, but uses the suffix correctly
+  020000000000UL; // COMPLIANT - unsigned, but uses the suffix correctly
+  040000000000UL; // COMPLIANT - unsigned, but uses the suffix correctly
+  0777777777777777777777UL;  // COMPLIANT - unsigned, but uses the suffix
+                             // correctly
+  01000000000000000000000UL; // COMPLIANT - unsigned, but uses the suffix
+                             // correctly
+}
+
+#define COMPLIANT_VAL 0x80000000U
+#define NON_COMPLIANT_VAL 0x80000000
+
+void test_macro() {
+  COMPLIANT_VAL;     // COMPLIANT
+  NON_COMPLIANT_VAL; // NON_COMPLIANT[FALSE_NEGATIVE] - cannot determine suffix
+                     // in macro expansions
 }


### PR DESCRIPTION
## Description

This PR:
 * Updates the `RULE-7-2` test case to include octal literals.
 * Updates the C++ `UnsignedLiteralsNotAppropriatelySuffixed` shared query test case to copy the `RULE-7-2` test case.
 * Adds support to the C++ query for binary literals, and extends the test case (as per `RULE-5-13-4`).

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `RULE-7-2`
     - `M2-13-3`
     - `RULE-5-13-4`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)