### PR TITLE
Performance improvements since upgrade to 2.16.6

### DIFF
--- a/c/cert/src/rules/DCL40-C/IncompatibleFunctionDeclarations.ql
+++ b/c/cert/src/rules/DCL40-C/IncompatibleFunctionDeclarations.ql
@@ -16,30 +16,32 @@
 
 import cpp
 import codingstandards.c.cert
+import codingstandards.cpp.Compatible
 import ExternalIdentifiers
-
-//checks if they are incompatible based on return type, number of parameters and parameter types
-predicate checkMatchingFunction(FunctionDeclarationEntry d, FunctionDeclarationEntry d2) {
-  not d.getType() = d2.getType()
-  or
-  not d.getNumberOfParameters() = d2.getNumberOfParameters()
-  or
-  exists(ParameterDeclarationEntry p, ParameterDeclarationEntry p2, int i |
-    d.getParameterDeclarationEntry(i) = p and
-    d2.getParameterDeclarationEntry(i) = p2 and
-    not p.getType() = p2.getType()
-  )
-}
 
 from ExternalIdentifiers d, FunctionDeclarationEntry f1, FunctionDeclarationEntry f2
 where
   not isExcluded(f1, Declarations2Package::incompatibleFunctionDeclarationsQuery()) and
   not isExcluded(f2, Declarations2Package::incompatibleFunctionDeclarationsQuery()) and
-  f1 = d.getADeclarationEntry() and
-  f2 = d.getADeclarationEntry() and
   not f1 = f2 and
-  f1.getLocation().getStartLine() >= f2.getLocation().getStartLine() and
+  f1.getDeclaration() = d and
+  f2.getDeclaration() = d and
   f1.getName() = f2.getName() and
-  checkMatchingFunction(f1, f2)
+  (
+    //return type check
+    not typesCompatible(f1.getType(), f2.getType())
+    or
+    //parameter type check
+    parameterTypesIncompatible(f1, f2)
+    or
+    not f1.getNumberOfParameters() = f2.getNumberOfParameters()
+  ) and
+  // Apply ordering on start line, trying to avoid the optimiser applying this join too early
+  // in the pipeline
+  exists(int f1Line, int f2Line |
+    f1.getLocation().hasLocationInfo(_, f1Line, _, _, _) and
+    f2.getLocation().hasLocationInfo(_, f2Line, _, _, _) and
+    f1Line >= f2Line
+  )
 select f1, "The object $@ is not compatible with re-declaration $@", f1, f1.getName(), f2,
   f2.getName()

--- a/c/cert/src/rules/MSC39-C/DoNotCallVaArgOnAVaListThatHasAnIndeterminateValue.ql
+++ b/c/cert/src/rules/MSC39-C/DoNotCallVaArgOnAVaListThatHasAnIndeterminateValue.ql
@@ -71,12 +71,19 @@ predicate sameSource(VaAccess e1, VaAccess e2) {
   )
 }
 
+/**
+ * Extracted to avoid poor magic join ordering on the `isExcluded` predicate.
+ */
+predicate query(VaAccess va_acc, VaArgArg va_arg, FunctionCall fc) {
+  sameSource(va_acc, va_arg) and
+  fc = preceedsFC(va_acc) and
+  fc.getTarget().calls*(va_arg.getEnclosingFunction())
+}
+
 from VaAccess va_acc, VaArgArg va_arg, FunctionCall fc
 where
   not isExcluded(va_acc,
     Contracts7Package::doNotCallVaArgOnAVaListThatHasAnIndeterminateValueQuery()) and
-  sameSource(va_acc, va_arg) and
-  fc = preceedsFC(va_acc) and
-  fc.getTarget().calls*(va_arg.getEnclosingFunction())
+  query(va_acc, va_arg, fc)
 select va_acc, "The value of " + va_acc.toString() + " is indeterminate after the $@.", fc,
   fc.toString()

--- a/c/misra/src/rules/RULE-9-4/RepeatedInitializationOfAggregateObjectElement.ql
+++ b/c/misra/src/rules/RULE-9-4/RepeatedInitializationOfAggregateObjectElement.ql
@@ -60,6 +60,7 @@ int getMaxDepth(ArrayAggregateLiteral al) {
   else result = 1 + max(Expr child | child = al.getAnElementExpr(_) | getMaxDepth(child))
 }
 
+// internal recursive predicate for `hasMultipleInitializerExprsForSameIndex`
 predicate hasMultipleInitializerExprsForSameIndexInternal(
   ArrayAggregateLiteral root, Expr e1, Expr e2
 ) {
@@ -73,29 +74,6 @@ predicate hasMultipleInitializerExprsForSameIndexInternal(
   )
 }
 
