### PR TITLE
Implement Rule-1-4's rule amendment from Amendment4 (also amended in Amd3)

### DIFF
--- a/amendments.csv
+++ b/amendments.csv
@@ -24,7 +24,7 @@ c,MISRA-C-2012,Amendment4,RULE-8-9,Yes,Clarification,Yes,Import
 c,MISRA-C-2012,Amendment4,RULE-9-4,Yes,Clarification,Yes,Import
 c,MISRA-C-2012,Amendment4,RULE-10-1,Yes,Clarification,Yes,Import
 c,MISRA-C-2012,Amendment4,RULE-18-3,Yes,Clarification,Yes,Import
-c,MISRA-C-2012,Amendment4,RULE-1-4,Yes,Replace,No,Easy
+c,MISRA-C-2012,Amendment4,RULE-1-4,Yes,Replace,Yes,Easy
 c,MISRA-C-2012,Amendment4,RULE-9-1,Yes,Refine,Yes,Easy
 c,MISRA-C-2012,Corrigendum2,DIR-4-10,Yes,Clarification,Yes,Import
 c,MISRA-C-2012,Corrigendum2,RULE-7-4,Yes,Refine,Yes,Easy

--- a/c/misra/test/rules/RULE-1-4/EmergentLanguageFeaturesUsed.expected
+++ b/c/misra/test/rules/RULE-1-4/EmergentLanguageFeaturesUsed.expected
@@ -1,7 +1,1 @@
-| test.c:2:1:2:22 | #include <stdatomic.h> | Usage of emergent language feature. |
-| test.c:4:1:4:20 | #include <threads.h> | Usage of emergent language feature. |
 | test.c:7:1:7:32 | #define __STDC_WANT_LIB_EXT1__ 1 | Usage of emergent language feature. |
-| test.c:12:26:12:40 | atomic_new_type | Usage of emergent language feature. |
-| test.c:17:15:17:15 | i | Usage of emergent language feature. |
-| test.c:24:27:24:28 | i3 | Usage of emergent language feature. |
-| test.c:25:28:25:29 | i4 | Usage of emergent language feature. |

--- a/c/misra/test/rules/RULE-1-4/test.c
+++ b/c/misra/test/rules/RULE-1-4/test.c
@@ -1,15 +1,15 @@
 #include <stdalign.h>    //COMPLIANT
-#include <stdatomic.h>   //NON_COMPLIANT
+#include <stdatomic.h>   //COMPLIANT
 #include <stdnoreturn.h> //COMPLIANT
-#include <threads.h>     //NON_COMPLIANT
+#include <threads.h>     //COMPLIANT
 
-#define MACRO(x) _Generic((x), int : 0, long : 1) // NON_COMPLIANT
+#define MACRO(x) _Generic((x), int : 0, long : 1) // COMPLIANT
 #define __STDC_WANT_LIB_EXT1__ 1                  // NON_COMPLIANT
 
 _Noreturn void f0(); // COMPLIANT
 
 typedef int new_type;                     // COMPLIANT
-typedef _Atomic new_type atomic_new_type; // NON_COMPLIANT
+typedef _Atomic new_type atomic_new_type; // COMPLIANT
 
 void f(int p) {
   int i0 = _Generic(p, int : 0, long : 1); // COMPLIANT
@@ -21,6 +21,6 @@ void f(int p) {
   int a = _Alignof(int); // COMPLIANT
   int a1 = alignof(int); // COMPLIANT
 
-  static thread_local int i3;  // NON_COMPLIANT
-  static _Thread_local int i4; // NON_COMPLIANT
+  static thread_local int i3;  // COMPLIANT
+  static _Thread_local int i4; // COMPLIANT
 }

--- a/change_notes/2025-03-31-allow-atomics-threads-and-threadlocals-in-misra-c.md
+++ b/change_notes/2025-03-31-allow-atomics-threads-and-threadlocals-in-misra-c.md
@@ -1,0 +1,2 @@
+ - `RULE-1-4` - `EmergentLanguageFeaturesUsed.ql`:
+   - Allow usage of atomics, `thread.h`, and `_Thread_local` as per Misra C 2012 Amendment 4.

--- a/cpp/common/src/codingstandards/cpp/Emergent.qll
+++ b/cpp/common/src/codingstandards/cpp/Emergent.qll
@@ -6,24 +6,6 @@ import cpp
 module C11 {
   abstract class EmergentLanguageFeature extends Element { }
 
-  class AtomicVariableSpecifier extends EmergentLanguageFeature, Variable {
-    AtomicVariableSpecifier() {
-      getType().(DerivedType).getBaseType*().getASpecifier().getName() = "atomic"
-    }
-  }
-
-  class AtomicDeclaration extends EmergentLanguageFeature, Declaration {
-    AtomicDeclaration() { getASpecifier().getName() = "atomic" }
-  }
-
-  class ThreadLocalDeclaration extends EmergentLanguageFeature, Declaration {
-    ThreadLocalDeclaration() { getASpecifier().getName() = "is_thread_local" }
-  }
-
-  class EmergentHeader extends EmergentLanguageFeature, Include {
-    EmergentHeader() { getIncludedFile().getBaseName() = ["stdatomic.h", "threads.h"] }
-  }
-
   class LibExt1Macro extends EmergentLanguageFeature, Macro {
     LibExt1Macro() {
       getName() = "__STDC_WANT_LIB_EXT1__" and


### PR DESCRIPTION
## Description

I thought this update to `RULE-1-4` ("Emergent language features shall not be used") was already done but not marked as such in `amendments.csv`. `RULE-1-4` is the only rule that has changes from `Amendment3`, as well as changes in `Amendment4`. The first pass on it from `Amendment3` didn't complete that aspect of the work (waiting for generics) and I misremembered (fairly clearly, but wholly incorrectly) that the amdt4 work had been done.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `RULE-1-4`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)