### PR TITLE
Fix RULE-7-0-2 false positives: UnknownType and reference-to-bool dereference

### DIFF
--- a/change_notes/2026-08-25-fix-fp-rule-7-0-2-unknown-and-reference-bool.md
+++ b/change_notes/2026-08-25-fix-fp-rule-7-0-2-unknown-and-reference-bool.md
@@ -1,0 +1,13 @@
+- `RULE-7-0-2` - `NoImplicitBoolConversion.ql`:
+   - Fixed false positives where a conversion's source expression type could
+     not be resolved to a concrete type (`UnknownType`), which occurs only in
+     template-dependent contexts that the extractor cannot resolve, e.g. a
+     `constexpr bool` variable template whose initializer is itself another
+     dependent variable template such as `std::conjunction_v<...>`.
+   - Fixed false positives on reference-dereference conversions (`bool&`/
+     `bool&&` to `bool`), which occur e.g. via the compiler-synthesized
+     `std::get<N>(...)` call used to implement structured binding
+     decomposition (`auto [a, b] = some_pair_or_tuple_expr;` where `b` is
+     `bool`). Dereferencing a reference to `bool` does not change the type or
+     representation of the value, so this is not a conversion to `bool` in
+     the sense intended by the rule.

--- a/cpp/misra/src/rules/RULE-7-0-2/NoImplicitBoolConversion.ql
+++ b/cpp/misra/src/rules/RULE-7-0-2/NoImplicitBoolConversion.ql
@@ -56,6 +56,30 @@ where
       e = conv and
       conv.getType().getUnspecifiedType() instanceof BoolType and
       not conv.getExpr().getType().getUnspecifiedType() instanceof BoolType and
+      // Exclude conversions whose source expression type could not be resolved to a concrete
+      // type (`UnknownType`). This shape occurs only in template-dependent contexts that the
+      // extractor has not (and, for uninstantiated templates, cannot) resolve to an actual type
+      // - e.g. a `constexpr bool` variable template / `noexcept(...)` specifier built from
+      // another variable template such as `std::conjunction_v<...>`. There is no actual,
+      // concrete conversion to `bool` that a developer wrote or that the compiler ultimately
+      // performs; flagging it produces a false positive because the "conversion from 'unknown'"
+      // is an artifact of incomplete extraction of template-dependent/library code, not a
+      // genuine violation.
+      not conv.getExpr().getType() instanceof UnknownType and
+      // Exclude reference-dereference conversions (`T& -> T` / `T&& -> T`) whose referenced type
+      // is itself `bool` once its reference-ness is stripped, e.g. the compiler-synthesized
+      // `std::get<N>(...)` call used to implement structured binding decomposition
+      // (`auto [a, b] = some_pair_or_tuple_expr;` where `b` is `bool`). `getUnspecifiedType()`
+      // resolves typedefs/specifiers but does not strip reference qualification, so a `bool&`/
+      // `bool&&` is not itself recognised as already being `bool` by the check above. But
+      // dereferencing a reference to `bool` does not represent a conversion from a different
+      // type to `bool` - the referenced value is already a `bool` - so this is not a violation.
+      not conv.getExpr()
+          .getType()
+          .getUnspecifiedType()
+          .(ReferenceType)
+          .getBaseType()
+          .getUnspecifiedType() instanceof BoolType and
       // Exception 2: Contextual conversion from pointer
       not (
         isPointerType(conv.getExpr().getType()) and

--- a/cpp/misra/test/rules/RULE-7-0-2/test.cpp
+++ b/cpp/misra/test/rules/RULE-7-0-2/test.cpp
@@ -214,3 +214,58 @@ void test_member_function_pointer_conversion() {
   bool l4 = l2;              // NON_COMPLIANT
   bool l5 = (l1 != nullptr); // COMPLIANT
 }
+
+// Regression test for a false positive where the compiler-synthesized
+// `get<N>(...)` call used to implement structured binding decomposition (`auto
+// [a, b] = ...;`) was incorrectly flagged as a "conversion to bool", even
+// though the decomposed member is already `bool` - dereferencing a
+// `bool&`/`bool&&` reference is not a conversion from another type to `bool`.
+struct BoolPair {
+  std::int32_t first;
+  bool second;
+};
+
+template <std::size_t I> auto get(const BoolPair &p) {
+  if constexpr (I == 0) {
+    return p.first;
+  } else {
+    return p.second;
+  }
+}
+
+namespace std {
+template <class T> struct tuple_size;
+template <std::size_t I, class T> struct tuple_element;
+
+template <> struct tuple_size<BoolPair> {
+  static constexpr std::size_t value = 2;
+};
+template <> struct tuple_element<0, BoolPair> { using type = std::int32_t; };
+template <> struct tuple_element<1, BoolPair> { using type = bool; };
+} // namespace std
+
+BoolPair make_bool_pair();
+
+void test_structured_binding_bool_decomposition() {
+  auto [l1, l2] =
+      make_bool_pair(); // COMPLIANT - structured binding decomposition, not a
+                        // real conversion to bool
+  if (l2) {             // COMPLIANT
+  }
+  bool l3 = l2; // COMPLIANT - l2 is already bool
+}
+
+// Regression test for a false positive where a `constexpr bool` variable
+// template, whose initializer is itself a dependent expression built from
+// another variable template, was incorrectly flagged as a "conversion from
+// 'unknown' to bool". The extractor cannot resolve a concrete type for a
+// dependent, uninstantiated template expression, so it should not be treated as
+// an actual conversion.
+template <typename T> constexpr bool is_something_v = true;
+
+template <typename T>
+constexpr bool derived_from_template_v = is_something_v<T>; // COMPLIANT
+
+bool test_dependent_variable_template_instantiation() {
+  return derived_from_template_v<std::int32_t>; // COMPLIANT
+}


### PR DESCRIPTION
## Description

NoImplicitBoolConversion.ql flagged two systematic false-positive shapes:

1. Conversions whose source expression type could not be resolved to a concrete type (UnknownType). This occurs only in template-dependent contexts the extractor cannot resolve, e.g. a `constexpr bool` variable template initialized from another dependent variable template such as `std::conjunction_v<...>`, or a `noexcept(...)` specifier built the same way.

2. Reference-dereference conversions (`bool&`/`bool&&` -> `bool`). `getUnspecifiedType()` resolves typedefs/specifiers but does not strip reference qualification, so a `bool&`/`bool&&` is not recognised as already being `bool`. This is most commonly synthesized by the compiler for structured binding decomposition (`auto [a, b] = pair_or_tuple_expr;` where `b` is `bool`), which is not a real conversion since the referenced value is already a `bool`.

This mirrors the same root-cause pattern already fixed for the sibling rule RULE-7-0-1 in 6f872c7c5 ("Fix RULE-7-0-1 false positives for bool-to- reference bindings"), applied here to the reverse conversion direction.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [X] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [X] Queries have been modified for the following rules:
     - RULE-7-0-2

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [X] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [X] Have all the relevant rule package description files been checked in?
 - [X] Have you verified that the metadata properties of each new query is set appropriately?
 - [X] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [X] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [X] Does the query have an appropriate level of in-query comments/documentation?
 - [X] Have you considered/identified possible edge cases?
 - [X] Does the query not reinvent features in the standard library?
 - [X] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)