### PR TITLE
Make dataflow imports private in libraries and remove unused imports

### DIFF
--- a/c/cert/src/rules/ARR32-C/VariableLengthArraySizeNotInValidRange.ql
+++ b/c/cert/src/rules/ARR32-C/VariableLengthArraySizeNotInValidRange.ql
@@ -20,6 +20,7 @@
 import cpp
 import codingstandards.c.cert
 import codingstandards.cpp.Overflow
+import semmle.code.cpp.dataflow.TaintTracking
 
 /**
  * Gets the maximum size (in bytes) a variable-length array

--- a/c/cert/src/rules/ERR32-C/DoNotRelyOnIndeterminateValuesOfErrno.ql
+++ b/c/cert/src/rules/ERR32-C/DoNotRelyOnIndeterminateValuesOfErrno.ql
@@ -20,6 +20,7 @@ import codingstandards.c.cert
 import codingstandards.c.Errno
 import codingstandards.c.Signal
 import semmle.code.cpp.controlflow.Guards
+import semmle.code.cpp.dataflow.DataFlow
 
 /**
  * A check on `signal` call return value

--- a/c/cert/src/rules/ERR33-C/DetectAndHandleStandardLibraryErrors.ql
+++ b/c/cert/src/rules/ERR33-C/DetectAndHandleStandardLibraryErrors.ql
@@ -20,6 +20,7 @@ import cpp
 import codingstandards.c.cert
 import semmle.code.cpp.commons.NULL
 import codingstandards.cpp.ReadErrorsAndEOF
+import semmle.code.cpp.dataflow.DataFlow
 
 ComparisonOperation getAValidComparison(string spec) {
   spec = "=0" and result.(EqualityOperation).getAnOperand().getValue() = "0"

--- a/c/cert/src/rules/FIO40-C/ResetStringsOnFgetsOrFgetwsFailure.ql
+++ b/c/cert/src/rules/FIO40-C/ResetStringsOnFgetsOrFgetwsFailure.ql
@@ -21,6 +21,7 @@ import cpp
 import codingstandards.cpp.FgetsErrorManagement
 import codingstandards.cpp.Dereferenced
 import codingstandards.c.cert
+import semmle.code.cpp.dataflow.DataFlow
 
 /*
  * Models calls to `memcpy` `strcpy` `strncpy` and their wrappers

--- a/c/cert/test/rules/ARR32-C/VariableLengthArraySizeNotInValidRange.expected
+++ b/c/cert/test/rules/ARR32-C/VariableLengthArraySizeNotInValidRange.expected
@@ -1,5 +1,5 @@
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (VariableLengthArraySizeNotInValidRange.ql:109,11-19)
-WARNING: module 'TaintTracking' has been deprecated and may be removed in future (VariableLengthArraySizeNotInValidRange.ql:92,5-18)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (VariableLengthArraySizeNotInValidRange.ql:110,11-19)
+WARNING: module 'TaintTracking' has been deprecated and may be removed in future (VariableLengthArraySizeNotInValidRange.ql:93,5-18)
 | test.c:14:8:14:8 | VLA declaration | Variable-length array dimension size may be in an invalid range. |
 | test.c:15:8:15:8 | VLA declaration | Variable-length array dimension size may be in an invalid range. |
 | test.c:16:8:16:8 | VLA declaration | Variable-length array dimension size may be in an invalid range. |

--- a/c/cert/test/rules/ERR32-C/DoNotRelyOnIndeterminateValuesOfErrno.expected
+++ b/c/cert/test/rules/ERR32-C/DoNotRelyOnIndeterminateValuesOfErrno.expected
@@ -1,7 +1,7 @@
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotRelyOnIndeterminateValuesOfErrno.ql:55,7-15)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotRelyOnIndeterminateValuesOfErrno.ql:55,27-35)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotRelyOnIndeterminateValuesOfErrno.ql:56,9-17)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotRelyOnIndeterminateValuesOfErrno.ql:59,9-17)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotRelyOnIndeterminateValuesOfErrno.ql:56,7-15)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotRelyOnIndeterminateValuesOfErrno.ql:56,27-35)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotRelyOnIndeterminateValuesOfErrno.ql:57,9-17)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotRelyOnIndeterminateValuesOfErrno.ql:60,9-17)
 | test.c:12:5:12:10 | call to perror | `errno` has indeterminate value after this $@. | test.c:10:21:10:26 | call to signal | call to signal |
 | test.c:30:5:30:10 | call to perror | `errno` has indeterminate value after this $@. | test.c:26:21:26:26 | call to signal | call to signal |
 | test.c:49:5:49:10 | call to perror | `errno` has indeterminate value after this $@. | test.c:45:21:45:26 | call to signal | call to signal |

--- a/c/cert/test/rules/ERR33-C/DetectAndHandleStandardLibraryErrors.expected
+++ b/c/cert/test/rules/ERR33-C/DetectAndHandleStandardLibraryErrors.expected
@@ -1,4 +1,4 @@
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DetectAndHandleStandardLibraryErrors.ql:458,5-13)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (DetectAndHandleStandardLibraryErrors.ql:459,5-13)
 | test.c:18:3:18:11 | call to setlocale | Missing error detection for the call to function `setlocale`. |
 | test.c:24:23:24:31 | call to setlocale | Missing error detection for the call to function `setlocale`. |
 | test.c:29:22:29:27 | call to calloc | Missing error detection for the call to function `calloc`. |

--- a/c/cert/test/rules/FIO40-C/ResetStringsOnFgetsOrFgetwsFailure.expected
+++ b/c/cert/test/rules/FIO40-C/ResetStringsOnFgetsOrFgetwsFailure.expected
@@ -1,6 +1,6 @@
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (ResetStringsOnFgetsOrFgetwsFailure.ql:47,11-19)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (ResetStringsOnFgetsOrFgetwsFailure.ql:47,31-39)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (ResetStringsOnFgetsOrFgetwsFailure.ql:48,13-21)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (ResetStringsOnFgetsOrFgetwsFailure.ql:48,11-19)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (ResetStringsOnFgetsOrFgetwsFailure.ql:48,31-39)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (ResetStringsOnFgetsOrFgetwsFailure.ql:49,13-21)
 | test.c:20:10:20:12 | buf | The buffer is not reset before being referenced following a failed $@. | test.c:15:7:15:11 | call to fgets | call to fgets |
 | test.c:57:10:57:12 | buf | The buffer is not reset before being referenced following a failed $@. | test.c:52:7:52:11 | call to fgets | call to fgets |
 | test.c:66:18:66:20 | buf | The buffer is not reset before being referenced following a failed $@. | test.c:61:7:61:11 | call to fgets | call to fgets |

--- a/c/common/src/codingstandards/c/OutOfBounds.qll
+++ b/c/common/src/codingstandards/c/OutOfBounds.qll
@@ -11,7 +11,7 @@ import codingstandards.cpp.Allocations
 import codingstandards.cpp.Overflow
 import codingstandards.cpp.PossiblyUnsafeStringOperation
 import codingstandards.cpp.SimpleRangeAnalysisCustomizations
-import semmle.code.cpp.dataflow.DataFlow
+private import semmle.code.cpp.dataflow.DataFlow
 import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 
 module OOB {

--- a/c/common/src/codingstandards/c/Signal.qll
+++ b/c/common/src/codingstandards/c/Signal.qll
@@ -1,5 +1,5 @@
 import cpp
-import semmle.code.cpp.dataflow.DataFlow
+private import semmle.code.cpp.dataflow.DataFlow
 
 /**
  * A signal corresponding to a computational exception

--- a/c/misra/src/rules/RULE-22-17/InvalidOperationOnUnlockedMutex.ql
+++ b/c/misra/src/rules/RULE-22-17/InvalidOperationOnUnlockedMutex.ql
@@ -18,7 +18,6 @@ import codingstandards.c.misra
 import codingstandards.c.SubObjects
 import codingstandards.cpp.Concurrency
 import codingstandards.cpp.dominance.BehavioralSet
-import semmle.code.cpp.dataflow.new.DataFlow::DataFlow as NewDF
 
 /* A call to mtx_unlock() or cnd_wait() or cnd_timedwait(), which require a locked mutex */
 class RequiresLockOperation extends FunctionCall {

--- a/c/misra/src/rules/RULE-22-7/EofShallBeComparedWithUnmodifiedReturnValues.ql
+++ b/c/misra/src/rules/RULE-22-7/EofShallBeComparedWithUnmodifiedReturnValues.ql
@@ -15,6 +15,7 @@
 import cpp
 import codingstandards.c.misra
 import codingstandards.cpp.ReadErrorsAndEOF
+import semmle.code.cpp.dataflow.DataFlow
 
 /**
  * The getchar() return value propagates directly to a check against EOF macro

--- a/c/misra/test/rules/RULE-22-7/EofShallBeComparedWithUnmodifiedReturnValues.expected
+++ b/c/misra/test/rules/RULE-22-7/EofShallBeComparedWithUnmodifiedReturnValues.expected
@@ -1,10 +1,10 @@
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (EofShallBeComparedWithUnmodifiedReturnValues.ql:23,28-36)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (EofShallBeComparedWithUnmodifiedReturnValues.ql:24,22-30)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (EofShallBeComparedWithUnmodifiedReturnValues.ql:28,20-28)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (EofShallBeComparedWithUnmodifiedReturnValues.ql:37,23-31)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (EofShallBeComparedWithUnmodifiedReturnValues.ql:42,17-25)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (EofShallBeComparedWithUnmodifiedReturnValues.ql:51,5-13)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (EofShallBeComparedWithUnmodifiedReturnValues.ql:59,20-28)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (EofShallBeComparedWithUnmodifiedReturnValues.ql:59,46-54)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (EofShallBeComparedWithUnmodifiedReturnValues.ql:24,28-36)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (EofShallBeComparedWithUnmodifiedReturnValues.ql:25,22-30)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (EofShallBeComparedWithUnmodifiedReturnValues.ql:29,20-28)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (EofShallBeComparedWithUnmodifiedReturnValues.ql:38,23-31)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (EofShallBeComparedWithUnmodifiedReturnValues.ql:43,17-25)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (EofShallBeComparedWithUnmodifiedReturnValues.ql:52,5-13)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (EofShallBeComparedWithUnmodifiedReturnValues.ql:60,20-28)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (EofShallBeComparedWithUnmodifiedReturnValues.ql:60,46-54)
 | test.c:6:7:6:20 | ... != ... | The check is not reliable as the type of the return value of $@ is converted. | test.c:5:14:5:20 | call to getchar | call to getchar |
 | test.c:13:7:13:15 | ... != ... | The check is not reliable as the type of the return value of $@ is converted. | test.c:12:14:12:20 | call to getchar | call to getchar |

--- a/cpp/autosar/src/rules/A8-4-9/InOutParametersDeclaredAsTNotModified.ql
+++ b/cpp/autosar/src/rules/A8-4-9/InOutParametersDeclaredAsTNotModified.ql
@@ -21,6 +21,7 @@ import codingstandards.cpp.autosar
 import codingstandards.cpp.FunctionParameter
 import codingstandards.cpp.ConstHelpers
 import codingstandards.cpp.Operator
+import semmle.code.cpp.dataflow.DataFlow
 
 /**
  * Non-const T& `Parameter`s to `Function`s

--- a/cpp/autosar/test/rules/A8-4-9/InOutParametersDeclaredAsTNotModified.expected
+++ b/cpp/autosar/test/rules/A8-4-9/InOutParametersDeclaredAsTNotModified.expected
@@ -1,5 +1,5 @@
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (InOutParametersDeclaredAsTNotModified.ql:49,7-15)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (InOutParametersDeclaredAsTNotModified.ql:63,7-15)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (InOutParametersDeclaredAsTNotModified.ql:50,7-15)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (InOutParametersDeclaredAsTNotModified.ql:64,7-15)
 | test.cpp:4:13:4:13 | i | In-out parameter i that is not written to. |
 | test.cpp:7:22:7:24 | str | In-out parameter str that is not read from. |
 | test.cpp:18:14:18:14 | i | In-out parameter i that is not read from. |

--- a/cpp/cert/src/rules/CTR53-CPP/UseValidIteratorRanges.ql
+++ b/cpp/cert/src/rules/CTR53-CPP/UseValidIteratorRanges.ql
@@ -19,6 +19,7 @@
 import cpp
 import codingstandards.cpp.cert
 import codingstandards.cpp.Iterators
+import semmle.code.cpp.dataflow.DataFlow
 
 predicate startEndArgumentsDoNotPointToTheSameContainer(
   IteratorRangeFunctionCall fc, Expr arg, string reason

--- a/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
+++ b/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
@@ -20,6 +20,7 @@ import cpp
 import codingstandards.cpp.cert
 import codingstandards.cpp.Iterators
 import semmle.code.cpp.controlflow.Dominance
+import semmle.code.cpp.dataflow.DataFlow
 
 /**
  * Models a call to an iterator's `operator+`

--- a/cpp/cert/test/rules/CTR53-CPP/UseValidIteratorRanges.expected
+++ b/cpp/cert/test/rules/CTR53-CPP/UseValidIteratorRanges.expected
@@ -1,9 +1,9 @@
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (UseValidIteratorRanges.ql:28,5-13)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (UseValidIteratorRanges.ql:28,25-33)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (UseValidIteratorRanges.ql:29,7-15)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (UseValidIteratorRanges.ql:35,5-13)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (UseValidIteratorRanges.ql:35,25-33)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (UseValidIteratorRanges.ql:36,7-15)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (UseValidIteratorRanges.ql:29,5-13)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (UseValidIteratorRanges.ql:29,25-33)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (UseValidIteratorRanges.ql:30,7-15)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (UseValidIteratorRanges.ql:36,5-13)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (UseValidIteratorRanges.ql:36,25-33)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (UseValidIteratorRanges.ql:37,7-15)
 | test.cpp:7:3:7:15 | call to for_each | The $@ of iterator range function does not point to the end of an iterator. | test.cpp:7:28:7:32 | call to begin | argument |
 | test.cpp:7:3:7:15 | call to for_each | The $@ of iterator range function does not point to the start of an iterator. | test.cpp:7:19:7:21 | call to end | argument |
 | test.cpp:8:3:8:15 | call to for_each | The $@ of iterator range function does not point to the end of an iterator. | test.cpp:8:30:8:34 | call to begin | argument |

--- a/cpp/cert/test/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.expected
+++ b/cpp/cert/test/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.expected
@@ -1,12 +1,12 @@
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotUseAnAdditiveOperatorOnAnIterator.ql:43,5-13)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotUseAnAdditiveOperatorOnAnIterator.ql:43,25-33)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotUseAnAdditiveOperatorOnAnIterator.ql:43,51-59)
 WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotUseAnAdditiveOperatorOnAnIterator.ql:44,5-13)
 WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotUseAnAdditiveOperatorOnAnIterator.ql:44,25-33)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotUseAnAdditiveOperatorOnAnIterator.ql:44,52-60)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotUseAnAdditiveOperatorOnAnIterator.ql:79,5-13)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotUseAnAdditiveOperatorOnAnIterator.ql:79,25-33)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotUseAnAdditiveOperatorOnAnIterator.ql:80,7-15)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotUseAnAdditiveOperatorOnAnIterator.ql:44,51-59)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotUseAnAdditiveOperatorOnAnIterator.ql:45,5-13)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotUseAnAdditiveOperatorOnAnIterator.ql:45,25-33)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotUseAnAdditiveOperatorOnAnIterator.ql:45,52-60)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotUseAnAdditiveOperatorOnAnIterator.ql:80,5-13)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotUseAnAdditiveOperatorOnAnIterator.ql:80,25-33)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (DoNotUseAnAdditiveOperatorOnAnIterator.ql:81,7-15)
 | test.cpp:8:7:8:7 | i | Increment of iterator may overflow since its bounds are not checked. |
 | test.cpp:9:9:9:9 | i | Increment of iterator may overflow since its bounds are not checked. |
 | test.cpp:10:9:10:9 | i | Increment of iterator may overflow since its bounds are not checked. |

--- a/cpp/common/src/codingstandards/cpp/AccessPath.qll
+++ b/cpp/common/src/codingstandards/cpp/AccessPath.qll
@@ -1,5 +1,5 @@
 import cpp
-import semmle.code.cpp.dataflow.DataFlow
+private import semmle.code.cpp.dataflow.DataFlow
 
 newtype TFieldQualifier =
   ExplicitQualifier(VariableAccess v) or

--- a/cpp/common/src/codingstandards/cpp/Allocations.qll
+++ b/cpp/common/src/codingstandards/cpp/Allocations.qll
@@ -7,7 +7,7 @@
 
 import cpp
 import semmle.code.cpp.controlflow.SSA
-import semmle.code.cpp.dataflow.DataFlow
+private import semmle.code.cpp.dataflow.DataFlow
 
 /**
  * Holds if `alloc` is a use of `malloc` or `new`.  `kind` is

--- a/cpp/common/src/codingstandards/cpp/Concurrency.qll
+++ b/cpp/common/src/codingstandards/cpp/Concurrency.qll
@@ -1,5 +1,4 @@
 import cpp
-import semmle.code.cpp.dataflow.TaintTracking
 import codingstandards.cpp.concurrency.Atomic
 import codingstandards.cpp.concurrency.CConditionOperation
 import codingstandards.cpp.concurrency.ControlFlow

--- a/cpp/common/src/codingstandards/cpp/ConstHelpers.qll
+++ b/cpp/common/src/codingstandards/cpp/ConstHelpers.qll
@@ -4,7 +4,7 @@
 
 import cpp
 import codingstandards.cpp.SideEffect
-import semmle.code.cpp.dataflow.DataFlow
+private import semmle.code.cpp.dataflow.DataFlow
 import codingstandards.cpp.FunctionParameter
 
 /** A variable that can be modified (both the pointer and object pointed to if pointer type) */

--- a/cpp/common/src/codingstandards/cpp/Expr.qll
+++ b/cpp/common/src/codingstandards/cpp/Expr.qll
@@ -1,4 +1,5 @@
 import cpp
+private import semmle.code.cpp.dataflow.DataFlow
 private import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import codingstandards.cpp.AccessPath
 

--- a/cpp/common/src/codingstandards/cpp/FgetsErrorManagement.qll
+++ b/cpp/common/src/codingstandards/cpp/FgetsErrorManagement.qll
@@ -4,7 +4,7 @@
  */
 
 import cpp
-import semmle.code.cpp.dataflow.DataFlow
+private import semmle.code.cpp.dataflow.DataFlow
 import semmle.code.cpp.controlflow.Guards
 
 /*

--- a/cpp/common/src/codingstandards/cpp/Iterators.qll
+++ b/cpp/common/src/codingstandards/cpp/Iterators.qll
@@ -3,8 +3,8 @@
  */
 
 import cpp
-import semmle.code.cpp.dataflow.DataFlow
-import semmle.code.cpp.dataflow.TaintTracking
+private import semmle.code.cpp.dataflow.DataFlow
+private import semmle.code.cpp.dataflow.TaintTracking
 import codingstandards.cpp.StdNamespace
 import codingstandards.cpp.rules.containeraccesswithoutrangecheck.ContainerAccessWithoutRangeCheck as ContainerAccessWithoutRangeCheck
 import semmle.code.cpp.controlflow.Guards
@@ -16,7 +16,9 @@ abstract class ContainerAccess extends VariableAccess {
 }
 
 pragma[noinline, nomagic]
-predicate localTaint(DataFlow::Node n1, DataFlow::Node n2) { TaintTracking::localTaint(n1, n2) }
+private predicate localTaint(DataFlow::Node n1, DataFlow::Node n2) {
+  TaintTracking::localTaint(n1, n2)
+}
 
 // define this as anything with dataflow FROM the vector
 class ContainerPointerOrReferenceAccess extends ContainerAccess {

--- a/cpp/common/src/codingstandards/cpp/Overflow.qll
+++ b/cpp/common/src/codingstandards/cpp/Overflow.qll
@@ -6,7 +6,7 @@ import cpp
 import semmle.code.cpp.rangeanalysis.SimpleRangeAnalysis
 import SimpleRangeAnalysisCustomizations
 import semmle.code.cpp.controlflow.Guards
-import semmle.code.cpp.dataflow.TaintTracking
+private import semmle.code.cpp.dataflow.TaintTracking
 import semmle.code.cpp.valuenumbering.GlobalValueNumbering
 import codingstandards.cpp.Expr
 import codingstandards.cpp.UndefinedBehavior

--- a/cpp/common/src/codingstandards/cpp/ReadErrorsAndEOF.qll
+++ b/cpp/common/src/codingstandards/cpp/ReadErrorsAndEOF.qll
@@ -1,5 +1,5 @@
 import cpp
-import semmle.code.cpp.dataflow.DataFlow
+private import semmle.code.cpp.dataflow.DataFlow
 import codingstandards.cpp.standardlibrary.FileAccess
 
 /**

--- a/cpp/common/src/codingstandards/cpp/SideEffect.qll
+++ b/cpp/common/src/codingstandards/cpp/SideEffect.qll
@@ -1,7 +1,7 @@
 /** A module to reason about side effects. */
 
 import cpp
-import semmle.code.cpp.dataflow.DataFlow
+private import semmle.code.cpp.dataflow.DataFlow
 private import exceptions.ExceptionFlow
 private import codingstandards.cpp.Expr
 private import codingstandards.cpp.Variable

--- a/cpp/common/src/codingstandards/cpp/SmartPointers.qll
+++ b/cpp/common/src/codingstandards/cpp/SmartPointers.qll
@@ -1,5 +1,5 @@
 import cpp
-import semmle.code.cpp.dataflow.DataFlow
+private import semmle.code.cpp.dataflow.DataFlow
 
 // Local cached version of localExprFlow to avoid bad magic
 cached

--- a/cpp/common/src/codingstandards/cpp/concurrency/LockingOperation.qll
+++ b/cpp/common/src/codingstandards/cpp/concurrency/LockingOperation.qll
@@ -1,5 +1,5 @@
 import cpp
-import semmle.code.cpp.dataflow.TaintTracking
+private import semmle.code.cpp.dataflow.TaintTracking
 
 abstract class LockingOperation extends FunctionCall {
   /**

--- a/cpp/common/src/codingstandards/cpp/rules/invalidatedenvstringpointerswarn/InvalidatedEnvStringPointersWarn.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/invalidatedenvstringpointerswarn/InvalidatedEnvStringPointersWarn.qll
@@ -6,7 +6,6 @@
 import cpp
 import codingstandards.cpp.Customizations
 import codingstandards.cpp.Exclusions
-import semmle.code.cpp.dataflow.DataFlow
 import codingstandards.cpp.rules.invalidatedenvstringpointers.InvalidatedEnvStringPointers as EnvString
 
 abstract class InvalidatedEnvStringPointersWarnSharedQuery extends Query { }

--- a/cpp/common/src/codingstandards/cpp/rules/predicatefunctionobjectsshouldnotbemutable/PredicateFunctionObjectsShouldNotBeMutable.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/predicatefunctionobjectsshouldnotbemutable/PredicateFunctionObjectsShouldNotBeMutable.qll
@@ -9,6 +9,7 @@ import codingstandards.cpp.Customizations
 import codingstandards.cpp.Exclusions
 import codingstandards.cpp.SideEffect
 import codingstandards.cpp.sideeffect.DefaultEffects
+import semmle.code.cpp.dataflow.DataFlow
 
 abstract class PredicateFunctionObjectsShouldNotBeMutableSharedQuery extends Query { }
 

--- a/cpp/common/src/codingstandards/cpp/standardlibrary/FileStreams.qll
+++ b/cpp/common/src/codingstandards/cpp/standardlibrary/FileStreams.qll
@@ -10,8 +10,8 @@
  */
 
 import cpp
-import semmle.code.cpp.dataflow.DataFlow
-import semmle.code.cpp.dataflow.TaintTracking
+private import semmle.code.cpp.dataflow.DataFlow
+private import semmle.code.cpp.dataflow.TaintTracking
 private import codingstandards.cpp.Operator
 
 /**


### PR DESCRIPTION
## Description

Currently, many libraries non-privately import the dataflow or taint tracking library, even if the predicates and modules defined by these libraries do not depend on the dataflow or taint tracking library. This PR makes private some of these imports. This change will make it easier to port queries over to the new dataflow library, as this side-steps the issue of having to rewrite a query using dataflow at the same time we rewrite a library it depends upon.

While here, also remove some unused imports of the dataflow library.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)