### PR TITLE
RULE-5-10-1: fix false positives for locals/parameters in permitted std specializations (e.g. std::hash)

### DIFF
--- a/change_notes/2026-08-24-fix-fp-rule-5-10-1-hash-specialization-reserved-namespace.md
+++ b/change_notes/2026-08-24-fix-fp-rule-5-10-1-hash-specialization-reserved-namespace.md
@@ -1,0 +1,5 @@
+- `RULE-5-10-1` - `PoorlyFormedIdentifier.ql`:
+  - Fixed false positives where a local variable or function parameter was reported as
+    "defined in reserved namespace" merely because its enclosing function is the body of
+    an explicit template specialization that C++ permits users to add to namespace `std`
+    (for example, `std::hash<UserType>::operator()`'s parameter and local names).

--- a/cpp/common/src/codingstandards/cpp/Identifiers.qll
+++ b/cpp/common/src/codingstandards/cpp/Identifiers.qll
@@ -361,7 +361,20 @@ private module IdentifierIntroductionImpl {
 
     override string getAnIdent() { result = this.getName() }
 
-    override Namespace getNamespace() { result = variable.getNamespace() }
+    override Namespace getNamespace() {
+      // A parameter or local variable is scoped to the body of its enclosing function, not to
+      // that function's enclosing namespace. It does not itself become a new member of the
+      // namespace, so it cannot "pollute" a reserved namespace such as `std`, regardless of which
+      // namespace its enclosing function happens to be declared in. This matters in particular
+      // for the bodies of explicit template specializations that C++ explicitly permits users to
+      // add to namespace `std` (such as `std::hash<UserType>`), where parameter and local names
+      // are otherwise ordinary user-chosen identifiers that merely happen to be lexically nested
+      // inside `namespace std { ... }`. The function or class that actually introduces the
+      // specialization's name is still checked against `isReservedNamespace` independently, via
+      // `FunctionDeclarationEntryIdentifier` / `TypeDeclarationEntryIdentifier`.
+      not variable instanceof LocalScopeVariable and
+      result = variable.getNamespace()
+    }
   }
 
   /**

--- a/cpp/misra/test/rules/RULE-5-10-1/PoorlyFormedIdentifier.expected
+++ b/cpp/misra/test/rules/RULE-5-10-1/PoorlyFormedIdentifier.expected
@@ -51,3 +51,4 @@
 | test.cpp:186:7:186:12 | wint_t | Identifier 'wint_t' is a reserved name. |
 | test.cpp:203:1:203:42 | __PRETTY_FUNCTION__ | Identifier '__PRETTY_FUNCTION__' contains double underscores. |
 | test.cpp:203:1:203:42 | __PRETTY_FUNCTION__ | Identifier '__PRETTY_FUNCTION__' starts with underscore. |
+| test.cpp:263:6:263:21 | new_std_function | Identifier 'new_std_function' is defined in reserved namespace. |

--- a/cpp/misra/test/rules/RULE-5-10-1/test.cpp
+++ b/cpp/misra/test/rules/RULE-5-10-1/test.cpp
@@ -223,3 +223,42 @@ struct hash<int> { // COMPLIANT - rule does not apply to template
     return static_cast<std::size_t>(x);
   }
 };
+
+// Test case for RULE-5-10-1 false positive fix: a local variable or function
+// parameter is scoped to the body of its enclosing function, not to the
+// namespace that function happens to be declared in. This matters for the
+// body of an explicit template specialization that C++ explicitly permits
+// users to add to namespace `std` (such as `std::hash<UserType>`): the
+// parameter and local names below are ordinary user-chosen identifiers and
+// do not themselves become new members of namespace `std`.
+struct UserTypeForHash {
+  int payload;
+};
+
+namespace std {
+template <typename T>
+struct hash; // forward declaration of the primary
+             // template that is specialized below
+
+template <> struct hash<UserTypeForHash> {
+  std::size_t
+  operator()(const UserTypeForHash &value) const noexcept { // COMPLIANT -
+                                                            // 'value' is a
+                                                            // parameter
+                                                            // scoped to the
+                                                            // function body,
+                                                            // not a member
+                                                            // of namespace
+                                                            // std
+    std::size_t result = static_cast<std::size_t>(
+        value.payload); // COMPLIANT - 'result' is a local variable scoped to
+                        // the function body, not a member of namespace std
+    return result;
+  }
+};
+
+// A genuinely new function declared directly in namespace std remains a
+// violation: this is not a permitted specialization, and it does introduce a
+// new name into the reserved namespace.
+void new_std_function() {} // NON_COMPLIANT - namespace std is reserved
+} // namespace std


### PR DESCRIPTION
## Description


`RULE-5-10-1` ("User-defined identifiers shall have an appropriate form") reports
`Identifier 'X' is defined in reserved namespace.` for ordinary, well-formed,
snake_case local variables and function parameters — e.g. `value`, `result`,
`view`, `identifier`, `instance_identifier`, `skeleton_instance_identifier` —
whenever they are declared inside the body of an explicit template
specialization that C++ explicitly permits users to add to namespace `std`,
most commonly `std::hash<UserType>::operator()`:

```cpp
namespace std
{
template <>
struct hash<score::mw::com::impl::ServiceIdentifierType>
{
    size_t operator()(const score::mw::com::impl::ServiceIdentifierType& value) const noexcept
    //                                                                     ^^^^^ flagged: "Identifier 'value' is defined in reserved namespace."
    {
        return std::hash<std::string_view>{}(value.ToHashString());
    }
};
}  // namespace std
```

`[namespace.std]`/`[hash.requirements]` explicitly permit a program to add a
template specialization for a standard library template (like `std::hash`) to
namespace `std`, provided the specialization depends on a user-defined type.
`value` here is not a new member of namespace `std` in the sense the rule is
trying to prevent — it is an ordinary parameter name scoped to the function
body, which merely happens to be lexically nested inside `namespace std { ... }`
because that is where the standard requires the specialization to be written.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [X] Queries have been modified for the following rules:
     - RULE-5-10-1

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [X] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [x] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [x] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [X] Have all the relevant rule package description files been checked in?
 - [X] Have you verified that the metadata properties of each new query is set appropriately?
 - [X] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [X] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [X] Does the query have an appropriate level of in-query comments/documentation?
 - [X] Have you considered/identified possible edge cases?
 - [X] Does the query not reinvent features in the standard library?
 - [X] Can the query be simplified further (not golfed!)

### Reviewer 

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)