-// // internal recursive predicate for `hasMultipleInitializerExprsForSameIndex`
-// predicate hasMultipleInitializerExprsForSameIndexInternal(
-//   ArrayAggregateLiteral al1, ArrayAggregateLiteral al2, Expr out_al1_expr, Expr out_al2_expr
-// ) {
-//   exists(int shared_index, Expr al1_expr, Expr al2_expr |
-//     // an `Expr` initializing an element of the same index in both `al1` and `al2`
-//     shared_index = [0 .. al1.getArraySize() - 1] and
-//     al1_expr = al1.getAnElementExpr(shared_index) and
-//     al2_expr = al2.getAnElementExpr(shared_index) and
-//     // but not the same `Expr`
-//     not al1_expr = al2_expr and
-//     (
-//       // case A - the children are not aggregate literals
-//       // holds if `al1` and `al2` both hold for .getElement[sharedIndex]
-//       not al1_expr instanceof ArrayAggregateLiteral and
-//       out_al1_expr = al1_expr and
-//       out_al2_expr = al2_expr
-//       or
-//       // case B - `al1` and `al2` both have an aggregate literal child at the same index, so recurse
-//       hasMultipleInitializerExprsForSameIndexInternal(al1_expr, al2_expr, out_al1_expr, out_al2_expr)
-//     )
-//   )
-// }
 /**
  * Holds if `expr1` and `expr2` both initialize the same array element of `root`.
  */

--- a/c/misra/src/rules/RULE-9-4/RepeatedInitializationOfAggregateObjectElement.ql
+++ b/c/misra/src/rules/RULE-9-4/RepeatedInitializationOfAggregateObjectElement.ql
@@ -60,35 +60,55 @@ int getMaxDepth(ArrayAggregateLiteral al) {
   else result = 1 + max(Expr child | child = al.getAnElementExpr(_) | getMaxDepth(child))
 }
 
