### PR TITLE
Fix bad joins on function names and unnecessarily large relation on integer constant macros

### DIFF
--- a/c/cert/src/rules/DCL40-C/IncompatibleFunctionDeclarations.ql
+++ b/c/cert/src/rules/DCL40-C/IncompatibleFunctionDeclarations.ql
@@ -24,28 +24,32 @@ import codingstandards.c.cert
 import codingstandards.cpp.types.Compatible
 import ExternalIdentifiers
 
-predicate interestedInFunctions(FunctionDeclarationEntry f1, FunctionDeclarationEntry f2) {
+predicate interestedInFunctions(
+  FunctionDeclarationEntry f1, FunctionDeclarationEntry f2, ExternalIdentifiers d
+) {
   not f1 = f2 and
-  f1.getDeclaration() = f2.getDeclaration() and
-  f1.getName() = f2.getName()
+  d = f1.getDeclaration() and
+  d = f2.getDeclaration()
 }
+
+predicate interestedInFunctions(FunctionDeclarationEntry f1, FunctionDeclarationEntry f2) {
+  interestedInFunctions(f1, f2, _)
+}
+
+module FuncDeclEquiv =
+  FunctionDeclarationTypeEquivalence<TypesCompatibleConfig, interestedInFunctions/2>;
 
 from ExternalIdentifiers d, FunctionDeclarationEntry f1, FunctionDeclarationEntry f2
 where
   not isExcluded(f1, Declarations2Package::incompatibleFunctionDeclarationsQuery()) and
   not isExcluded(f2, Declarations2Package::incompatibleFunctionDeclarationsQuery()) and
-  not f1 = f2 and
-  f1.getDeclaration() = d and
-  f2.getDeclaration() = d and
-  f1.getName() = f2.getName() and
+  interestedInFunctions(f1, f2, d) and
   (
     //return type check
-    not FunctionDeclarationTypeEquivalence<TypesCompatibleConfig, interestedInFunctions/2>::equalReturnTypes(f1,
-      f2)
+    not FuncDeclEquiv::equalReturnTypes(f1, f2)
     or
     //parameter type check
-    not FunctionDeclarationTypeEquivalence<TypesCompatibleConfig, interestedInFunctions/2>::equalParameterTypes(f1,
-      f2)
+    not FuncDeclEquiv::equalParameterTypes(f1, f2)
   ) and
   // Apply ordering on start line, trying to avoid the optimiser applying this join too early
   // in the pipeline

--- a/c/misra/src/rules/RULE-7-5/IncorrectlySizedIntegerConstantMacroArgument.ql
+++ b/c/misra/src/rules/RULE-7-5/IncorrectlySizedIntegerConstantMacroArgument.ql
@@ -20,6 +20,7 @@ predicate matchesSign(IntegerConstantMacro macro, PossiblyNegativeLiteral litera
   literal.isNegative() implies macro.isSigned()
 }
 
+bindingset[literal]
 predicate matchesSize(IntegerConstantMacro macro, PossiblyNegativeLiteral literal) {
   literal.getRawValue() <= macro.maxValue() and
   literal.getRawValue() >= macro.minValue()

--- a/c/misra/src/rules/RULE-8-4/CompatibleDeclarationFunctionDefined.ql
+++ b/c/misra/src/rules/RULE-8-4/CompatibleDeclarationFunctionDefined.ql
@@ -23,12 +23,13 @@ predicate interestedInFunctions(FunctionDeclarationEntry f1, FunctionDeclaration
   f1.getDeclaration() instanceof ExternalIdentifiers and
   f1.isDefinition() and
   f1.getDeclaration() = f2.getDeclaration() and
-  // This condition should always hold, but removing it affects join order performance.
-  f1.getName() = f2.getName() and
   not f2.isDefinition() and
   not f1.isFromTemplateInstantiation(_) and
   not f2.isFromTemplateInstantiation(_)
 }
+
+module FunDeclEquiv =
+  FunctionDeclarationTypeEquivalence<TypesCompatibleConfig, interestedInFunctions/2>;
 
 from FunctionDeclarationEntry f1
 where
@@ -44,17 +45,13 @@ where
     or
     //or one exists that is close but incompatible in some way
     exists(FunctionDeclarationEntry f2 |
-      f1.getName() = f2.getName() and
-      not f2.isDefinition() and
-      f2.getDeclaration() = f1.getDeclaration() and
+      interestedInFunctions(f1, f2) and
       (
         //return types differ
-        not FunctionDeclarationTypeEquivalence<TypesCompatibleConfig, interestedInFunctions/2>::equalReturnTypes(f1,
-          f2)
+        not FunDeclEquiv::equalReturnTypes(f1, f2)
         or
         //parameter types differ
-        not FunctionDeclarationTypeEquivalence<TypesCompatibleConfig, interestedInFunctions/2>::equalParameterTypes(f1,
-          f2)
+        not FunDeclEquiv::equalParameterTypes(f1, f2)
         or
         //parameter names differ
         parameterNamesUnmatched(f1, f2)

--- a/change_notes/2025-7-15-fix-performance-issues-in-2.20.7.md
+++ b/change_notes/2025-7-15-fix-performance-issues-in-2.20.7.md
@@ -1,0 +1,4 @@
+ - `DCL40-C`, `RULE-8-4`: `IncompatibleFunctionDeclarations.ql`, `CompatibleDeclarationFunctionDefined.ql`.
+   - Fixed performance issues introduced when upgrading to CodeQL `2.20.7` by removing unnecessary check that matching function declarations have matching names.
+ - `RULE-7-5`: `IncorrectlySizedIntegerConstantMacroArgument.ql`.
+   - Added a `bindingset` to improve performance when checking if a literal matches the size of an integer constant macro.


### PR DESCRIPTION
## Description

Performance fixes to upgrade to 2.20.7.

Note: I ran a check in the top 100 to find cases of `interestedInFunctions(f1, f2)` where `f1` and `f2` had different names and found no matches.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `RULE-7-5`, `RULE-8-4`, `DCL40-C`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)