### PR TITLE
Fix analysis_report crash on MISRA C++ results

### DIFF
--- a/scripts/reports/utils.py
+++ b/scripts/reports/utils.py
@@ -183,7 +183,10 @@ def generate_guideline_compliance_summary(output_directory, results_summary):
                 print(
                     "**Result**: " + ("Not compliant" if total_guidelines_violated > 0 else "Compliant"))
                 standard_pretty_name = {
-                    "cert": "CERT C++ 2016", "autosar": "AUTOSAR C++  R22-11, R21-11, R20-11, R19-11 and R19-03"}
+                    "cert": "CERT C++ 2016",
+                    "autosar": "AUTOSAR C++  R22-11, R21-11, R20-11, R19-11 and R19-03",
+                    "misra": "MISRA C++:2023",
+                }
                 print("**Coding Standards applied**: " + ", ".join([standard_pretty_name[standard_short_name]
                       for standard_short_name in results_summary.guideline_violation_count.keys()]))
 


### PR DESCRIPTION
## Description

generate_guideline_compliance_summary() renders the Guideline Compliance Summary report by mapping each applied standard's short name to a display name via the standard_pretty_name dict. That dict only contained entries for "cert" and "autosar", so analyzing a database against the MISRA C++ pack (codeql/misra-cpp-coding-standards) aborted the report generation with:

    KeyError: 'misra'

at the "**Coding Standards applied**" line (and the same lookup is used again when tabulating per-guideline results). Add the missing "misra" -> "MISRA C++ 2023" mapping so MISRA C++ analyses can produce the compliance summary report like the other supported standards.

Fixes https://github.com/github/codeql-coding-standards/issues/667

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [ ] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [x] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
 - [ ] Queries have been modified for the following rules:

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [ ] Yes
  - [X] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)