### PR TITLE
Update queries after `TemplateParameter` deprecation

### DIFF
--- a/c/misra/src/rules/RULE-2-4/UnusedTagDeclaration.ql
+++ b/c/misra/src/rules/RULE-2-4/UnusedTagDeclaration.ql
@@ -32,5 +32,5 @@ where
   // `isInMacroExpansion` is broken for `UserType`s.
   not s.isInMacroExpansion() and
   // Exclude template parameters, in case this is run on C++ code.
-  not s instanceof TemplateParameter
+  not s instanceof TypeTemplateParameter
 select s, "struct " + s.getName() + " has an unused tag."

--- a/cpp/autosar/src/rules/A13-3-1/FunctionThatContainsForwardingReferenceAsItsArgumentOverloaded.ql
+++ b/cpp/autosar/src/rules/A13-3-1/FunctionThatContainsForwardingReferenceAsItsArgumentOverloaded.ql
@@ -18,7 +18,8 @@ import codingstandards.cpp.FunctionEquivalence
 
 class Candidate extends TemplateFunction {
   Candidate() {
-    this.getAParameter().getType().(RValueReferenceType).getBaseType() instanceof TemplateParameter
+    this.getAParameter().getType().(RValueReferenceType).getBaseType() instanceof
+      TypeTemplateParameter
   }
 }
 

--- a/cpp/autosar/src/rules/A14-5-2/NonTemplateMemberDefinedInTemplate.ql
+++ b/cpp/autosar/src/rules/A14-5-2/NonTemplateMemberDefinedInTemplate.ql
@@ -18,7 +18,7 @@ import codingstandards.cpp.autosar
 import codingstandards.cpp.TypeUses
 import codingstandards.cpp.Operator
 
