### PR TITLE
Fix #972, CON51-CPP falsely reporting that std::lock_guard requires catch

### DIFF
--- a/change_notes/2025-11-19-exclude-raii-style-locks-from-con51-cpp.md
+++ b/change_notes/2025-11-19-exclude-raii-style-locks-from-con51-cpp.md
@@ -1,0 +1,2 @@
+ - `CON51-CPP` - `EnsureActivelyHeldLocksAreReleasedOnExceptionalConditions.ql`:
+   - Exclude RAII-style locks from query results, as they cannot be leaked, and are recommended to avoid alerts in this rule.

--- a/cpp/cert/src/rules/CON51-CPP/EnsureActivelyHeldLocksAreReleasedOnExceptionalConditions.ql
+++ b/cpp/cert/src/rules/CON51-CPP/EnsureActivelyHeldLocksAreReleasedOnExceptionalConditions.ql
@@ -36,6 +36,8 @@ where
   // To reduce the number of results we require that this is a direct child
   // of the lock within the same function
   lpn.coveredByLock().getASuccessor*() = lpn and
+  // Exclude RAII-style locks which cannot leak
+  lpn.coveredByLock().canLeak() and
   // report those expressions for which there doesn't exist a catch block
   not exists(CatchBlock cb |
     catches(cb, lpn, _) and

--- a/cpp/cert/test/rules/CON51-CPP/test.cpp
+++ b/cpp/cert/test/rules/CON51-CPP/test.cpp
@@ -83,6 +83,11 @@ void f8(std::mutex *pm) {
   }
 }
 
+void f9(std::mutex *pm) {
+  std::lock_guard<std::mutex> lg(*pm);
+  mightThrow(); // COMPLIANT
+}
+
 void m() {
   std::mutex pm;
   std::thread t1 = std::thread(f1, &pm);
@@ -93,4 +98,5 @@ void m() {
   std::thread t6 = std::thread(f6, &pm);
   std::thread t7 = std::thread(f7, &pm);
   std::thread t8 = std::thread(f8, &pm);
+  std::thread t9 = std::thread(f9, &pm);
 }

--- a/cpp/common/src/codingstandards/cpp/concurrency/LockProtectedControlFlow.qll
+++ b/cpp/common/src/codingstandards/cpp/concurrency/LockProtectedControlFlow.qll
@@ -38,9 +38,10 @@ class LockProtectedControlFlowNode extends ThreadedCFN {
   }
 
   /**
-   * The `MutexFunctionCall` holding the lock that locks this node.
+   * The LockingOperation (for instance, a `MutexFunctionCall`, or RAII-style lock constructor)
+   * holding the lock that locks this node.
    */
-  FunctionCall coveredByLock() { result = lockingFunction }
+  LockingOperation coveredByLock() { result = lockingFunction }
 
   /**
    * The lock underlying this `LockProtectedControlFlowNode`.

--- a/cpp/common/src/codingstandards/cpp/concurrency/LockingOperation.qll
+++ b/cpp/common/src/codingstandards/cpp/concurrency/LockingOperation.qll
@@ -23,6 +23,11 @@ abstract class LockingOperation extends FunctionCall {
   abstract predicate isUnlock();
 
   /**
+   * Holds if this locking operation can leak the lock. For example, RAII-style locks cannot leak.
+   */
+  abstract predicate canLeak();
+
+  /**
    * Holds if this locking operation is really a locking operation within a
    * designated locking operation. This library assumes the underlying locking
    * operations are implemented correctly in that calling a `LockingOperation`
@@ -34,10 +39,26 @@ abstract class LockingOperation extends FunctionCall {
 }
 
 /**
+ * A locking operation that can leak the lock.
+ *
+ * RAII style locks cannot leak, but other kinds of locks can.
+ */
+abstract class LeakableLockingOperation extends LockingOperation {
+  override predicate canLeak() { any() }
+}
+
+/**
+ * A locking operation that cannot leak the lock, such as RAII-style locks.
+ */
+abstract class NonLeakableLockingOperation extends LockingOperation {
+  override predicate canLeak() { none() }
+}
+
+/**
  * Common base class providing an interface into function call
  * based mutex locks.
  */
-abstract class MutexFunctionCall extends LockingOperation {
+abstract class MutexFunctionCall extends LeakableLockingOperation {
   abstract predicate isRecursive();
 
   abstract predicate isSpeculativeLock();
@@ -180,7 +201,7 @@ class CMutexFunctionCall extends MutexFunctionCall {
 /**
  * Models a RAII-Style lock.
  */
-class RAIIStyleLock extends LockingOperation {
+class RAIIStyleLock extends NonLeakableLockingOperation {
   VariableAccess lock;
 
   RAIIStyleLock() {


### PR DESCRIPTION
## Description

Mark certain lock operations as leakable or not, and exclude unleakable ones (RAII-style locks) from generating an alert in CON51-CPP.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `CON51-CPP`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)