### PR TITLE
Fix #1172, structured bindings reported by RULE-10-0-1

### DIFF
--- a/change_notes/2026-08-19-allow-structured-bindings.md
+++ b/change_notes/2026-08-19-allow-structured-bindings.md
@@ -1,0 +1,2 @@
+- `RULE-10-0-1`, `M8-0-1` - `MultipleLocalDeclarators.qll`:
+  - Added a check to ignore structured bindings from C++17, which are explicitly allowed by RULE 10-0-1 and serve a unique useful purpose.

--- a/cpp/common/src/codingstandards/cpp/rules/multiplelocaldeclarators/MultipleLocalDeclarators.qll
+++ b/cpp/common/src/codingstandards/cpp/rules/multiplelocaldeclarators/MultipleLocalDeclarators.qll
@@ -16,5 +16,7 @@ query predicate problems(DeclStmt ds, string message) {
   count(Declaration d | d = ds.getADeclaration()) > 1 and
   // Not a compiler generated `DeclStmt`, such as in the range-based for loop
   not ds.isCompilerGenerated() and
+  // Not a structured binding
+  not ds.getADeclaration().(Variable).isStructuredBinding() and
   message = "Declaration list contains more than one declaration."
 }

--- a/cpp/common/test/rules/multiplelocaldeclarators/test.cpp
+++ b/cpp/common/test/rules/multiplelocaldeclarators/test.cpp
@@ -22,3 +22,9 @@ void test_loop(std::vector<ClassA> v) {
     b;
   }
 }
+
+#include <utility>
+void f2() {
+  std::pair<int, int> p1;
+  auto [a, b] = p1; // COMPLIANT - structured bindings.
+}


### PR DESCRIPTION
## Description

MISRA expressly allows C++17 structured bindings, e.g `auto [a, b] = c`, however our implementation did not check for this condition specifically and so they were being flagged.

cc @castler since this is a common FP in [eclipse/communication](https://github.com/eclipse-score/communication)

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - `RULE-10-0-1`
     - `M8-0-1`

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)