### PR TITLE
Fix RULE-7-0-1 false positives for bool-to-reference bindings

### DIFF
--- a/change_notes/2026-08-20-fix-fp-rule-7-0-1-bool-reference.md
+++ b/change_notes/2026-08-20-fix-fp-rule-7-0-1-bool-reference.md
@@ -1,0 +1,9 @@
+ - `RULE-7-0-1` - `NoConversionFromBool.ql`:
+   - Fixed false positives where a `bool` value is bound to a reference whose
+     referenced type is also `bool` (e.g. `bool&`, `const bool&`), including
+     when this happens via a generic/forwarding-reference parameter (e.g.
+     `template<class T> void f(T&& t)`, or class template forwarding
+     constructors such as `std::pair`'s `pair(U1&&, U2&&)`) that happens to be
+     instantiated with `bool`. Binding a value to a reference of its own type
+     does not change the type or representation of the value, so this is not
+     a conversion from `bool` in the sense intended by the rule.

--- a/cpp/misra/src/rules/RULE-7-0-1/NoConversionFromBool.ql
+++ b/cpp/misra/src/rules/RULE-7-0-1/NoConversionFromBool.ql
@@ -23,6 +23,18 @@ where
   conv = e.getConversion() and
   conv.getExpr().getType().stripTopLevelSpecifiers() instanceof BoolType and
   not conv.getType().stripTopLevelSpecifiers() instanceof BoolType and
+  // Exclude conversions that only bind a `bool` value to a reference to `bool`
+  // (e.g. `bool&`, `const bool&`). Binding a value to a reference of its own
+  // type does not change the type or representation of the value, so this is
+  // not a "conversion from bool" in the sense intended by the rule. This
+  // commonly occurs when a `bool` argument is forwarded through a generic
+  // `bool&`/`const bool&` parameter (e.g. logging helpers, `std::pair`-style
+  // structured bindings/aggregates).
+  not conv.getType()
+      .stripTopLevelSpecifiers()
+      .(ReferenceType)
+      .getBaseType()
+      .stripTopLevelSpecifiers() instanceof BoolType and
   // Exclude cases that are explicitly allowed
   not (
     // Exception: equality operators with both bool operands

--- a/cpp/misra/test/rules/RULE-7-0-1/test.cpp
+++ b/cpp/misra/test/rules/RULE-7-0-1/test.cpp
@@ -123,3 +123,38 @@ void test_bool_conversion_compliant() {
   // Bit-field assignment exception - compliant
   bf.bit = b1; // COMPLIANT
 }
+
+void f3(bool &b) {}
+void f4(const bool &b) {}
+
+template <typename T> void f5(T &&t) {}
+
+template <typename T1, typename T2> struct Pair {
+  template <typename U1, typename U2> Pair(U1 &&x, U2 &&y) : a(x), b(y) {}
+  T1 a;
+  T2 b;
+};
+
+void test_bool_reference_conversion_compliant() {
+  bool b1 = true;
+
+  // Binding a bool lvalue to a bool reference parameter - compliant, no
+  // actual type conversion takes place.
+  f3(b1); // COMPLIANT
+
+  // Binding a bool value to a const bool reference parameter - compliant.
+  f4(b1);   // COMPLIANT
+  f4(true); // COMPLIANT
+
+  // Binding a bool value to a forwarding reference parameter deduced as
+  // bool - compliant.
+  f5(b1);   // COMPLIANT
+  f5(true); // COMPLIANT
+
+  // Binding a bool value through a generic forwarding-reference constructor,
+  // where the second template parameter is deduced as bool - compliant. This
+  // mirrors idiomatic `return {value, overflow_flag};` and structured-binding
+  // patterns (e.g. std::pair and std::map::insert()'s return value).
+  Pair<int, bool> p1{1, true};  // COMPLIANT
+  Pair<int, bool> p2 = {1, b1}; // COMPLIANT
+}


### PR DESCRIPTION
## Description

`RULE-7-0-1`'s `NoConversionFromBool.ql` excludes a conversion when the
destination type, after `stripTopLevelSpecifiers()`, is `bool`. However,
`ReferenceType` does not override `stripTopLevelSpecifiers()` (the base
`Type` implementation returns `this` unchanged), so a `bool` value bound
to a `bool&`/`const bool&` parameter is never stripped down to `BoolType`
and the rule fires — even though no actual value conversion happens, only
a reference binding to the same underlying type.

This was found while triaging RULE-7-0-1 alerts in
[`eclipse-score/communication`](https://github.com/eclipse-score/communication):
46 of 51 open alerts (~90%) are this shape:

- `bool&`/`const bool&` out-parameters and variadic/generic logging
  helpers (e.g. `LogInfo(logger, some_bool_expr, ...)` forwarded through
  `Args&&...`).
- `std::pair`-style forwarding-reference constructors instantiated with
  `bool` (e.g. `return {value, overflow_flag};`, or a
  `map::insert()`-returned pair consumed via a structured binding),
  reported as `Conversion from 'bool' to 'type &'` because the
  constructor's un-instantiated template parameter name is shown instead
  of the deduced `bool`.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [X] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [X] Queries have been modified for the following rules:
     - RULE-7-0-1

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [X] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)
