### PR TITLE
`M5-0-*`: Ignore explicit casts when identifying `cvalues` by parent

### DIFF
--- a/cpp/autosar/test/rules/M5-0-3/CvalueExpressionConvertedToDifferentUnderlyingType.expected
+++ b/cpp/autosar/test/rules/M5-0-3/CvalueExpressionConvertedToDifferentUnderlyingType.expected
@@ -1,3 +1,5 @@
-| test.cpp:11:8:11:14 | (int16_t)... | Implicit conversion converts cvalue $@ from signed char to signed short. | test.cpp:11:8:11:14 | ... + ... | expression |
-| test.cpp:11:8:11:14 | ... + ... | Implicit conversion converts cvalue $@ from signed char to signed short. | test.cpp:11:8:11:14 | ... + ... | expression |
-| test.cpp:13:8:13:13 | ... + ... | Implicit conversion converts cvalue $@ from signed short to signed int. | test.cpp:13:8:13:13 | ... + ... | expression |
+| test.cpp:12:8:12:14 | (int16_t)... | Implicit conversion converts cvalue $@ from signed char to signed short. | test.cpp:12:8:12:14 | ... + ... | expression |
+| test.cpp:12:8:12:14 | ... + ... | Implicit conversion converts cvalue $@ from signed char to signed short. | test.cpp:12:8:12:14 | ... + ... | expression |
+| test.cpp:14:8:14:13 | ... + ... | Implicit conversion converts cvalue $@ from signed short to signed int. | test.cpp:14:8:14:13 | ... + ... | expression |
+| test.cpp:23:13:23:19 | (int16_t)... | Implicit conversion converts cvalue $@ from signed char to signed short. | test.cpp:23:13:23:19 | ... + ... | expression |
+| test.cpp:30:12:30:18 | (int16_t)... | Implicit conversion converts cvalue $@ from signed char to signed short. | test.cpp:30:12:30:18 | ... + ... | expression |

--- a/cpp/autosar/test/rules/M5-0-3/CvalueExpressionConvertedToDifferentUnderlyingType.expected
+++ b/cpp/autosar/test/rules/M5-0-3/CvalueExpressionConvertedToDifferentUnderlyingType.expected
@@ -2,4 +2,6 @@
 | test.cpp:12:8:12:14 | ... + ... | Implicit conversion converts cvalue $@ from signed char to signed short. | test.cpp:12:8:12:14 | ... + ... | expression |
 | test.cpp:14:8:14:13 | ... + ... | Implicit conversion converts cvalue $@ from signed short to signed int. | test.cpp:14:8:14:13 | ... + ... | expression |
 | test.cpp:23:13:23:19 | (int16_t)... | Implicit conversion converts cvalue $@ from signed char to signed short. | test.cpp:23:13:23:19 | ... + ... | expression |
-| test.cpp:30:12:30:18 | (int16_t)... | Implicit conversion converts cvalue $@ from signed char to signed short. | test.cpp:30:12:30:18 | ... + ... | expression |
+| test.cpp:25:13:25:45 | (int16_t)... | Implicit conversion converts cvalue $@ from signed char to signed short. | test.cpp:25:13:25:45 | static_cast<int8_t>... | expression |
+| test.cpp:31:12:31:18 | (int16_t)... | Implicit conversion converts cvalue $@ from signed char to signed short. | test.cpp:31:12:31:18 | ... + ... | expression |
+| test.cpp:33:12:33:44 | (int16_t)... | Implicit conversion converts cvalue $@ from signed char to signed short. | test.cpp:33:12:33:44 | static_cast<int8_t>... | expression |

