### PR TITLE
RULE-8-2-10: Avoid callers of recursive functions being flagged

### DIFF
--- a/c/misra/test/rules/RULE-17-2/test.c
+++ b/c/misra/test/rules/RULE-17-2/test.c
@@ -8,7 +8,7 @@ void f3() {
   f3(); // NON_COMPLIANT
 }
 void f6() {
-  f3(); // NON_COMPLIANT
+  f3(); // COMPLIANT - merely calls a recursive function
 }
 
 void f5() {

--- a/change_notes/2026-06-18-fix-fp-recursive-functions.md
+++ b/change_notes/2026-06-18-fix-fp-recursive-functions.md
@@ -1,0 +1,2 @@
+`A7-5-2`, `RULE-8-2-10`: `FunctionsCallThemselvesEitherDirectlyOrIndirectly.ql`:
+    - Fix false positives where callers of recursive functions were incorrectly reported as recursive. Only calls that participate in a recursive cycle are now reported.

--- a/cpp/common/src/codingstandards/cpp/rules/functionscallthemselveseitherdirectlyorindirectly/FunctionsCallThemselvesEitherDirectlyOrIndirectly.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/functionscallthemselveseitherdirectlyorindirectly/FunctionsCallThemselvesEitherDirectlyOrIndirectly.qll
@@ -23,7 +23,7 @@ class RecursiveFunction extends Function {
   RecursiveFunction() { exists(RecursiveCall fc | fc.getEnclosingFunction() = this) }
 }
 
-query predicate problems(FunctionCall fc, string message, RecursiveFunction f, string functionName) {
+query predicate problems(RecursiveCall fc, string message, Function f, string functionName) {
   not isExcluded(fc, getQuery()) and
   f = fc.getTarget() and
   functionName = f.getName() and

--- a/cpp/common/test/rules/functionscallthemselveseitherdirectlyorindirectly/FunctionsCallThemselvesEitherDirectlyOrIndirectly.expected
+++ b/cpp/common/test/rules/functionscallthemselveseitherdirectlyorindirectly/FunctionsCallThemselvesEitherDirectlyOrIndirectly.expected
@@ -1,5 +1,4 @@
 | test.cpp:7:13:7:35 | call to test_recursive_function | This call directly invokes its containing function $@. | test.cpp:5:5:5:27 | test_recursive_function | test_recursive_function |
-| test.cpp:21:9:21:31 | call to test_recursive_function | The function test_indirect_recursive_function is indirectly recursive via this call to $@. | test.cpp:5:5:5:27 | test_recursive_function | test_recursive_function |
-| test.cpp:27:5:27:30 | call to test_indirect_recursive_f2 | The function test_indirect_recursive_f1 is indirectly recursive via this call to $@. | test.cpp:36:5:36:30 | test_indirect_recursive_f2 | test_indirect_recursive_f2 |
-| test.cpp:38:9:38:34 | call to test_indirect_recursive_f1 | The function test_indirect_recursive_f2 is indirectly recursive via this call to $@. | test.cpp:25:5:25:30 | test_indirect_recursive_f1 | test_indirect_recursive_f1 |
-| test.cpp:75:10:75:19 | call to operator== | This call directly invokes its containing function $@. | test.cpp:74:6:74:15 | operator== | operator== |
+| test.cpp:33:5:33:30 | call to test_indirect_recursive_f2 | The function test_indirect_recursive_f1 is indirectly recursive via this call to $@. | test.cpp:42:5:42:30 | test_indirect_recursive_f2 | test_indirect_recursive_f2 |
+| test.cpp:44:9:44:34 | call to test_indirect_recursive_f1 | The function test_indirect_recursive_f2 is indirectly recursive via this call to $@. | test.cpp:31:5:31:30 | test_indirect_recursive_f1 | test_indirect_recursive_f1 |
+| test.cpp:81:10:81:19 | call to operator== | This call directly invokes its containing function $@. | test.cpp:80:6:80:15 | operator== | operator== |

--- a/cpp/common/test/rules/functionscallthemselveseitherdirectlyorindirectly/test.cpp
+++ b/cpp/common/test/rules/functionscallthemselveseitherdirectlyorindirectly/test.cpp
@@ -18,8 +18,14 @@ int test_nonrecursive_function(int i) { // COMPLIANT
 
 int test_indirect_recursive_function(int i) {
   if (i > 10) {
-    i = test_recursive_function(i * i); // NON_COMPLIANT
+    i = test_recursive_function(
+        i * i); // COMPLIANT - merely calls a recursive function
   }
+}
+
+int test_calls_recursive_function(int i) {
+  return test_recursive_function(
+      i); // COMPLIANT - not part of a recursive cycle
 }
 
 int test_indirect_recursive_f1(int i) {


### PR DESCRIPTION
## Description

The rule forbids only recursive functions. It can be fair to have a recursive function and justify this within one. With the behavior before this change, also every caller would need to be argued.

This is additonal burden that is not required and intended by the MISRA standard.

Fixes #935

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [X] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [X] Queries have been modified for the following rules:
     - RULE-8-2-10

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [X] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)