### PR TITLE
C++: Fix queries after #20126

### DIFF
--- a/c/misra/test/rules/RULE-21-26/TimedlockOnInappropriateMutexType.expected
+++ b/c/misra/test/rules/RULE-21-26/TimedlockOnInappropriateMutexType.expected
@@ -1,11 +1,25 @@
 edges
+| test.c:3:7:3:8 | *g1 | test.c:3:7:3:8 | *g1 | provenance |  |
+| test.c:3:7:3:8 | *g1 | test.c:14:17:14:19 | *& ... | provenance |  |
+| test.c:3:7:3:8 | *g1 | test.c:15:14:15:16 | *& ... | provenance |  |
+| test.c:4:7:4:8 | *g2 | test.c:4:7:4:8 | *g2 | provenance |  |
+| test.c:4:7:4:8 | *g2 | test.c:18:17:18:19 | *& ... | provenance |  |
+| test.c:4:7:4:8 | *g2 | test.c:19:14:19:16 | *& ... | provenance |  |
+| test.c:10:24:10:24 | *m | test.c:10:24:10:24 | *m | provenance |  |
 | test.c:10:24:10:24 | *m | test.c:10:43:10:43 | *m | provenance |  |
+| test.c:10:24:10:24 | *m | test.c:10:43:10:43 | *m | provenance |  |
+| test.c:13:12:13:14 | mtx_init output argument | test.c:3:7:3:8 | *g1 | provenance |  |
 | test.c:13:12:13:14 | mtx_init output argument | test.c:14:17:14:19 | *& ... | provenance |  |
 | test.c:13:12:13:14 | mtx_init output argument | test.c:15:14:15:16 | *& ... | provenance |  |
 | test.c:15:14:15:16 | *& ... | test.c:10:24:10:24 | *m | provenance |  |
+| test.c:15:14:15:16 | *& ... | test.c:15:14:15:16 | doTimeLock output argument | provenance |  |
+| test.c:15:14:15:16 | doTimeLock output argument | test.c:3:7:3:8 | *g1 | provenance |  |
+| test.c:17:12:17:14 | mtx_init output argument | test.c:4:7:4:8 | *g2 | provenance |  |
 | test.c:17:12:17:14 | mtx_init output argument | test.c:18:17:18:19 | *& ... | provenance |  |
 | test.c:17:12:17:14 | mtx_init output argument | test.c:19:14:19:16 | *& ... | provenance |  |
 | test.c:19:14:19:16 | *& ... | test.c:10:24:10:24 | *m | provenance |  |
+| test.c:19:14:19:16 | *& ... | test.c:19:14:19:16 | doTimeLock output argument | provenance |  |
+| test.c:19:14:19:16 | doTimeLock output argument | test.c:4:7:4:8 | *g2 | provenance |  |
 | test.c:30:12:30:14 | mtx_init output argument | test.c:31:17:31:19 | *& ... | provenance |  |
 | test.c:30:12:30:14 | mtx_init output argument | test.c:32:14:32:16 | *& ... | provenance |  |
 | test.c:32:14:32:16 | *& ... | test.c:10:24:10:24 | *m | provenance |  |
@@ -16,14 +30,20 @@ edges
 | test.c:44:14:44:18 | *& ... | test.c:10:24:10:24 | *m | provenance |  |
 | test.c:44:15:44:16 | *l3 [m] | test.c:44:14:44:18 | *& ... | provenance |  |
 nodes
+| test.c:3:7:3:8 | *g1 | semmle.label | *g1 |
+| test.c:4:7:4:8 | *g2 | semmle.label | *g2 |
+| test.c:10:24:10:24 | *m | semmle.label | *m |
+| test.c:10:24:10:24 | *m | semmle.label | *m |
 | test.c:10:24:10:24 | *m | semmle.label | *m |
 | test.c:10:43:10:43 | *m | semmle.label | *m |
 | test.c:13:12:13:14 | mtx_init output argument | semmle.label | mtx_init output argument |
 | test.c:14:17:14:19 | *& ... | semmle.label | *& ... |
 | test.c:15:14:15:16 | *& ... | semmle.label | *& ... |
+| test.c:15:14:15:16 | doTimeLock output argument | semmle.label | doTimeLock output argument |
 | test.c:17:12:17:14 | mtx_init output argument | semmle.label | mtx_init output argument |
 | test.c:18:17:18:19 | *& ... | semmle.label | *& ... |
 | test.c:19:14:19:16 | *& ... | semmle.label | *& ... |
+| test.c:19:14:19:16 | doTimeLock output argument | semmle.label | doTimeLock output argument |
 | test.c:30:12:30:14 | mtx_init output argument | semmle.label | mtx_init output argument |
 | test.c:31:17:31:19 | *& ... | semmle.label | *& ... |
 | test.c:32:14:32:16 | *& ... | semmle.label | *& ... |
@@ -34,6 +54,8 @@ nodes
 | test.c:44:14:44:18 | *& ... | semmle.label | *& ... |
 | test.c:44:15:44:16 | *l3 [m] | semmle.label | *l3 [m] |
 subpaths
+| test.c:15:14:15:16 | *& ... | test.c:10:24:10:24 | *m | test.c:10:24:10:24 | *m | test.c:15:14:15:16 | doTimeLock output argument |
+| test.c:19:14:19:16 | *& ... | test.c:10:24:10:24 | *m | test.c:10:24:10:24 | *m | test.c:19:14:19:16 | doTimeLock output argument |
 #select
 | test.c:10:43:10:43 | *m | test.c:13:12:13:14 | mtx_init output argument | test.c:10:43:10:43 | *m | Call to mtx_timedlock with mutex which is $@ without flag 'mtx_timed'. | test.c:13:12:13:14 | mtx_init output argument | initialized |
 | test.c:10:43:10:43 | *m | test.c:17:12:17:14 | mtx_init output argument | test.c:10:43:10:43 | *m | Call to mtx_timedlock with mutex which is $@ without flag 'mtx_timed'. | test.c:17:12:17:14 | mtx_init output argument | initialized |


### PR DESCRIPTION
## Description

https://github.com/github/codeql/pull/20126 fixes a long standing missing flow issue for global variables (see that PR's description for details). It looks like the `c/cert/clean-up-thread-specific-storage` query was not written with this global variable flow in mind, and the improvements to global variable flow is causing false negatives on stuff like:
```cpp
static tss_t k;

void m1() {
  tss_create(&k, NULL); // non compliant
}

void m2() {
  thrd_t id;
  tss_create(&k, free);
  ...
  tss_delete(k);
}
```
Before https://github.com/github/codeql/pull/20126 we'd not flow from `tss_create`'s outgoing argument (`&k`) to the global variable declaration, and then to `&k` in `m2` (read the description in https://github.com/github/codeql/pull/20126 to see why!). However, after https://github.com/github/codeql/pull/20126 we now get this flow. This results in a false negative.

To fix this, I've blocked flow _into_ the sources. This means that, once again, the flow starting at `m1` doesn't go to any sink.

I'll keep this in draft until https://github.com/github/codeql/pull/20126 is ready to go in (which will likely be waiting until Jeroen is back).

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [ ] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)