--- a/cpp/autosar/test/rules/M5-0-3/test.cpp
+++ b/cpp/autosar/test/rules/M5-0-3/test.cpp
@@ -22,12 +22,15 @@ void test_func_call() {
   std::int8_t l1;
   int16_arg(l1 + l1);                            // NON_COMPLIANT
   int16_arg(static_cast<std::int16_t>(l1 + l1)); // COMPLIANT
+  int16_arg(static_cast<std::int8_t>(l1 + l1));  // NON_COMPLIANT
 }
 
 std::int16_t test_return(int test) {
   std::int8_t l1;
   if (test > 0) {
     return l1 + l1; // NON_COMPLIANT
+  } else if (test < 0) {
+    return static_cast<std::int8_t>(l1 + l1); // NON_COMPLIANT
   } else {
     return static_cast<std::int16_t>(l1 + l1); // COMPLIANT
   }

--- a/cpp/autosar/test/rules/M5-0-3/test.cpp
+++ b/cpp/autosar/test/rules/M5-0-3/test.cpp
@@ -1,4 +1,5 @@
 #include <cstdint>
+
 void f1() {
   using std::int16_t;
   using std::int32_t;
@@ -13,4 +14,21 @@ void f1() {
   l3 = l2 + 1;                        // NON_COMPLIANT
   l3 = static_cast<int32_t>(l2) + 1;  // COMPLIANT
   l3 = l2 + 0x01ffff;                 // COMPLIANT
+}
+
+void int16_arg(std::int16_t t);
+
+void test_func_call() {
+  std::int8_t l1;
+  int16_arg(l1 + l1);                            // NON_COMPLIANT
+  int16_arg(static_cast<std::int16_t>(l1 + l1)); // COMPLIANT
+}
+
+std::int16_t test_return(int test) {
+  std::int8_t l1;
+  if (test > 0) {
+    return l1 + l1; // NON_COMPLIANT
+  } else {
+    return static_cast<std::int16_t>(l1 + l1); // COMPLIANT
+  }
 }

--- a/cpp/autosar/test/rules/M5-0-7/test.cpp
+++ b/cpp/autosar/test/rules/M5-0-7/test.cpp
@@ -19,3 +19,12 @@ void f1() {
   s16a = static_cast<int16_t>(f32a);        // COMPLIANT
   s16a = static_cast<int16_t>(f32a) / f32b; // COMPLIANT
 }
+
+void int_arg(std::int32_t i);
+
+std::int16_t test_args() {
+  float f32a;
+  float f32b;
+  int_arg(static_cast<std::int16_t>(f32a)); // COMPLIANT - f32a is not a cvalue
+  return static_cast<std::int16_t>(f32a);   // COMPLIANT - f32a is not a cvalue
+}

--- a/cpp/autosar/test/rules/M5-0-8/test.cpp
+++ b/cpp/autosar/test/rules/M5-0-8/test.cpp
@@ -23,3 +23,21 @@ void f() {
   f32 = static_cast<float>(1.0f + 1);     // COMPLIANT
   f64 = static_cast<double>(1.0 + 1); // COMPLIANT; no suffix defines a double
 }
+
+#include <vector>
+
+void function_args() {
+  std::vector<std::uint8_t> v{0};
+
+  std::uint32_t u32{0};
+  v.at(static_cast<std::size_t>(u32)); // COMPLIANT - cast is not a cvalue
+  std::size_t st =
+      static_cast<std::size_t>(u32); // COMPLIANT - cast is not a cvalue
+  v.at(st);
+}
+
+std::size_t return_args() {
+  std::uint32_t u32{0};
+
+  return static_cast<std::size_t>(u32); // COMPLIANT
+}

--- a/cpp/autosar/test/rules/M5-0-9/ExplicitSignednessConversionOfCValue.expected
+++ b/cpp/autosar/test/rules/M5-0-9/ExplicitSignednessConversionOfCValue.expected
@@ -1,3 +1,3 @@
-| test.cpp:16:8:16:35 | static_cast<int8_t>... | Explicit integral conversion converts the signedness of the $@ from unsigned to signed. | test.cpp:16:28:16:34 | ... + ... | cvalue |
-| test.cpp:18:8:18:40 | static_cast<int8_t>... | Explicit integral conversion converts the signedness of the $@ from unsigned to signed. | test.cpp:18:28:18:39 | ... + ... | cvalue |
-| test.cpp:20:8:20:35 | static_cast<int8_t>... | Explicit integral conversion converts the signedness of the $@ from unsigned to signed. | test.cpp:20:28:20:34 | ... * ... | cvalue |
+| test.cpp:20:8:20:35 | static_cast<int8_t>... | Explicit integral conversion converts the signedness of the $@ from unsigned to signed. | test.cpp:20:28:20:34 | ... + ... | cvalue |
+| test.cpp:22:8:22:40 | static_cast<int8_t>... | Explicit integral conversion converts the signedness of the $@ from unsigned to signed. | test.cpp:22:28:22:39 | ... + ... | cvalue |
+| test.cpp:24:8:24:35 | static_cast<int8_t>... | Explicit integral conversion converts the signedness of the $@ from unsigned to signed. | test.cpp:24:28:24:34 | ... * ... | cvalue |

--- a/cpp/autosar/test/rules/M5-0-9/test.cpp
+++ b/cpp/autosar/test/rules/M5-0-9/test.cpp
@@ -1,4 +1,8 @@
 #include <cstdint>
+
+void signed_arg(std::uint32_t s);
+void unsigned_arg(std::uint32_t u);
+
 void f() {
   using std::int16_t;
   using std::int32_t;
@@ -22,4 +26,7 @@ void f() {
   i16 = static_cast<int16_t>(i16 / i8); // NON_COMPLIANT
 
   i8 = static_cast<int8_t>(u8) + static_cast<int8_t>(u8); // COMPLIANT
+
+  unsigned(static_cast<uint32_t>(i32)); // COMPLIANT - i32 is not a cvalue
+  signed(static_cast<int32_t>(u32));    // COMPLIANT - u32 is not a cvalue
 }

--- a/cpp/common/src/codingstandards/cpp/Expr.qll
+++ b/cpp/common/src/codingstandards/cpp/Expr.qll
@@ -148,17 +148,9 @@ module MisraExpr {
   private predicate isCValue(Expr e) {
     not e.isConstant() and
     (
-      exists(ReturnStmt return |
-        e = return.getExpr() and
-        // Only return statements which are not explicitly casted are considered
-        not exists(Cast c | not c.isImplicit() and c.getExpr() = e)
-      )
+      exists(ReturnStmt return | e = return.getExpr().getExplicitlyConverted())
       or
-      exists(FunctionCall call |
-        e = call.getAnArgument() and
-        // // Only function arguments which are not explicitly casted are considered
-        not exists(Cast c | not c.isImplicit() and c.getExpr() = e)
-      )
+      exists(FunctionCall call | e = call.getAnArgument().getExplicitlyConverted())
     )
     or
     isCValue(e.(ParenthesisExpr).getExpr())

--- a/cpp/common/src/codingstandards/cpp/Expr.qll
+++ b/cpp/common/src/codingstandards/cpp/Expr.qll
@@ -148,9 +148,17 @@ module MisraExpr {
   private predicate isCValue(Expr e) {
     not e.isConstant() and
     (
-      exists(ReturnStmt return | e = return.getExpr())
+      exists(ReturnStmt return |
+        e = return.getExpr() and
+        // Only return statements which are not explicitly casted are considered
+        not exists(Cast c | not c.isImplicit() and c.getExpr() = e)
+      )
       or
-      exists(Call call | e = call.getAnArgument())
+      exists(FunctionCall call |
+        e = call.getAnArgument() and
+        // // Only function arguments which are not explicitly casted are considered
+        not exists(Cast c | not c.isImplicit() and c.getExpr() = e)
+      )
     )
     or
     isCValue(e.(ParenthesisExpr).getExpr())


### PR DESCRIPTION
## Description

Fixes https://github.com/github/codeql-coding-standards/issues/602.

Function argument expressions and return expressions are both considered to be `cvalue`s. However, they shouldn't be considered as `cvalue`s if they are explicitly casted.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `M5-0-3`
     - `M5-0-7`
     - `M5-0-8`
     - `M5-0-9`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)