### PR TITLE
Rule 8.13

### DIFF
--- a/c/misra/src/rules/RULE-8-13/PointerShouldPointToConstTypeWhenPossible.ql
+++ b/c/misra/src/rules/RULE-8-13/PointerShouldPointToConstTypeWhenPossible.ql
@@ -25,7 +25,12 @@ class NonConstPointerVariableCandidate extends Variable {
     // Ignore parameters in functions without bodies
     (this instanceof Parameter implies exists(this.(Parameter).getFunction().getBlock())) and
     // Ignore variables in functions that use ASM commands
-    not exists(AsmStmt a | a.getEnclosingFunction() = this.(LocalScopeVariable).getFunction()) and
+    not exists(AsmStmt a |
+      a.getEnclosingFunction() = this.(LocalScopeVariable).getFunction()
+      or
+      // In a type declared locally
+      this.(Field).getDeclaringType+().getEnclosingFunction() = a.getEnclosingFunction()
+    ) and
     // Avoid elements in macro expansions, as they cannot be equated across copies
     not this.isInMacroExpansion() and
     exists(PointerOrArrayType type |

--- a/c/misra/src/rules/RULE-8-13/PointerShouldPointToConstTypeWhenPossible.ql
+++ b/c/misra/src/rules/RULE-8-13/PointerShouldPointToConstTypeWhenPossible.ql
@@ -18,29 +18,47 @@ import cpp
 import codingstandards.c.misra
 import codingstandards.cpp.Pointers
 import codingstandards.cpp.SideEffect
+import codingstandards.cpp.alertreporting.HoldsForAllCopies
 
-from Variable ptr, PointerOrArrayType type
+class NonConstPointerVariableCandidate extends Variable {
+  NonConstPointerVariableCandidate() {
+    // Avoid elements in macro expansions, as they cannot be equated across copies
+    not this.isInMacroExpansion() and
+    exists(PointerOrArrayType type |
+      // include only pointers which point to a const-qualified type
+      this.getType() = type and
+      not type.isDeeplyConstBelow()
+    ) and
+    // exclude pointers passed as arguments to functions which take a
+    // parameter that points to a non-const-qualified type
+    not exists(FunctionCall fc, int i |
+      fc.getArgument(i) = this.getAnAccess() and
+      not fc.getTarget().getParameter(i).getType().isDeeplyConstBelow()
+    ) and
+    // exclude any pointers which have their underlying data modified
+    not exists(VariableEffect effect |
+      effect.getTarget() = this and
+      // but not pointers that are only themselves modified
+      not effect.(AssignExpr).getLValue() = effect.getAnAccess() and
+      not effect.(CrementOperation).getOperand() = effect.getAnAccess()
+    ) and
+    // exclude pointers assigned to another pointer to a non-const-qualified type
+    not exists(Variable a |
+      a.getAnAssignedValue() = this.getAnAccess() and
+      not a.getType().(PointerOrArrayType).isDeeplyConstBelow()
+    )
+  }
+}
+
+/**
+ * Ensure that all copies of a variable are considered to be missing const qualification to avoid
+ * false positives where a variable is only used/modified in a single copy.
+ */
+class NonConstPointerVariable =
+  HoldsForAllCopies<NonConstPointerVariableCandidate, Variable>::LogicalResultElement;
+
+from NonConstPointerVariable ptr
 where
-  not isExcluded(ptr, Pointers1Package::pointerShouldPointToConstTypeWhenPossibleQuery()) and
-  // include only pointers which point to a const-qualified type
-  ptr.getType() = type and
-  not type.isDeeplyConstBelow() and
-  // exclude pointers passed as arguments to functions which take a
-  // parameter that points to a non-const-qualified type
-  not exists(FunctionCall fc, int i |
-    fc.getArgument(i) = ptr.getAnAccess() and
-    not fc.getTarget().getParameter(i).getType().isDeeplyConstBelow()
-  ) and
-  // exclude any pointers which have their underlying data modified
-  not exists(VariableEffect effect |
-    effect.getTarget() = ptr and
-    // but not pointers that are only themselves modified
-    not effect.(AssignExpr).getLValue() = effect.getAnAccess() and
-    not effect.(CrementOperation).getOperand() = effect.getAnAccess()
-  ) and
-  // exclude pointers assigned to another pointer to a non-const-qualified type
-  not exists(Variable a |
-    a.getAnAssignedValue() = ptr.getAnAccess() and
-    not a.getType().(PointerOrArrayType).isDeeplyConstBelow()
-  )
-select ptr, "$@ points to a non-const-qualified type.", ptr, ptr.getName()
+  not isExcluded(ptr.getAnElementInstance(),
+    Pointers1Package::pointerShouldPointToConstTypeWhenPossibleQuery())
+select ptr, "$@ points to a non-const-qualified type.", ptr, ptr.getAnElementInstance().getName()

--- a/c/misra/src/rules/RULE-8-13/PointerShouldPointToConstTypeWhenPossible.ql
+++ b/c/misra/src/rules/RULE-8-13/PointerShouldPointToConstTypeWhenPossible.ql
@@ -22,6 +22,8 @@ import codingstandards.cpp.alertreporting.HoldsForAllCopies
 
 class NonConstPointerVariableCandidate extends Variable {
   NonConstPointerVariableCandidate() {
+    // Ignore parameters in functions without bodies
+    (this instanceof Parameter implies exists(this.(Parameter).getFunction().getBlock())) and
     // Ignore variables in functions that use ASM commands
     not exists(AsmStmt a | a.getEnclosingFunction() = this.(LocalScopeVariable).getFunction()) and
     // Avoid elements in macro expansions, as they cannot be equated across copies

--- a/c/misra/src/rules/RULE-8-13/PointerShouldPointToConstTypeWhenPossible.ql
+++ b/c/misra/src/rules/RULE-8-13/PointerShouldPointToConstTypeWhenPossible.ql
@@ -41,8 +41,8 @@ class NonConstPointerVariableCandidate extends Variable {
     not exists(VariableEffect effect |
       effect.getTarget() = this and
       // but not pointers that are only themselves modified
-      not effect.(AssignExpr).getLValue() = effect.getAnAccess() and
-      not effect.(CrementOperation).getOperand() = effect.getAnAccess()
+      not effect.(AssignExpr).getLValue() = this.getAnAccess() and
+      not effect.(CrementOperation).getOperand() = this.getAnAccess()
     ) and
     // exclude pointers assigned to another pointer to a non-const-qualified type
     not exists(Variable a |

--- a/c/misra/src/rules/RULE-8-13/PointerShouldPointToConstTypeWhenPossible.ql
+++ b/c/misra/src/rules/RULE-8-13/PointerShouldPointToConstTypeWhenPossible.ql
@@ -22,6 +22,8 @@ import codingstandards.cpp.alertreporting.HoldsForAllCopies
 
 class NonConstPointerVariableCandidate extends Variable {
   NonConstPointerVariableCandidate() {
+    // Ignore variables in functions that use ASM commands
+    not exists(AsmStmt a | a.getEnclosingFunction() = this.(LocalScopeVariable).getFunction()) and
     // Avoid elements in macro expansions, as they cannot be equated across copies
     not this.isInMacroExpansion() and
     exists(PointerOrArrayType type |

--- a/c/misra/test/rules/RULE-8-13/PointerShouldPointToConstTypeWhenPossible.expected
+++ b/c/misra/test/rules/RULE-8-13/PointerShouldPointToConstTypeWhenPossible.expected
@@ -12,4 +12,4 @@
 | test.c:66:23:66:24 | p1 | $@ points to a non-const-qualified type. | test.c:66:23:66:24 | p1 | p1 |
 | test.c:71:17:71:18 | p1 | $@ points to a non-const-qualified type. | test.c:71:17:71:18 | p1 | p1 |
 | test.c:75:15:75:16 | p1 | $@ points to a non-const-qualified type. | test.c:75:15:75:16 | p1 | p1 |
-| test.c:97:30:97:30 | s | $@ points to a non-const-qualified type. | test.c:97:30:97:30 | s | s |
+| test.c:103:30:103:30 | s | $@ points to a non-const-qualified type. | test.c:103:30:103:30 | s | s |

--- a/c/misra/test/rules/RULE-8-13/PointerShouldPointToConstTypeWhenPossible.expected
+++ b/c/misra/test/rules/RULE-8-13/PointerShouldPointToConstTypeWhenPossible.expected
@@ -12,3 +12,4 @@
 | test.c:66:23:66:24 | p1 | $@ points to a non-const-qualified type. | test.c:66:23:66:24 | p1 | p1 |
 | test.c:71:17:71:18 | p1 | $@ points to a non-const-qualified type. | test.c:71:17:71:18 | p1 | p1 |
 | test.c:75:15:75:16 | p1 | $@ points to a non-const-qualified type. | test.c:75:15:75:16 | p1 | p1 |
+| test.c:97:30:97:30 | s | $@ points to a non-const-qualified type. | test.c:97:30:97:30 | s | s |

--- a/c/misra/test/rules/RULE-8-13/test.c
+++ b/c/misra/test/rules/RULE-8-13/test.c
@@ -82,6 +82,12 @@ int f17(char *p1) { // NON_COMPLIANT
 int16_t
 test_r(int16_t *value) { // COMPLIANT - ignored because of the use of ASM
   int16_t result;
+  struct S {
+    int *x; // COMPLIANT - ignored because of the use of ASM
+    struct S2 {
+      int *y; // COMPLIANT - ignored because of the use of ASM
+    } s2;
+  };
   __asm__("movb %bh (%eax)");
   return result;
 }

--- a/c/misra/test/rules/RULE-8-13/test.c
+++ b/c/misra/test/rules/RULE-8-13/test.c
@@ -76,3 +76,12 @@ int f17(char *p1) { // NON_COMPLIANT
   p1++;
   return 0;
 }
+
+#include <stdint.h>
+
+int16_t
+test_r(int16_t *value) { // COMPLIANT - ignored because of the use of ASM
+  int16_t result;
+  __asm__("movb %bh (%eax)");
+  return result;
+}

--- a/c/misra/test/rules/RULE-8-13/test.c
+++ b/c/misra/test/rules/RULE-8-13/test.c
@@ -85,3 +85,15 @@ test_r(int16_t *value) { // COMPLIANT - ignored because of the use of ASM
   __asm__("movb %bh (%eax)");
   return result;
 }
+
+struct S {
+  int x;
+};
+
+void test_struct(struct S *s) { // COMPLIANT
+  s->x = 1;
+}
+
+void test_struct_2(struct S *s) { // NON_COMPLIANT - could be const
+  s = 0;
+}

--- a/c/misra/test/rules/RULE-8-13/test.c
+++ b/c/misra/test/rules/RULE-8-13/test.c
@@ -97,3 +97,6 @@ void test_struct(struct S *s) { // COMPLIANT
 void test_struct_2(struct S *s) { // NON_COMPLIANT - could be const
   s = 0;
 }
+
+void test_no_body(int *p); // COMPLIANT - no body, so cannot evaluate whether it
+                           // should be const

--- a/c/misra/test/rules/RULE-8-13/test.c
+++ b/c/misra/test/rules/RULE-8-13/test.c
@@ -106,3 +106,7 @@ void test_struct_2(struct S *s) { // NON_COMPLIANT - could be const
 
 void test_no_body(int *p); // COMPLIANT - no body, so cannot evaluate whether it
                            // should be const
+
+void increment(int *p) { // COMPLIANT
+  *p++ = 1;
+}

--- a/change_notes/2024-10-20-8-13-fixes.md
+++ b/change_notes/2024-10-20-8-13-fixes.md
@@ -3,3 +3,4 @@
    - Exclude results for local scope variables in functions that use assembly code, as CodeQL cannot determine the impact of the assembly.
    - Exclude false positives when an assignment is made to a struct field.
    - Exclude false positives where the object pointed to by the variable is modified using `*p++ = ...`.
+   - Exclude false positives for functions without bodies.

--- a/change_notes/2024-10-20-8-13-fixes.md
+++ b/change_notes/2024-10-20-8-13-fixes.md
@@ -4,3 +4,4 @@
    - Exclude false positives when an assignment is made to a struct field.
    - Exclude false positives where the object pointed to by the variable is modified using `*p++ = ...`.
    - Exclude false positives for functions without bodies.
+ - Rules that rely on the determination of side-effects of an expression may change as a result of considering `*p++ = ...` as having a side-effect on `p`.

--- a/change_notes/2024-10-20-8-13-fixes.md
+++ b/change_notes/2024-10-20-8-13-fixes.md
@@ -1,0 +1,5 @@
+ - `RULE-8-13` - `PointerShouldPointToConstTypeWhenPossible.ql`
+   - Exclude false positives where a variable occurs in a file compiled multiple times, but where it may only be const in some of those scenarios.
+   - Exclude results for local scope variables in functions that use assembly code, as CodeQL cannot determine the impact of the assembly.
+   - Exclude false positives when an assignment is made to a struct field.
+   - Exclude false positives where the object pointed to by the variable is modified using `*p++ = ...`.

--- a/cpp/common/src/codingstandards/cpp/SideEffect.qll
+++ b/cpp/common/src/codingstandards/cpp/SideEffect.qll
@@ -190,6 +190,8 @@ Expr getAnEffect(Expr base) {
   or
   exists(PointerDereferenceExpr e | e.getOperand() = base | result = getAnEffect(e))
   or
+  exists(CrementOperation c | c.getOperand() = base | result = getAnEffect(c))
+  or
   // local alias analysis, assume alias when data flows to derived type (pointer/reference)
   // auto ptr = &base;
   exists(VariableAccess va, AddressOfExpr addressOf |


### PR DESCRIPTION
## Description

Fixes https://github.com/github/codeql-coding-standards/issues/761, https://github.com/github/codeql-coding-standards/issues/762, https://github.com/github/codeql-coding-standards/issues/763, https://github.com/github/codeql-coding-standards/issues/764.

In addition, applies a standard exclusion for results in functions with assembly included.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `RULE-8-13`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)