### PR TITLE
Fix FP for MISRA-C RULE-13-4

### DIFF
--- a/c/common/test/rules/resultofanassignmentoperatorshouldnotbeused/ResultOfAnAssignmentOperatorShouldNotBeUsed.expected
+++ b/c/common/test/rules/resultofanassignmentoperatorshouldnotbeused/ResultOfAnAssignmentOperatorShouldNotBeUsed.expected
@@ -1,3 +1,4 @@
 | test.c:9:7:9:12 | ... = ... | Use of an assignment operator's result. |
 | test.c:13:11:13:16 | ... = ... | Use of an assignment operator's result. |
 | test.c:15:8:15:13 | ... = ... | Use of an assignment operator's result. |
+| test.c:17:6:17:13 | ... += ... | Use of an assignment operator's result. |

--- a/c/common/test/rules/resultofanassignmentoperatorshouldnotbeused/test.c
+++ b/c/common/test/rules/resultofanassignmentoperatorshouldnotbeused/test.c
@@ -13,4 +13,15 @@ void test() {
   l1 = l3[l2 = 0]; // NON_COMPLIANT
 
   l1 = l2 = 0; // NON_COMPLIANT
+
+  l3[l1 += l2] = l3[l1]; // NON_COMPLIANT
+
+  for (l1 = 0; l1 < 10; l1 += l2) // COMPLIANT
+  {
+  }
+
+  while (l1 < 10) // COMPLIANT
+  {
+    l1 += l2; // COMPLIANT
+  }
 }

--- a/change_notes/2026-05-18-fix-fp-misra-c-13-4.md
+++ b/change_notes/2026-05-18-fix-fp-misra-c-13-4.md
@@ -1,4 +1,4 @@
 - `RULE-13-4` - `ResultOfAnAssignmentOperatorShouldNotBeUsed`:
-  - Fixed false positives.
+  - Fixed false positives and false negatives by reporting compound assignments (for example, `+=`).
 - `RULE-8-18-2` - `ResultOfAnAssignmentOperatorShouldNotBeUsed`:
-  - Fixed false positives.
+  - Fixed false positives and false negatives by reporting compound assignments (for example, `+=`).

--- a/change_notes/2026-05-18-fix-fp-misra-c-13-4.md
+++ b/change_notes/2026-05-18-fix-fp-misra-c-13-4.md
@@ -1,4 +1,5 @@
 - `RULE-13-4` - `ResultOfAnAssignmentOperatorShouldNotBeUsed`:
-  - Fixed false positives and false negatives.
+  - Fixed false positives for `=` assignments in for loop update expression.
+  - Fixed false negatives for when the result of compound assignment operators (`+=`, etc) are used.
 - `RULE-8-18-2` - `ResultOfAnAssignmentOperatorShouldNotBeUsed`:
   - Fixed false positives and false negatives.

--- a/change_notes/2026-05-18-fix-fp-misra-c-13-4.md
+++ b/change_notes/2026-05-18-fix-fp-misra-c-13-4.md
@@ -1,0 +1,4 @@
+- `RULE-13-4` - `ResultOfAnAssignmentOperatorShouldNotBeUsed`:
+  - Fixed false positives.
+- `RULE-8-18-2` - `ResultOfAnAssignmentOperatorShouldNotBeUsed`:
+  - Fixed false positives.

--- a/change_notes/2026-05-18-fix-fp-misra-c-13-4.md
+++ b/change_notes/2026-05-18-fix-fp-misra-c-13-4.md
@@ -1,4 +1,4 @@
 - `RULE-13-4` - `ResultOfAnAssignmentOperatorShouldNotBeUsed`:
-  - Fixed false positives and false negatives by reporting compound assignments (for example, `+=`).
+  - Fixed false positives and false negatives.
 - `RULE-8-18-2` - `ResultOfAnAssignmentOperatorShouldNotBeUsed`:
-  - Fixed false positives and false negatives by reporting compound assignments (for example, `+=`).
+  - Fixed false positives and false negatives.

--- a/change_notes/2026-05-18-fix-fp-misra-c-13-4.md
+++ b/change_notes/2026-05-18-fix-fp-misra-c-13-4.md
@@ -1,4 +1,4 @@
-- `RULE-13-4` - `ResultOfAnAssignmentOperatorShouldNotBeUsed`:
+- `RULE-13-4`, `RULE-8-18-2` - `ResultOfAnAssignmentOperatorShouldNotBeUsed.ql`:
   - Fixed false positives for `=` assignments in for loop update expression.
   - Fixed false negatives for when the result of compound assignment operators (`+=`, etc) are used.
 - `RULE-8-18-2` - `ResultOfAnAssignmentOperatorShouldNotBeUsed`:

--- a/cpp/common/src/codingstandards/cpp/rules/resultofanassignmentoperatorshouldnotbeused/ResultOfAnAssignmentOperatorShouldNotBeUsed.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/resultofanassignmentoperatorshouldnotbeused/ResultOfAnAssignmentOperatorShouldNotBeUsed.qll
@@ -11,8 +11,9 @@ abstract class ResultOfAnAssignmentOperatorShouldNotBeUsedSharedQuery extends Qu
 
 Query getQuery() { result instanceof ResultOfAnAssignmentOperatorShouldNotBeUsedSharedQuery }
 
-query predicate problems(AssignExpr e, string message) {
+query predicate problems(Assignment e, string message) {
   not isExcluded(e, getQuery()) and
   not exists(ExprStmt s | s.getExpr() = e) and
+  not exists(ForStmt for | for.getUpdate() = e) and
   message = "Use of an assignment operator's result."
 }

--- a/cpp/common/test/rules/resultofanassignmentoperatorshouldnotbeused/ResultOfAnAssignmentOperatorShouldNotBeUsed.expected
+++ b/cpp/common/test/rules/resultofanassignmentoperatorshouldnotbeused/ResultOfAnAssignmentOperatorShouldNotBeUsed.expected
@@ -1,3 +1,4 @@
 | test.cpp:9:7:9:12 | ... = ... | Use of an assignment operator's result. |
 | test.cpp:13:11:13:16 | ... = ... | Use of an assignment operator's result. |
 | test.cpp:15:8:15:13 | ... = ... | Use of an assignment operator's result. |
+| test.cpp:17:6:17:13 | ... += ... | Use of an assignment operator's result. |

--- a/cpp/common/test/rules/resultofanassignmentoperatorshouldnotbeused/test.cpp
+++ b/cpp/common/test/rules/resultofanassignmentoperatorshouldnotbeused/test.cpp
@@ -13,4 +13,15 @@ void test() {
   l1 = l3[l2 = 0]; // NON_COMPLIANT
 
   l1 = l2 = 0; // NON_COMPLIANT
+
+  l3[l1 += l2] = l3[l1]; // NON_COMPLIANT
+
+  for (l1 = 0; l1 < 10; l1 += l2) // COMPLIANT
+  {
+  }
+
+  while (l1 < 10) // COMPLIANT
+  {
+    l1 += l2; // COMPLIANT
+  }
 }


### PR DESCRIPTION
This pull request addresses false positives in the `ResultOfAnAssignmentOperatorShouldNotBeUsed` rule by refining how assignment expressions are detected and reported.
Includes all types of Assignment (e.g. artihmetic assignments) and excludes the update section of for loops.
Improve tests to ensure that only genuine violations are flagged.

Motivated by this FP example:
https://github.com/mbaluda-org/judo-misra-c-autofix/security/code-scanning/690

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - RULE-8-18-2
     - RULE-13-4

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)