### PR TITLE
C++: Fix queries after shared guards

### DIFF
--- a/c/cert/src/rules/EXP16-C/DoNotCompareFunctionPointersToConstantValues.ql
+++ b/c/cert/src/rules/EXP16-C/DoNotCompareFunctionPointersToConstantValues.ql
@@ -51,7 +51,7 @@ class ExplicitComparison extends EffectivelyComparison, FinalComparisonOperation
   override FunctionExpr getFunctionExpr() { result = funcExpr }
 }
 
-class ImplicitComparison extends EffectivelyComparison, GuardCondition {
+class ImplicitComparison extends EffectivelyComparison, GuardCondition instanceof Expr {
   ImplicitComparison() {
     this instanceof FunctionExpr and
     not getParent() instanceof ComparisonOperation

--- a/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
+++ b/cpp/cert/src/rules/CTR55-CPP/DoNotUseAnAdditiveOperatorOnAnIterator.ql
@@ -78,8 +78,8 @@ predicate isUpperBoundEndCheckedIteratorAccess(IteratorSource source, ContainerI
     basicBlockOfIteratorAccess.contains(it) and
     //guard is comprised of end check and an iterator access
     DataFlow::localFlow(DataFlow::exprNode(referenceToOnePassedTheEndElement),
-      DataFlow::exprNode(upperBoundCheck.getChild(_))) and
-    upperBoundCheck.getChild(_) = checkedIteratorAccess and
+      DataFlow::exprNode(upperBoundCheck.(Expr).getChild(_))) and
+    upperBoundCheck.(Expr).getChild(_) = checkedIteratorAccess and
     //make sure its the same iterator being checked in the guard as accessed
     checkedIteratorAccess.getOwningContainer() = it.getOwningContainer() and
     //if its the end call itself (or its parts), make sure its the same container providing its end as giving the iterator

--- a/cpp/cert/src/rules/MEM52-CPP/DetectAndHandleMemoryAllocationErrors.ql
+++ b/cpp/cert/src/rules/MEM52-CPP/DetectAndHandleMemoryAllocationErrors.ql
@@ -63,7 +63,7 @@ class NoThrowAllocExprWrapperFunction extends Function {
     n.getEnclosingFunction() = this and
     DataFlow::localExprFlow(n, any(ReturnStmt rs).getExpr()) and
     // Not checked in this wrapper function
-    not exists(GuardCondition gc | DataFlow::localExprFlow(n, gc.getAChild*()))
+    not exists(GuardCondition gc | DataFlow::localExprFlow(n, gc.(Expr).getAChild*()))
   }
 
   /** Gets the underlying nothrow allocation ultimately being wrapped. */

--- a/cpp/common/src/codingstandards/cpp/rules/functionerroneousreturnvaluenottested/FunctionErroneousReturnValueNotTested.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/functionerroneousreturnvaluenottested/FunctionErroneousReturnValueNotTested.qll
@@ -56,7 +56,7 @@ query predicate problems(FunctionCall fc, string message) {
           "vsnwprintf_s"
         ]) and
   not exists(GuardCondition gc |
-    DataFlow::localFlow(DataFlow::exprNode(fc), DataFlow::exprNode(gc.getAChild*()))
+    DataFlow::localFlow(DataFlow::exprNode(fc), DataFlow::exprNode(gc.(Expr).getAChild*()))
   ) and
   message = "Return value from " + fc.getTarget().getName() + " is not tested for errors."
 }


### PR DESCRIPTION
## Description

https://github.com/github/codeql/pull/20485 switches C/C++ away from its own guards library and over to the shared guards library (which is currently used by Java, and soon by C#). One of the changes is that a `GuardCondition` is now an `Element` instead of always being an `Expr`. So a couple of the coding standard queries needs an additional cast.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [ ] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)