### PR TITLE
Fix #540: A3-9-1: Dont consider variables from template instantiations

### DIFF
--- a/change_notes/2024-12-18-fix-fp-540-a3-9-1.md
+++ b/change_notes/2024-12-18-fix-fp-540-a3-9-1.md
@@ -1,0 +1,2 @@
+ - `A3-9-1` - `VariableWidthIntegerTypesUsed.ql`:
+   - Reduce false positives by not considering variables from template instantiations.

--- a/cpp/autosar/src/rules/A3-9-1/VariableWidthIntegerTypesUsed.ql
+++ b/cpp/autosar/src/rules/A3-9-1/VariableWidthIntegerTypesUsed.ql
@@ -32,6 +32,10 @@ where
     typeStrippedOfSpecifiers instanceof SignedCharType
   ) and
   not v instanceof ExcludedVariable and
+  // Dont consider template instantiations because instantiations with
+  // Fixed Width Types are recorded after stripping their typedef'd type,
+  // thereby, causing false positives (#540).
+  not v.isFromTemplateInstantiation(_) and
   //post-increment/post-decrement operators are required by the standard to have a dummy int parameter
   not v.(Parameter).getFunction() instanceof PostIncrementOperator and
   not v.(Parameter).getFunction() instanceof PostDecrementOperator

--- a/cpp/autosar/test/rules/A3-9-1/test.cpp
+++ b/cpp/autosar/test/rules/A3-9-1/test.cpp
@@ -76,3 +76,14 @@ struct test_fix_fp_614 {
   test_fix_fp_614 operator++(int); // COMPLIANT
   test_fix_fp_614 operator--(int); // COMPLIANT
 };
+
+// COMPLIANT - instantiated with Fixed Width Types.
+template <typename MyType> constexpr void test_fix_fp_540(MyType value) {
+  value++;
+}
+
+int call_test_fix_fp_540() {
+  test_fix_fp_540<std::uint8_t>(19);
+  test_fix_fp_540<std::int16_t>(20);
+  return 0;
+}


### PR DESCRIPTION
## Description

Since CodeQL stores the Fixed Width types after resolving their typedef'd types, this query reports false positives as mentioned in #540. This PR modifies the query to avoid reporting on template instantiated variables.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - A3-9-1

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)