### PR TITLE
Fix issue 755 and typo in A18-1-1 test

### DIFF
--- a/change_notes/2024-10-22-fix-fp-m6-5-3.md
+++ b/change_notes/2024-10-22-fix-fp-m6-5-3.md
@@ -1,0 +1,2 @@
+- `M6-5-3` - `Loops.qll`:
+  - Fixes #755. Specifies that the access to the loop counter must be via non-const address.

--- a/cpp/autosar/test/rules/A18-1-1/test.cpp
+++ b/cpp/autosar/test/rules/A18-1-1/test.cpp
@@ -11,6 +11,6 @@ int test_c_arrays() {
   int x[100];                 // NON_COMPLIANT
   constexpr int a[]{0, 1, 2}; // NON_COMPLIANT
 
-  __func__; // COMPLAINT
+  __func__; // COMPLIANT
   return 0;
 }

--- a/cpp/common/src/codingstandards/cpp/Loops.qll
+++ b/cpp/common/src/codingstandards/cpp/Loops.qll
@@ -204,7 +204,7 @@ predicate isLoopCounterModifiedInCondition(ForStmt forLoop, VariableAccess loopC
   loopCounterAccess = getAnIterationVariable(forLoop).getAnAccess() and
   (
     loopCounterAccess.isModified() or
-    loopCounterAccess.isAddressOfAccess()
+    loopCounterAccess.isAddressOfAccessNonConst()
   )
 }
 
@@ -219,7 +219,7 @@ predicate isLoopCounterModifiedInStatement(
   loopCounterAccess = loopCounter.getAnAccess() and
   (
     loopCounterAccess.isModified() or
-    loopCounterAccess.isAddressOfAccess()
+    loopCounterAccess.isAddressOfAccessNonConst()
   ) and
   forLoop.getStmt().getChildStmt*() = loopCounterAccess.getEnclosingStmt()
 }


### PR DESCRIPTION
## Description

Fix issue #755 following suggestion therein.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] Queries have been modified for the following rules:
     - `M6-5-3`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)