### PR TITLE
M5-3-1: Exclude unknown types

### DIFF
--- a/change_notes/2025-02-06-m5-3-1-exclude-unknown-type.md
+++ b/change_notes/2025-02-06-m5-3-1-exclude-unknown-type.md
@@ -1,0 +1,2 @@
+ - `M5-3-1` - `EachOperandOfTheOperatorOfTheLogicalAndOrTheLogicalOperatorsShallHaveTypeBool.ql`:
+   - Consistently exclude results in unevaluated contexts associated with uninstantiated templates, for example `noexcept` specifiers and `static_assert`s.

--- a/cpp/autosar/src/rules/M5-3-1/EachOperandOfTheOperatorTheLogicalAndOrTheLogicalOperatorsShallHaveTypeBool.ql
+++ b/cpp/autosar/src/rules/M5-3-1/EachOperandOfTheOperatorTheLogicalAndOrTheLogicalOperatorsShallHaveTypeBool.ql
@@ -25,6 +25,11 @@ where
   ) and
   t = operand.getType() and
   not t.getUnderlyingType().getUnspecifiedType() instanceof BoolType and
+  // Ignore cases where the type is unknown - this will typically be in unevaluated contexts
+  // within uninstantiated templates. It's necessary to check for this explicitly because
+  // not all unevaluated contexts are considered to be `isFromUninstantiatedTemplate(_)`,
+  // e.g. `noexcept` specifiers
+  not t instanceof UnknownType and
   not exists(ReferenceType rt |
     rt = t.getUnderlyingType().getUnspecifiedType() and rt.getBaseType() instanceof BoolType
   ) and

--- a/cpp/autosar/test/rules/M5-3-1/test.cpp
+++ b/cpp/autosar/test/rules/M5-3-1/test.cpp
@@ -26,3 +26,12 @@ void f() {
   A<int> a;
   a.test1();
 }
+
+template <typename T> constexpr bool some_variable_template_v = false;
+template <> constexpr bool some_variable_template_v<int> = true;
+
+template <typename S>
+void template_with_no_except() noexcept(some_variable_template_v<S> &&
+                                        true) { // COMPLIANT
+}
+void test_template() { template_with_no_except<int>(); }


### PR DESCRIPTION
## Description

Fixes #851.

Ensure we consistently exclude unknown results for unevaluated contexts in uninstantiated templates.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `M5-3-1`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)