### PR TITLE
Fix false positives in RULE-6-9-2/A3-9-1 for auto-deduced types

### DIFF
--- a/change_notes/2026-06-19-fix-fp-rule-6-9-2-auto-deduced.md
+++ b/change_notes/2026-06-19-fix-fp-rule-6-9-2-auto-deduced.md
@@ -1,0 +1,2 @@
+- `RULE-6-9-2`, `A3-9-1` - `VariableWidthIntegerTypesUsed.qll`:
+  - Fixed false positives for variables declared with `auto` or `decltype(auto)` where the deduced type resolves through fixed-width typedefs (e.g., `std::uint32_t`) to a built-in integer type. The programmer never wrote a variable-width type name in these cases.

--- a/cpp/common/src/codingstandards/cpp/rules/variablewidthintegertypesused/VariableWidthIntegerTypesUsed.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/variablewidthintegertypesused/VariableWidthIntegerTypesUsed.qll
@@ -33,6 +33,10 @@ query predicate problems(Element e, string message) {
       // Fixed Width Types are recorded after stripping their typedef'd type,
       // thereby, causing false positives (#540).
       not v.isFromTemplateInstantiation(_) and
+      // Dont consider variables declared with `auto` or `decltype(auto)` because
+      // the deduced type may resolve through fixed-width typedefs (e.g. uint32_t)
+      // to a built-in type, even though the programmer never wrote that type name.
+      not v.declaredUsingAutoType() and
       //post-increment/post-decrement operators are required by the standard to have a dummy int parameter
       not v.(Parameter).getFunction() instanceof PostIncrementOperator and
       not v.(Parameter).getFunction() instanceof PostDecrementOperator and

--- a/cpp/common/test/rules/variablewidthintegertypesused/VariableWidthIntegerTypesUsed.expected
+++ b/cpp/common/test/rules/variablewidthintegertypesused/VariableWidthIntegerTypesUsed.expected
@@ -50,3 +50,5 @@
 | test.cpp:123:6:123:21 | test_long_return | Function 'test_long_return' has variable-width return type. |
 | test.cpp:126:15:126:39 | test_unsigned_long_return | Function 'test_unsigned_long_return' has variable-width return type. |
 | test.cpp:129:13:129:35 | test_signed_long_return | Function 'test_signed_long_return' has variable-width return type. |
+| test.cpp:160:5:160:11 | get_int | Function 'get_int' has variable-width return type. |
+| test.cpp:166:7:166:18 | explicit_int | Variable 'explicit_int' has variable-width type. |

--- a/cpp/common/test/rules/variablewidthintegertypesused/test.cpp
+++ b/cpp/common/test/rules/variablewidthintegertypesused/test.cpp
@@ -153,3 +153,15 @@ std::uint32_t test_uint32_t_return() { // COMPLIANT
 std::uint64_t test_uint64_t_return() { // COMPLIANT
   return 60;
 }
+
+// Regression test: auto-deduced types should not be flagged even when
+// the deduced type resolves through fixed-width typedefs to a built-in type.
+std::uint32_t get_uint32() { return 0; }
+int get_int() { return 0; }
+
+void test_auto_deduced_types() {
+  auto a1 = get_uint32(); // COMPLIANT - auto deduces through uint32_t
+  auto a2 = get_int();    // COMPLIANT - auto, programmer didn't write 'int'
+  const auto a3 = 42U;    // COMPLIANT - auto
+  int explicit_int = 0;   // NON_COMPLIANT - explicit variable-width type
+}


### PR DESCRIPTION
## Description

Variables declared with 'auto' or 'decltype(auto)' should not be flagged when the deduced type resolves through fixed-width typedefs (e.g. uint32_t) to a built-in integer type. The programmer never explicitly wrote a variable-width type name in these cases.

This is analogous to the existing template instantiation exclusion (#540).

Fixes: #1145
## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - RULE-6-9-2
     - A3-9-1

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [X] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)