### PR TITLE
Update test expectations after switch to SoftFloat library in the extractor

### DIFF
--- a/cpp/autosar/test/rules/A13-6-1/UseCorrectIntervalForDigitSequencesSeparators.expected
+++ b/cpp/autosar/test/rules/A13-6-1/UseCorrectIntervalForDigitSequencesSeparators.expected
@@ -7,8 +7,8 @@
 | test.cpp:19:3:19:17 | 1370 | The digit sequence 01010101'1010 uses a digit sequence separator at a spacing other than 4. |
 | test.cpp:20:3:20:15 | 85 | The digit sequence 01'01'01'01 uses a digit sequence separator at a spacing other than 4. |
 | test.cpp:21:3:21:14 | 85 | The digit sequence 010'1010'1 uses a digit sequence separator at a spacing other than 4. |
-| test.cpp:26:3:26:15 | 11000000000.0 | The digit sequence 1000'000 uses a digit sequence separator at a spacing other than 3. |
-| test.cpp:27:3:27:16 | 11000000000.0 | The digit sequence 10'00'000 uses a digit sequence separator at a spacing other than 3. |
-| test.cpp:28:3:28:17 | 11000000000.0 | The digit sequence 1'0 uses a digit sequence separator at a spacing other than 3. |
-| test.cpp:29:3:29:16 | 11000000000.0 | The digit sequence 10'000'00 uses a digit sequence separator at a spacing other than 3. |
-| test.cpp:30:3:30:15 | 11000000000.0 | The digit sequence 1'0 uses a digit sequence separator at a spacing other than 3. |
+| test.cpp:26:3:26:15 | 1.1E10 | The digit sequence 1000'000 uses a digit sequence separator at a spacing other than 3. |
+| test.cpp:27:3:27:16 | 1.1E10 | The digit sequence 10'00'000 uses a digit sequence separator at a spacing other than 3. |
+| test.cpp:28:3:28:17 | 1.1E10 | The digit sequence 1'0 uses a digit sequence separator at a spacing other than 3. |
+| test.cpp:29:3:29:16 | 1.1E10 | The digit sequence 10'000'00 uses a digit sequence separator at a spacing other than 3. |
+| test.cpp:30:3:30:15 | 1.1E10 | The digit sequence 1'0 uses a digit sequence separator at a spacing other than 3. |

--- a/cpp/autosar/test/rules/M2-13-4/LiteralSuffixNotUpperCase.expected
+++ b/cpp/autosar/test/rules/M2-13-4/LiteralSuffixNotUpperCase.expected
@@ -8,5 +8,5 @@
 | test.cpp:16:3:16:14 | 1254450 | Numeric literal 0x13'24'32Ul has the lower case suffix l. |
 | test.cpp:17:3:17:13 | 1254450 | Numeric literal 0x13'24'32u has the lower case suffix u. |
 | test.cpp:18:3:18:13 | 1254450 | Numeric literal 0x13'24'32l has the lower case suffix l. |
-| test.cpp:22:3:22:15 | 1.123122995e+10 | Numeric literal 1.123'123e10f has the lower case suffix f. |
-| test.cpp:23:3:23:15 | 11231230000.0 | Numeric literal 1.123'123e10l has the lower case suffix l. |
+| test.cpp:22:3:22:15 | 1.123123E10 | Numeric literal 1.123'123e10f has the lower case suffix f. |
+| test.cpp:23:3:23:15 | 1.123123E10 | Numeric literal 1.123'123e10l has the lower case suffix l. |

--- a/cpp/autosar/test/rules/M5-0-6/ImplicitConstConversionToSmallerUnderlyingType.expected
+++ b/cpp/autosar/test/rules/M5-0-6/ImplicitConstConversionToSmallerUnderlyingType.expected
@@ -1,2 +1,2 @@
 | test.cpp:11:8:11:10 | (int8_t)... | Implicit conversion of integral $@ reduces the size from 4 bytes to 1 bytes. | test.cpp:11:8:11:10 | 256 | 256 |
-| test.cpp:24:9:24:14 | (float)... | Implicit conversion of floating point $@ reduces the size from 8 bytes to 4 bytes. | test.cpp:24:9:24:14 | 3.500000000000000016e+38 | 3.5e38 |
+| test.cpp:24:9:24:14 | (float)... | Implicit conversion of floating point $@ reduces the size from 8 bytes to 4 bytes. | test.cpp:24:9:24:14 | 3.5E38 | 3.5e38 |


### PR DESCRIPTION


## Description

_please enter the description of your change here_

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [ ] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)