-// internal recursive predicate for `hasMultipleInitializerExprsForSameIndex`
 predicate hasMultipleInitializerExprsForSameIndexInternal(
-  ArrayAggregateLiteral al1, ArrayAggregateLiteral al2, Expr out_al1_expr, Expr out_al2_expr
+  ArrayAggregateLiteral root, Expr e1, Expr e2
 ) {
-  exists(int shared_index, Expr al1_expr, Expr al2_expr |
-    // an `Expr` initializing an element of the same index in both `al1` and `al2`
-    shared_index = [0 .. al1.getArraySize() - 1] and
-    al1_expr = al1.getAnElementExpr(shared_index) and
-    al2_expr = al2.getAnElementExpr(shared_index) and
-    // but not the same `Expr`
-    not al1_expr = al2_expr and
-    (
-      // case A - the children are not aggregate literals
-      // holds if `al1` and `al2` both hold for .getElement[sharedIndex]
-      not al1_expr instanceof ArrayAggregateLiteral and
-      out_al1_expr = al1_expr and
-      out_al2_expr = al2_expr
-      or
-      // case B - `al1` and `al2` both have an aggregate literal child at the same index, so recurse
-      hasMultipleInitializerExprsForSameIndexInternal(al1_expr, al2_expr, out_al1_expr, out_al2_expr)
-    )
+  root = e1 and root = e2
+  or
+  exists(ArrayAggregateLiteral parent1, ArrayAggregateLiteral parent2, int shared_index |
+    hasMultipleInitializerExprsForSameIndexInternal(root, parent1, parent2) and
+    shared_index = [0 .. parent1.getArraySize() - 1] and
+    e1 = parent1.getAnElementExpr(shared_index) and
+    e2 = parent2.getAnElementExpr(shared_index)
   )
 }
 
+// // internal recursive predicate for `hasMultipleInitializerExprsForSameIndex`
+// predicate hasMultipleInitializerExprsForSameIndexInternal(
+//   ArrayAggregateLiteral al1, ArrayAggregateLiteral al2, Expr out_al1_expr, Expr out_al2_expr
+// ) {
+//   exists(int shared_index, Expr al1_expr, Expr al2_expr |
+//     // an `Expr` initializing an element of the same index in both `al1` and `al2`
+//     shared_index = [0 .. al1.getArraySize() - 1] and
+//     al1_expr = al1.getAnElementExpr(shared_index) and
+//     al2_expr = al2.getAnElementExpr(shared_index) and
+//     // but not the same `Expr`
+//     not al1_expr = al2_expr and
+//     (
+//       // case A - the children are not aggregate literals
+//       // holds if `al1` and `al2` both hold for .getElement[sharedIndex]
+//       not al1_expr instanceof ArrayAggregateLiteral and
+//       out_al1_expr = al1_expr and
+//       out_al2_expr = al2_expr
+//       or
+//       // case B - `al1` and `al2` both have an aggregate literal child at the same index, so recurse
+//       hasMultipleInitializerExprsForSameIndexInternal(al1_expr, al2_expr, out_al1_expr, out_al2_expr)
+//     )
+//   )
+// }
 /**
  * Holds if `expr1` and `expr2` both initialize the same array element of `root`.
  */
 predicate hasMultipleInitializerExprsForSameIndex(ArrayAggregateLiteral root, Expr expr1, Expr expr2) {
-  hasMultipleInitializerExprsForSameIndexInternal(root, root, expr1, expr2)
+  hasMultipleInitializerExprsForSameIndexInternal(root, expr1, expr2) and
+  not root = expr1 and
+  not root = expr2 and
+  not expr1 = expr2 and
+  (
+    not expr1 instanceof ArrayAggregateLiteral
+    or
+    not expr2 instanceof ArrayAggregateLiteral
+  )
 }
 
 /**

--- a/change_notes/2024-10-24-compatible-types.md
+++ b/change_notes/2024-10-24-compatible-types.md
@@ -1,0 +1,2 @@
+ - `DCL40-C` - `IncompatibleFunctionDeclarations.ql`:
+   - Reduce false positives by identifying compatible integer arithmetic types (e.g. "signed int" and "int").

--- a/cpp/common/src/codingstandards/cpp/Compatible.qll
+++ b/cpp/common/src/codingstandards/cpp/Compatible.qll
@@ -1,5 +1,7 @@
 import cpp
 
+pragma[noinline]
+pragma[nomagic]
 predicate typesCompatible(Type t1, Type t2) {
   t1 = t2
   or
@@ -8,6 +10,7 @@ predicate typesCompatible(Type t1, Type t2) {
 }
 
 predicate parameterTypesIncompatible(FunctionDeclarationEntry f1, FunctionDeclarationEntry f2) {
+  f1.getDeclaration() = f2.getDeclaration() and
   exists(ParameterDeclarationEntry p1, ParameterDeclarationEntry p2, int i |
     p1 = f1.getParameterDeclarationEntry(i) and
     p2 = f2.getParameterDeclarationEntry(i)
@@ -17,6 +20,7 @@ predicate parameterTypesIncompatible(FunctionDeclarationEntry f1, FunctionDeclar
 }
 
 predicate parameterNamesIncompatible(FunctionDeclarationEntry f1, FunctionDeclarationEntry f2) {
+  f1.getDeclaration() = f2.getDeclaration() and
   exists(ParameterDeclarationEntry p1, ParameterDeclarationEntry p2, int i |
     p1 = f1.getParameterDeclarationEntry(i) and
     p2 = f2.getParameterDeclarationEntry(i)

--- a/cpp/common/src/codingstandards/cpp/rules/notdistinctidentifier/NotDistinctIdentifier.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/notdistinctidentifier/NotDistinctIdentifier.qll
@@ -12,6 +12,16 @@ abstract class NotDistinctIdentifierSharedQuery extends Query { }
 
 Query getQuery() { result instanceof NotDistinctIdentifierSharedQuery }
 
+bindingset[d, d2]
+pragma[inline_late]
+private predicate after(ExternalIdentifiers d, ExternalIdentifiers d2) {
+  exists(int dStartLine, int d2StartLine |
+    d.getLocation().hasLocationInfo(_, dStartLine, _, _, _) and
+    d2.getLocation().hasLocationInfo(_, d2StartLine, _, _, _) and
+    dStartLine >= d2StartLine
+  )
+}
+
 query predicate problems(
   ExternalIdentifiers d, string message, ExternalIdentifiers d2, string nameplaceholder
 ) {
@@ -20,10 +30,10 @@ query predicate problems(
   d.getName().length() >= 31 and
   d2.getName().length() >= 31 and
   not d = d2 and
-  d.getLocation().getStartLine() >= d2.getLocation().getStartLine() and
   d.getSignificantName() = d2.getSignificantName() and
   not d.getName() = d2.getName() and
   nameplaceholder = d2.getName() and
+  after(d, d2) and
   message =
     "External identifer " + d.getName() +
       " is nondistinct in characters at or over 31 limit, compared to $@"


### PR DESCRIPTION
## Description

Addresses some performance issues noted in the upgrade to 2.16.6:
 * Determination of compatible function types was slow across multiple queries. This has been addressed by standardizing on the `Compatible.qll` library, and ensuring all predicates are appropriately bound.
 * In some cases the `isExcluded` mechanism was causing bad join orders. These have been addressed on a case-by-base basis.
 * `RULE-9-4` has been modified to perform a top-down, rather than bottom-up, detection of pairs of expressions initializing the same element in an array aggregate literal. This reduces the cases significantly.

The performance logs for 2.16.6 still note some increases, particularly in the calculation of standard library features such as the IR. I suggest we re-trigger performance analysis on this PR and see whether they replicate.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `DCL40-C`
     - `RULE-5-1`
     - `RULE-8-3`
     - `RULE-8-4`
     - `MSC39-C`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)