### PR TITLE
Fix shared query problems predicate format

### DIFF
--- a/cpp/common/src/codingstandards/cpp/rules/bitfieldsshouldnotbedeclared/BitFieldsShouldNotBeDeclared.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/bitfieldsshouldnotbedeclared/BitFieldsShouldNotBeDeclared.qll
@@ -17,17 +17,17 @@ signature module BitFieldsShouldNotBeDeclaredConfigSig {
 }
 
 module BitFieldsShouldNotBeDeclared<BitFieldsShouldNotBeDeclaredConfigSig Config> {
-  query predicate problems(BitField bf, string message, Class linkLocation, string linkDescription) {
+  query predicate problems(BitField bf, string message, Class c, string className) {
     /*
      * The condition that is allowed that is IF this is a bit-field, then it should be part of a class
      * that is flagged as a hardware or protocol class. To detect this we look for violations of that form.
      */
 
     not isExcluded(bf, Config::getQuery()) and
-    not isExcluded(linkLocation, Config::getQuery()) and
-    bf = linkLocation.getAField() and
-    linkDescription = linkLocation.getName() and
-    not linkLocation instanceof HardwareOrProtocolInterfaceClass and
+    not isExcluded(c, Config::getQuery()) and
+    bf = c.getAField() and
+    className = c.getName() and
+    not c instanceof HardwareOrProtocolInterfaceClass and
     message = "Bit-field used within a class $@ that is not a hardware or protocol class."
   }
 }

--- a/cpp/common/src/codingstandards/cpp/rules/bitfieldsshouldnotbedeclared/BitFieldsShouldNotBeDeclared.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/bitfieldsshouldnotbedeclared/BitFieldsShouldNotBeDeclared.qll
@@ -17,20 +17,17 @@ signature module BitFieldsShouldNotBeDeclaredConfigSig {
 }
 
 module BitFieldsShouldNotBeDeclared<BitFieldsShouldNotBeDeclaredConfigSig Config> {
-  query predicate problems(
-    BitField bf, Class c, string message, Class linkLocation, string linkDescription
-  ) {
+  query predicate problems(BitField bf, string message, Class linkLocation, string linkDescription) {
     /*
      * The condition that is allowed that is IF this is a bit-field, then it should be part of a class
      * that is flagged as a hardware or protocol class. To detect this we look for violations of that form.
      */
 
     not isExcluded(bf, Config::getQuery()) and
-    not isExcluded(c, Config::getQuery()) and
-    bf = c.getAField() and
-    linkLocation = c and
-    linkDescription = c.getName() and
-    not c instanceof HardwareOrProtocolInterfaceClass and
+    not isExcluded(linkLocation, Config::getQuery()) and
+    bf = linkLocation.getAField() and
+    linkDescription = linkLocation.getName() and
+    not linkLocation instanceof HardwareOrProtocolInterfaceClass and
     message = "Bit-field used within a class $@ that is not a hardware or protocol class."
   }
 }

--- a/cpp/common/test/rules/bitfieldsshouldnotbedeclared/BitFieldsShouldNotBeDeclared.expected
+++ b/cpp/common/test/rules/bitfieldsshouldnotbedeclared/BitFieldsShouldNotBeDeclared.expected
@@ -1,1 +1,1 @@
-| test.cpp:57:8:57:8 | c | test.cpp:53:7:53:8 | B2 | Bit-field used within a class $@ that is not a hardware or protocol class. | test.cpp:53:7:53:8 | B2 | B2 |
+| test.cpp:57:8:57:8 | c | Bit-field used within a class $@ that is not a hardware or protocol class. | test.cpp:53:7:53:8 | B2 | B2 |


### PR DESCRIPTION
## Description

Fix shared query problems predicate format for query BitFieldsShouldNotBeDeclared

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - A9-6-2
     - RULE-12-2-1

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [x] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)