### PR TITLE
Fix RULE-7-0-4 false positives for non-built-in operators

### DIFF
--- a/change_notes/2026-08-20-fix-fp-rule-7-0-4-non-numeric-operand-types.md
+++ b/change_notes/2026-08-20-fix-fp-rule-7-0-4-non-numeric-operand-types.md
@@ -1,0 +1,11 @@
+- `RULE-7-0-4` - `InappropriateBitwiseOrShiftOperands.ql`:
+  - Fixes #1177 - the rule no longer reports operands whose type is not a MISRA numeric type. The
+    operand checks used `not isUnsignedType(operandType)`, which is vacuously true for every type
+    that has no MISRA numeric type at all, such as class types and the unresolved dependent types
+    of uninstantiated template bodies. As a result the rule reported operations that do not use
+    the built-in operators, most notably the stream insertion and extraction operators. The checks
+    now use `isSignedType(operandType)` instead.
+  - Operands of character type, of a non-standard integral type, and of an unscoped enumeration
+    type without a fixed underlying type are consequently no longer reported, because none of them
+    has a MISRA numeric type. Unscoped enumerations without a fixed underlying type are covered by
+    `RULE-10-2-3`.

--- a/cpp/misra/src/rules/RULE-7-0-4/InappropriateBitwiseOrShiftOperands.ql
+++ b/cpp/misra/src/rules/RULE-7-0-4/InappropriateBitwiseOrShiftOperands.ql
@@ -63,7 +63,7 @@ where
     |
       x = op.getLeftOperand() and
       operandType = op.getLeftOperand().getExplicitlyConverted().getType() and
-      not MisraCpp23BuiltInTypes::isUnsignedType(operandType) and
+      MisraCpp23BuiltInTypes::isSignedType(operandType) and
       message =
         "Bitwise operator '" + op.getOperator() +
           "' requires unsigned numeric operands, but the left operand has type '" + operandType +
@@ -71,7 +71,7 @@ where
       or
       x = op.getRightOperand() and
       operandType = op.getRightOperand().getExplicitlyConverted().getType() and
-      not MisraCpp23BuiltInTypes::isUnsignedType(operandType) and
+      MisraCpp23BuiltInTypes::isSignedType(operandType) and
       message =
         "Bitwise operator '" + op.getOperator() +
           "' requires unsigned numeric operands, but the right operand has type '" + operandType +
@@ -82,7 +82,7 @@ where
     exists(ComplementExpr comp, Type opType |
       x = comp.getOperand() and
       opType = comp.getOperand().getExplicitlyConverted().getType() and
-      not MisraCpp23BuiltInTypes::isUnsignedType(opType) and
+      MisraCpp23BuiltInTypes::isSignedType(opType) and
       message =
         "Bit complement operator '~' requires unsigned operand, but has type '" + opType + "'."
     )
