### PR TITLE
C++: Fix queries I forgot after merging github/codeql#20485.

### DIFF
--- a/c/cert/src/rules/EXP16-C/DoNotCompareFunctionPointersToConstantValues.ql
+++ b/c/cert/src/rules/EXP16-C/DoNotCompareFunctionPointersToConstantValues.ql
@@ -53,8 +53,9 @@ class ExplicitComparison extends EffectivelyComparison, FinalComparisonOperation
 
 class ImplicitComparison extends EffectivelyComparison, GuardCondition instanceof Expr {
   ImplicitComparison() {
+    this.valueControlsEdge(_, _, _) and
     this instanceof FunctionExpr and
-    not getParent() instanceof ComparisonOperation
+    not super.getParent() instanceof ComparisonOperation
   }
 
   override string getExplanation() { result = "$@ undergoes implicit constant comparison." }

--- a/cpp/autosar/src/rules/A4-7-1/IntegerExpressionLeadToDataLoss.ql
+++ b/cpp/autosar/src/rules/A4-7-1/IntegerExpressionLeadToDataLoss.ql
@@ -23,7 +23,7 @@ from InterestingOverflowingOperation e
 where
   not isExcluded(e, IntegerConversionPackage::integerExpressionLeadToDataLossQuery()) and
   // Not within a guard condition
-  not exists(GuardCondition gc | gc.getAChild*() = e) and
+  not e.getParent*().(GuardCondition).valueControlsEdge(_, _, _) and
   // Not guarded by a check, where the check is not an invalid overflow check
   not e.hasValidPreCheck() and
   // Covered by `IntMultToLong.ql` instead

--- a/cpp/cert/test/rules/MEM52-CPP/DetectAndHandleMemoryAllocationErrors.expected
+++ b/cpp/cert/test/rules/MEM52-CPP/DetectAndHandleMemoryAllocationErrors.expected
@@ -1,9 +1,8 @@
 WARNING: module 'DataFlow' has been deprecated and may be removed in future (DetectAndHandleMemoryAllocationErrors.ql:64,5-13)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DetectAndHandleMemoryAllocationErrors.ql:66,36-44)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DetectAndHandleMemoryAllocationErrors.ql:82,46-54)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DetectAndHandleMemoryAllocationErrors.ql:83,22-30)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DetectAndHandleMemoryAllocationErrors.ql:87,20-28)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DetectAndHandleMemoryAllocationErrors.ql:90,35-43)
-WARNING: module 'DataFlow' has been deprecated and may be removed in future (DetectAndHandleMemoryAllocationErrors.ql:95,38-46)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (DetectAndHandleMemoryAllocationErrors.ql:86,46-54)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (DetectAndHandleMemoryAllocationErrors.ql:87,22-30)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (DetectAndHandleMemoryAllocationErrors.ql:91,20-28)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (DetectAndHandleMemoryAllocationErrors.ql:96,35-43)
+WARNING: module 'DataFlow' has been deprecated and may be removed in future (DetectAndHandleMemoryAllocationErrors.ql:101,38-46)
 | test.cpp:24:7:24:34 | new | nothrow new allocation of $@ returns here without a subsequent check to see whether the pointer is valid. | test.cpp:24:7:24:34 | new | StructA * |
 | test.cpp:40:17:40:38 | call to allocate_without_check | nothrow new allocation of $@ returns here without a subsequent check to see whether the pointer is valid. | test.cpp:35:17:35:44 | new | StructA * |

--- a/cpp/common/src/codingstandards/cpp/rules/functionerroneousreturnvaluenottested/FunctionErroneousReturnValueNotTested.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/functionerroneousreturnvaluenottested/FunctionErroneousReturnValueNotTested.qll
@@ -55,8 +55,6 @@ query predicate problems(FunctionCall fc, string message) {
           "vwprintf", "vfwprintf", "vswprintf", "vwprintf_s", "vfwprintf_s", "vswprintf_s",
           "vsnwprintf_s"
         ]) and
-  not exists(GuardCondition gc |
-    DataFlow::localFlow(DataFlow::exprNode(fc), DataFlow::exprNode(gc.(Expr).getAChild*()))
-  ) and
+  not fc.(GuardCondition).valueControlsEdge(_, _, _) and
   message = "Return value from " + fc.getTarget().getName() + " is not tested for errors."
 }

--- a/cpp/common/src/codingstandards/cpp/rules/unsignedoperationwithconstantoperandswraps/UnsignedOperationWithConstantOperandsWraps.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/unsignedoperationwithconstantoperandswraps/UnsignedOperationWithConstantOperandsWraps.qll
@@ -18,7 +18,7 @@ query predicate problems(InterestingOverflowingOperation op, string message) {
   not isExcluded(op, getQuery()) and
   op.getType().getUnderlyingType().(IntegralType).isUnsigned() and
   // Not within a guard condition
-  not exists(GuardCondition gc | gc.getAChild*() = op) and
+  not op.getParent*().(GuardCondition).valueControlsEdge(_, _, _) and
   // Not guarded by a check, where the check is not an invalid overflow check
   not op.hasValidPreCheck() and
   // Is not checked after the operation


### PR DESCRIPTION
## Description

The changes in https://github.com/github/codeql-coding-standards/pull/958 weren't enough to fixup the Coding Standards queries after we merged https://github.com/github/codeql/pull/20485. This PR fixes those missing queries.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [ ] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)