-predicate templateDefinitionMentionsTypeParameter(Declaration d, TemplateParameter tp) {
+predicate templateDefinitionMentionsTypeParameter(Declaration d, TypeTemplateParameter tp) {
   exists(Type t |
     (
       // direct reference, e.g., fields.
@@ -50,36 +50,36 @@ predicate templateDefinitionMentionsTypeParameter(Declaration d, TemplateParamet
 }
 
 /**
- * The set of `TemplateParameter` references within an `Enum`.
+ * The set of `TypeTemplateParameter` references within an `Enum`.
  */
-TemplateParameter enumTemplateReferences(Enum e) {
+TypeTemplateParameter enumTemplateReferences(Enum e) {
   templateDefinitionMentionsTypeParameter(e.getADeclaration(), result)
   or
   result = e.getExplicitUnderlyingType()
 }
 
 /**
- * The set of `TemplateParameter` references within an `Class`.
+ * The set of `TypeTemplateParameter` references within an `Class`.
  */
-TemplateParameter classTemplateReferences(Class c) {
+TypeTemplateParameter classTemplateReferences(Class c) {
   templateDefinitionMentionsTypeParameter(c.getAMember(), result)
   or
   c.getADerivation().getBaseType() = result
 }
 
 /**
- * The set of all of the `TemplateParameter`s referenced by a `EnumConstant`.
+ * The set of all of the `TypeTemplateParameter`s referenced by a `EnumConstant`.
  */
-TemplateParameter enumConstantTemplateReferences(EnumConstant ec) {
+TypeTemplateParameter enumConstantTemplateReferences(EnumConstant ec) {
   templateDefinitionMentionsTypeParameter(ec.getDeclaringType(), result)
 }
 
 /**
- * The set of all `TemplateParameter`s referenced by a `Function`.
+ * The set of all `TypeTemplateParameter`s referenced by a `Function`.
  */
-TemplateParameter functionTemplateReferences(Function mf) {
+TypeTemplateParameter functionTemplateReferences(Function mf) {
   // the type of the function
-  exists(TemplateParameter tp |
+  exists(TypeTemplateParameter tp |
     result = tp and
     (
       mf.getType().refersTo(result)
@@ -115,10 +115,10 @@ TemplateParameter functionTemplateReferences(Function mf) {
 }
 
 /**
- * The set of all `TemplateParameters` available as arguments to the declaring
+ * The set of all `TypeTemplateParameters` available as arguments to the declaring
  * element of some `Declarations`.
  */
-TemplateParameter templateParametersOfDeclaringTemplateClass(Declaration d) {
+TypeTemplateParameter templateParametersOfDeclaringTemplateClass(Declaration d) {
   result = d.getDeclaringType().getATemplateArgument()
 }
 
@@ -149,7 +149,7 @@ where
   not d instanceof UserNegationOperator and
   // for each declaration within a template class get the
   // template parameters of the declaring class
-  not exists(TemplateParameter t |
+  not exists(TypeTemplateParameter t |
     t = templateParametersOfDeclaringTemplateClass(d) and
     // and require that the declaration depends on at least
     // one of those template parameters.
@@ -170,7 +170,7 @@ where
   ) and
   // Omit using alias (cf. https://github.com/github/codeql-coding-standards/issues/739)
   // Exclude Using alias which refer directly to a TypeParameter
-  not d.(UsingAliasTypedefType).getBaseType() instanceof TemplateParameter
+  not d.(UsingAliasTypedefType).getBaseType() instanceof TypeTemplateParameter
 select d,
   "Member " + d.getName() + " template class does not use any of template arguments of its $@.",
   d.getDeclaringType(), "declaring type"

--- a/cpp/autosar/src/rules/A14-5-3/NonMemberGenericOperatorCondition.ql
+++ b/cpp/autosar/src/rules/A14-5-3/NonMemberGenericOperatorCondition.ql
@@ -18,7 +18,7 @@ import codingstandards.cpp.autosar
 class NonMemberGenericOperator extends TemplateFunction {
   NonMemberGenericOperator() {
     this instanceof Operator and
-    exists(TemplateParameter tp, Type pType |
+    exists(TypeTemplateParameter tp, Type pType |
       pType = getAParameter().getType().getUnspecifiedType() //Parameter Type
     |
       pType = tp or

--- a/cpp/autosar/src/rules/A7-1-7/IdentifierDeclarationAndInitializationNotOnSeparateLines.ql
+++ b/cpp/autosar/src/rules/A7-1-7/IdentifierDeclarationAndInitializationNotOnSeparateLines.ql
@@ -23,7 +23,7 @@ class UniqueLineStmt extends Locatable {
       exists(Declaration d |
         this = d.getADeclarationEntry() and
         not d instanceof Parameter and
-        not d instanceof TemplateParameter and
+        not d instanceof TypeTemplateParameter and
         // TODO - Needs to be enhanced to solve issues with
         // templated inner classes.
         not d instanceof Function and

--- a/cpp/autosar/src/rules/M14-5-3/CopyAssignmentOperatorNotDeclared.ql
+++ b/cpp/autosar/src/rules/M14-5-3/CopyAssignmentOperatorNotDeclared.ql
@@ -34,10 +34,10 @@ class TemplateAssignmentOperatorMember extends MemberFunction {
   }
 
   /**
-   * is a copy assigment operator candidate if it has only one param and form in [T, T&, const T&, volatile T&, const volatile T&]
+   * is a copy assignment operator candidate if it has only one param and form in [T, T&, const T&, volatile T&, const volatile T&]
    */
   predicate hasGenericCopyCompatibleParameter() {
-    exists(TemplateParameter tp, Type pType |
+    exists(TypeTemplateParameter tp, Type pType |
       pType = this.getAParameter().getType().getUnspecifiedType() and //Parameter Type
       (
         tp = pType //T

--- a/cpp/common/test/guideline_recategorizations/DisappliedQuery.ql
+++ b/cpp/common/test/guideline_recategorizations/DisappliedQuery.ql
@@ -17,7 +17,7 @@ from UserType ut, string reason
 where
   isExcluded(ut, DeadCodePackage::unusedTypeDeclarationsQuery(), reason) and
   exists(ut.getFile()) and
-  not ut instanceof TemplateParameter and
+  not ut instanceof TypeTemplateParameter and
   not ut instanceof ProxyClass and
   not exists(getATypeUse(ut)) and
   not ut.isFromUninstantiatedTemplate(_)


### PR DESCRIPTION
## Description

_please enter the description of your change here_

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [ ] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)