### PR TITLE
Revert "Convert DanglingCaptureWhenReturningLambdaObject to use new dataflow library"

### DIFF
--- a/cpp/common/src/codingstandards/cpp/rules/danglingcapturewhenreturninglambdaobject/DanglingCaptureWhenReturningLambdaObject.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/danglingcapturewhenreturninglambdaobject/DanglingCaptureWhenReturningLambdaObject.qll
@@ -5,7 +5,7 @@
  */
 
 import cpp
-import semmle.code.cpp.dataflow.new.DataFlow
+import semmle.code.cpp.dataflow.DataFlow
 import codingstandards.cpp.Customizations
 import codingstandards.cpp.Exclusions
 


### PR DESCRIPTION
This reverts commit b18c7b4625d35af8e4411b3d5a3531eee81b4f90. This change broke some tests.
