### PR TITLE
Add additional tags to query metadata

### DIFF
--- a/cpp/misra/src/rules/RULE-7-0-1/NoConversionFromBool.ql
+++ b/cpp/misra/src/rules/RULE-7-0-1/NoConversionFromBool.ql
@@ -9,6 +9,9 @@
  * @problem.severity error
  * @tags external/misra/id/rule-7-0-1
  *       scope/single-translation-unit
+ *       maintainability
+ *       readability
+ *       correctness
  *       external/misra/enforcement/decidable
  *       external/misra/obligation/required
  */

--- a/cpp/misra/src/rules/RULE-7-0-2/NoImplicitBoolConversion.ql
+++ b/cpp/misra/src/rules/RULE-7-0-2/NoImplicitBoolConversion.ql
@@ -9,6 +9,9 @@
  * @problem.severity error
  * @tags external/misra/id/rule-7-0-2
  *       scope/single-translation-unit
+ *       maintainability
+ *       readability
+ *       correctness
  *       external/misra/enforcement/decidable
  *       external/misra/obligation/required
  */

--- a/cpp/misra/src/rules/RULE-7-0-3/NoCharacterNumericalValue.ql
+++ b/cpp/misra/src/rules/RULE-7-0-3/NoCharacterNumericalValue.ql
@@ -9,6 +9,8 @@
  * @problem.severity error
  * @tags external/misra/id/rule-7-0-3
  *       scope/single-translation-unit
+ *       maintainability
+ *       readability
  *       external/misra/enforcement/decidable
  *       external/misra/obligation/required
  */

--- a/cpp/misra/src/rules/RULE-7-0-4/InappropriateBitwiseOrShiftOperands.ql
+++ b/cpp/misra/src/rules/RULE-7-0-4/InappropriateBitwiseOrShiftOperands.ql
@@ -8,6 +8,7 @@
  * @problem.severity error
  * @tags external/misra/id/rule-7-0-4
  *       scope/single-translation-unit
+ *       correctness
  *       external/misra/enforcement/decidable
  *       external/misra/obligation/required
  */

--- a/cpp/misra/src/rules/RULE-7-0-5/NoSignednessChangeFromPromotion.ql
+++ b/cpp/misra/src/rules/RULE-7-0-5/NoSignednessChangeFromPromotion.ql
@@ -9,6 +9,8 @@
  * @problem.severity error
  * @tags external/misra/id/rule-7-0-5
  *       scope/single-translation-unit
+ *       correctness
+ *       maintainability
  *       external/misra/enforcement/decidable
  *       external/misra/obligation/required
  */

--- a/cpp/misra/src/rules/RULE-7-0-6/NumericAssignmentTypeMismatch.ql
+++ b/cpp/misra/src/rules/RULE-7-0-6/NumericAssignmentTypeMismatch.ql
@@ -9,6 +9,8 @@
  * @problem.severity error
  * @tags external/misra/id/rule-7-0-6
  *       scope/single-translation-unit
+ *       correctness
+ *       maintainability
  *       external/misra/enforcement/decidable
  *       external/misra/obligation/required
  */

--- a/cpp/misra/src/rules/RULE-7-11-3/FunctionPointerConversionContext.ql
+++ b/cpp/misra/src/rules/RULE-7-11-3/FunctionPointerConversionContext.ql
@@ -9,6 +9,8 @@
  * @problem.severity error
  * @tags external/misra/id/rule-7-11-3
  *       scope/single-translation-unit
+ *       correctness
+ *       readability
  *       external/misra/enforcement/decidable
  *       external/misra/obligation/required
  */

--- a/rule_packages/cpp/Conversions.json
+++ b/rule_packages/cpp/Conversions.json
@@ -14,7 +14,10 @@
           "severity": "error",
           "short_name": "NoConversionFromBool",
           "tags": [
-            "scope/single-translation-unit"
+            "scope/single-translation-unit",
+            "maintainability",
+            "readability",
+            "correctness"
           ]
         }
       ],
@@ -34,7 +37,10 @@
           "severity": "error",
           "short_name": "NoImplicitBoolConversion",
           "tags": [
-            "scope/single-translation-unit"
+            "scope/single-translation-unit",
+            "maintainability",
+            "readability",
+            "correctness"
           ]
         }
       ],
@@ -54,7 +60,9 @@
           "severity": "error",
           "short_name": "NoCharacterNumericalValue",
           "tags": [
-            "scope/single-translation-unit"
+            "scope/single-translation-unit",
+            "maintainability",
+            "readability"
           ]
         }
       ],
@@ -74,7 +82,8 @@
           "severity": "error",
           "short_name": "InappropriateBitwiseOrShiftOperands",
           "tags": [
-            "scope/single-translation-unit"
+            "scope/single-translation-unit",
+            "correctness"
           ]
         }
       ],
@@ -94,7 +103,9 @@
           "severity": "error",
           "short_name": "NoSignednessChangeFromPromotion",
           "tags": [
-            "scope/single-translation-unit"
+            "scope/single-translation-unit",
+            "correctness",
+            "maintainability"
           ],
           "implementation_scope": {
             "description": "Arithmetic conversions in preprocessor directives are not supported."
@@ -117,7 +128,9 @@
           "severity": "error",
           "short_name": "NumericAssignmentTypeMismatch",
           "tags": [
-            "scope/single-translation-unit"
+            "scope/single-translation-unit",
+            "correctness",
+            "maintainability"
           ]
         }
       ],
@@ -137,7 +150,9 @@
           "severity": "error",
           "short_name": "FunctionPointerConversionContext",
           "tags": [
-            "scope/single-translation-unit"
+            "scope/single-translation-unit",
+            "correctness",
+            "readability"
           ]
         }
       ],


### PR DESCRIPTION
## Description

The `Conversions` rule package was missing some tags in every query it had. Add reasonable tags to each:

- 7.0.1:
  - maintainability: Tracking which expressions are actually `bool` would be challenging.
  - readability: It would be puzzling to see a `bool` in a numeric context.
  - correctness: The `bool` type expression might be accidentally included in a non-`bool` context, which would still pass the type checker.
- 7.0.2:
  - maintainability, readability, correctness: similar reason as for 7-0-1.
- 7.0.3:
  - maintainability: Similar to reasons above.
  - readability: It would be puzzling to see a character literal in a numeric context, though it sometimes be needed (e.g. ASCII value).
- 7.0.4:
  - correctness: May flip the signedness.
- 7.0.5:
  - correctness: For similar reason as 7.0.4.
  - maintainability: It may be challenging to keep track of the signedness of both left-hand and right-hand-side operands.
- 7.0.6:
  - correctness, maintainability: For similar reasons as 7.0.5.
- 7.11.3:
  - correctness: As stated in the standard, it may signal programmer's mistake where the argument list is inadvertently omitted.
  - readability: It may be puzzling to see a function pointer in a boolean / numeric context, and the intent is ambiguous as stated in the standard.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [X] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [X] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [ ] Queries have been modified for the following rules:
     - _rule number here_

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [X] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [X] Have all the relevant rule package description files been checked in?
 - [X] Have you verified that the metadata properties of each new query is set appropriately?
 - [X] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)