### PR TITLE
`A5-2-6`: Ignore cases with the same operator

### DIFF
--- a/change_notes/2024-10-17-a5-2-6-no-ambiguity.md
+++ b/change_notes/2024-10-17-a5-2-6-no-ambiguity.md
@@ -1,0 +1,2 @@
+ - `A5-2-6` - `OperandsOfAlogicalAndOrNotParenthesized.ql`:
+   - Remove false positives where the operator is identical.

--- a/change_notes/2024-10-17-a5-2-6-no-ambiguity.md
+++ b/change_notes/2024-10-17-a5-2-6-no-ambiguity.md
@@ -1,2 +1,3 @@
  - `A5-2-6` - `OperandsOfAlogicalAndOrNotParenthesized.ql`:
    - Remove false positives where the operator is identical.
+   - Improve alert message to clarify which expression needs to be parenthesized.

--- a/cpp/autosar/src/rules/A5-2-6/OperandsOfALogicalAndOrNotParenthesized.ql
+++ b/cpp/autosar/src/rules/A5-2-6/OperandsOfALogicalAndOrNotParenthesized.ql
@@ -17,13 +17,20 @@
 import cpp
 import codingstandards.cpp.autosar
 
-from BinaryLogicalOperation op, BinaryOperation binop
+from BinaryLogicalOperation op, BinaryOperation binop, string leftOrRight
 where
   not isExcluded(op, OrderOfEvaluationPackage::operandsOfALogicalAndOrNotParenthesizedQuery()) and
-  op.getAnOperand() = binop and
+  (
+    op.getLeftOperand() = binop and
+    leftOrRight = "Left"
+    or
+    op.getRightOperand() = binop and
+    leftOrRight = "Right"
+  ) and
   // Ignore cases with the same operator
   not op.getOperator() = binop.getOperator() and
   not exists(ParenthesisExpr p | p = binop.getFullyConverted()) and
   // Exclude binary operations expanded by a macro.
   not binop.isInMacroExpansion()
-select op, "Binary $@ operand of logical operation is not parenthesized.", binop, "operator"
+select op, "$@ of logical operation " + op.getOperator() + " is not parenthesized.", binop,
+  leftOrRight + " operand " + binop.getOperator()

--- a/cpp/autosar/src/rules/A5-2-6/OperandsOfALogicalAndOrNotParenthesized.ql
+++ b/cpp/autosar/src/rules/A5-2-6/OperandsOfALogicalAndOrNotParenthesized.ql
@@ -21,6 +21,8 @@ from BinaryLogicalOperation op, BinaryOperation binop
 where
   not isExcluded(op, OrderOfEvaluationPackage::operandsOfALogicalAndOrNotParenthesizedQuery()) and
   op.getAnOperand() = binop and
+  // Ignore cases with the same operator
+  not op.getOperator() = binop.getOperator() and
   not exists(ParenthesisExpr p | p = binop.getFullyConverted()) and
   // Exclude binary operations expanded by a macro.
   not binop.isInMacroExpansion()

--- a/cpp/autosar/test/rules/A5-2-6/OperandsOfALogicalAndOrNotParenthesized.expected
+++ b/cpp/autosar/test/rules/A5-2-6/OperandsOfALogicalAndOrNotParenthesized.expected
@@ -1,3 +1,3 @@
-| test.cpp:3:7:3:23 | ... && ... | Binary $@ operand of logical operation is not parenthesized. | test.cpp:3:7:3:12 | ... > ... | operator |
-| test.cpp:3:7:3:23 | ... && ... | Binary $@ operand of logical operation is not parenthesized. | test.cpp:3:17:3:23 | ... < ... | operator |
-| test.cpp:7:7:7:24 | ... \|\| ... | Binary $@ operand of logical operation is not parenthesized. | test.cpp:7:19:7:24 | ... > ... | operator |
+| test.cpp:3:7:3:23 | ... && ... | $@ of logical operation && is not parenthesized. | test.cpp:3:7:3:12 | ... > ... | Left operand > |
+| test.cpp:3:7:3:23 | ... && ... | $@ of logical operation && is not parenthesized. | test.cpp:3:17:3:23 | ... < ... | Right operand < |
+| test.cpp:7:7:7:24 | ... \|\| ... | $@ of logical operation \|\| is not parenthesized. | test.cpp:7:19:7:24 | ... > ... | Right operand > |

--- a/cpp/autosar/test/rules/A5-2-6/test.cpp
+++ b/cpp/autosar/test/rules/A5-2-6/test.cpp
@@ -25,6 +25,8 @@ void f2(int p1, int p2) {
     f1();
   }
 
+  (p1 > 0) && (p2 > 0) && (p1 > p2); // COMPLIANT - no ambiguity
+
   Sample *sample_ptr = &sample;
 
   if ((p1 > 0) || sample_ptr->x) { // COMPLIANT: struct member accessors with


### PR DESCRIPTION
## Description

Fixes #231 

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `A5-2-6`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)