### PR TITLE
Fix #718

### DIFF
--- a/change_notes/2025-02-13-fix-issue-718.md
+++ b/change_notes/2025-02-13-fix-issue-718.md
@@ -1,0 +1,2 @@
+- `A2-7-3` - `UndocumentedUserDefinedType.ql`
+  - Fixes #718. Include trailing characters after group comment endings with ///@{ ... ///@}.

--- a/cpp/autosar/src/rules/A2-7-3/UndocumentedUserDefinedType.ql
+++ b/cpp/autosar/src/rules/A2-7-3/UndocumentedUserDefinedType.ql
@@ -28,7 +28,7 @@ private predicate isInFunctionScope(Declaration d) {
 private string doxygenCommentGroupStrings(boolean opening) {
   opening = true and result = ["///@{", "/**@{*/"]
   or
-  opening = false and result = ["///@}", "/**@}*/"]
+  opening = false and result = ["///@}%", "/**@}*/"]
 }
 
 pragma[inline]

--- a/cpp/autosar/test/rules/A2-7-3/test.cpp
+++ b/cpp/autosar/test/rules/A2-7-3/test.cpp
@@ -226,3 +226,13 @@ class ClassG3 { // COMPLIANT
 public:
   friend int foo3() { return 1; } // NON_COMPLIANT
 };
+
+/// @brief A Doxygen comment.
+class ClassH { // COMPLIANT
+public:
+  /// @brief Group with comment at the end.
+  ///@{
+  void m(); // COMPLIANT
+  void n(); // COMPLIANT
+  ///@} End of group
+};


### PR DESCRIPTION
## Description

Use `%` in string::matches to accept any sequence of characters after the group comment ending `///@}`.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] Queries have been added for the following rules:
     - `A2-7-3`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)