### PR TITLE
C++: Accept path changes caused by codeql#20040.

### DIFF
--- a/c/misra/test/rules/RULE-21-14/MemcmpUsedToCompareNullTerminatedStrings.expected
+++ b/c/misra/test/rules/RULE-21-14/MemcmpUsedToCompareNullTerminatedStrings.expected
@@ -1,17 +1,11 @@
 edges
-| test.c:6:6:6:6 | *c | test.c:6:15:6:17 | 97 | provenance |  |
 | test.c:6:6:6:6 | *c | test.c:16:10:16:10 | *c | provenance |  |
 | test.c:6:6:6:6 | *c | test.c:26:13:26:13 | *c | provenance |  |
 | test.c:6:6:6:6 | *c | test.c:27:10:27:10 | *c | provenance |  |
 | test.c:6:14:6:26 | {...} | test.c:6:6:6:6 | *c | provenance |  |
-| test.c:6:15:6:17 | 97 | test.c:6:20:6:22 | 98 | provenance |  |
-| test.c:6:20:6:22 | 98 | test.c:6:25:6:25 | {...} | provenance |  |
 | test.c:6:25:6:25 | {...} | test.c:6:14:6:26 | {...} | provenance |  |
-| test.c:7:6:7:6 | *d | test.c:7:15:7:17 | 97 | provenance |  |
 | test.c:7:6:7:6 | *d | test.c:16:13:16:13 | *d | provenance |  |
 | test.c:7:14:7:26 | {...} | test.c:7:6:7:6 | *d | provenance |  |
-| test.c:7:15:7:17 | 97 | test.c:7:20:7:22 | 98 | provenance |  |
-| test.c:7:20:7:22 | 98 | test.c:7:25:7:25 | {...} | provenance |  |
 | test.c:7:25:7:25 | {...} | test.c:7:14:7:26 | {...} | provenance |  |
 | test.c:12:13:12:15 | *a | test.c:14:10:14:10 | *a | provenance | DataFlowFunction |
 | test.c:12:13:12:15 | *a | test.c:23:13:23:13 | *a | provenance | DataFlowFunction |
@@ -24,13 +18,9 @@ edges
 nodes
 | test.c:6:6:6:6 | *c | semmle.label | *c |
 | test.c:6:14:6:26 | {...} | semmle.label | {...} |
-| test.c:6:15:6:17 | 97 | semmle.label | 97 |
-| test.c:6:20:6:22 | 98 | semmle.label | 98 |
 | test.c:6:25:6:25 | {...} | semmle.label | {...} |
 | test.c:7:6:7:6 | *d | semmle.label | *d |
 | test.c:7:14:7:26 | {...} | semmle.label | {...} |
-| test.c:7:15:7:17 | 97 | semmle.label | 97 |
-| test.c:7:20:7:22 | 98 | semmle.label | 98 |
 | test.c:7:25:7:25 | {...} | semmle.label | {...} |
 | test.c:10:10:10:12 | *a | semmle.label | *a |
 | test.c:10:15:10:17 | *b | semmle.label | *b |


### PR DESCRIPTION
## Description

https://github.com/github/codeql/pull/20040 fixed some spurious flow that reduced the number of `PathNode`s.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [ ] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)