@@ -91,7 +91,7 @@ where
     exists(BinaryShiftOpOrAssignOp shift, Type leftType |
       x = shift.getLeftOperand() and
       leftType = shift.getLeftOperand().getExplicitlyConverted().getType() and
-      not MisraCpp23BuiltInTypes::isUnsignedType(leftType) and
+      MisraCpp23BuiltInTypes::isSignedType(leftType) and
       not isSignedConstantLeftShiftException(shift) and
       message =
         "Shift operator '" + shift.getOperator() +
@@ -112,7 +112,7 @@ where
           "Shift operator '" + shift.getOperator() + "' shifts by " + right.getValue().toInt() +
             " which is not within the valid range 0.." + ((leftType.getSize() * 8) - 1) + "."
       else (
-        not MisraCpp23BuiltInTypes::isUnsignedType(rightType) and
+        MisraCpp23BuiltInTypes::isSignedType(rightType) and
         message =
           "Shift operator '" + shift.getOperator() +
             "' requires unsigned right operand, but has type '" + rightType + "'."

--- a/cpp/misra/test/rules/RULE-7-0-4/InappropriateBitwiseOrShiftOperands.expected
+++ b/cpp/misra/test/rules/RULE-7-0-4/InappropriateBitwiseOrShiftOperands.expected
@@ -47,3 +47,6 @@
 | test.cpp:156:3:156:12 | 1073741824 | Shift operator '<<' requires unsigned left operand, but has type 'int'. |
 | test.cpp:162:3:162:5 | s32 | Shift operator '<<' requires unsigned left operand, but has type 'int32_t'. |
 | test.cpp:170:3:170:5 | s32 | Shift operator '>>' requires unsigned left operand, but has type 'int32_t'. |
+| test.cpp:201:3:201:7 | value | Shift operator '<<' requires unsigned left operand, but has type 'signed int'. |
+| test.cpp:226:3:226:4 | e3 | Bitwise operator '&' requires unsigned numeric operands, but the left operand has type 'UnscopedEnumSignedUnderlyingType'. |
+| test.cpp:226:7:226:8 | e3 | Bitwise operator '&' requires unsigned numeric operands, but the right operand has type 'UnscopedEnumSignedUnderlyingType'. |

--- a/cpp/misra/test/rules/RULE-7-0-4/test.cpp
+++ b/cpp/misra/test/rules/RULE-7-0-4/test.cpp
@@ -169,3 +169,69 @@ void test_right_shift_signed_operands() {
   u32 >> 1U; // COMPLIANT
   s32 >> 1U; // NON_COMPLIANT
 }
+
+class TestStream {
+public:
+  TestStream &operator<<(std::int32_t value);
+  TestStream &operator>>(std::int32_t &value);
+};
+
+void test_overloaded_shift_operators() {
+  TestStream stream;
+  std::int32_t s32 = 1;
+
+  // User provided operators, not the built-in shift operators
+  stream << 1;   // COMPLIANT
+  stream << s32; // COMPLIANT
+  stream >> s32; // COMPLIANT
+}
+
+template <typename T>
+void test_overloaded_shift_operators_in_template(TestStream &stream,
+                                                 const T &value) {
+  // The left operand of the second `<<` is the `TestStream &` returned by the
+  // first one, and the right operand is dependent, so the operation is
+  // unresolved in the uninstantiated template body
+  stream << 1 << value; // COMPLIANT
+}
+
+template <typename T> void test_dependent_shift_operands(T value) {
+  // Dependent operands are unresolved in the uninstantiated template body, but
+  // reported through the instantiation below
+  value << 2; // NON_COMPLIANT
+}
+
+void test_template_instantiations() {
+  TestStream stream;
+  test_overloaded_shift_operators_in_template(stream, 1);
+  test_dependent_shift_operands<std::int32_t>(1);
+}
+enum UnscopedEnumNoFixedUnderlyingType { EnumeratorA = 1, EnumeratorB = 2 };
+
+enum UnscopedEnumUnsignedUnderlyingType : unsigned int { EnumeratorC = 1 };
+
+enum UnscopedEnumSignedUnderlyingType : int { EnumeratorD = 1 };
+
+void test_enum_operands() {
+  UnscopedEnumNoFixedUnderlyingType e1 = EnumeratorA;
+  UnscopedEnumUnsignedUnderlyingType e2 = EnumeratorC;
+  UnscopedEnumSignedUnderlyingType e3 = EnumeratorD;
+
+  // Without a fixed underlying type the enum has no MISRA numeric type, so the
+  // operands are not analysed by this rule
+  e1 &e1; // COMPLIANT
+
+  e2 &e2; // COMPLIANT
+
+  e3 &e3; // NON_COMPLIANT
+}
+
+void test_character_type_operands() {
+  char32_t c32 = 1;
+
+  // `char32_t` is of character type, not of numeric type, and is always
+  // unsigned
+  c32 &c32;  // COMPLIANT
+  c32 << 1U; // COMPLIANT
+  ~c32;      // COMPLIANT
+}


### PR DESCRIPTION
## Description
`InappropriateBitwiseOrShiftOperands.ql` reported operations that do not use the built-in bitwise or shift operators, most notably the stream insertion and extraction operators, e.g. `stream << value`.

Resolved calls to a user provided operator are modelled as `FunctionCall`s and therefore never reach this query. The reported operations were instead the syntactic `LShiftExpr`/`RShiftExpr` nodes emitted for uninstantiated template bodies, where the operands are either unresolved (`unknown`, `auto &&`) or are the non-dependent result of an already resolved overload, such as `std::basic_ostream<char, std::char_traits<char>> &`.

The built-in bitwise and shift operators are only applicable to integral and unscoped enumeration operands, so an operation with an operand of any other type does not use them. The query now requires both operands to be of such a type before reporting a violation.

This does not introduce false negatives for dependent operands, because the template instantiations, in which the operand types are known, are still reported.

Fixes #1177

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [X] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [X] Queries have been modified for the following rules:
     - RULE-7-0-4

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [X] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [X] Have all the relevant rule package description files been checked in?
 - [X] Have you verified that the metadata properties of each new query is set appropriately?
 - [X] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [X] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [X] Does the query have an appropriate level of in-query comments/documentation?
 - [X] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [X] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)