### PR TITLE
Refactor EXP37-C rule to improve performance

### DIFF
--- a/c/cert/src/rules/EXP37-C/DoNotCallFunctionsWithIncompatibleArguments.ql
+++ b/c/cert/src/rules/EXP37-C/DoNotCallFunctionsWithIncompatibleArguments.ql
@@ -20,14 +20,15 @@ import cpp
 import codingstandards.c.cert
 import codingstandards.cpp.MistypedFunctionArguments
 
-from FunctionCall fc, Function f, Parameter p
+from FunctionCall fc, Parameter p
 where
   not isExcluded(fc, ExpressionsPackage::doNotCallFunctionsWithIncompatibleArgumentsQuery()) and
+  p = fc.getTarget().getAParameter() and
   (
-    mistypedFunctionArguments(fc, f, p)
+    mistypedFunctionArguments(fc, p)
     or
-    complexArgumentPassedToRealParameter(fc, f, p)
+    complexArgumentPassedToRealParameter(fc, p)
   )
 select fc,
-  "Argument $@ in call to " + f.toString() + " is incompatible with parameter " + p.getTypedName() +
-    ".", fc.getArgument(p.getIndex()) as arg, arg.toString()
+  "Argument $@ in " + fc.toString() + " is incompatible with parameter " + p.getTypedName() + ".",
+  fc.getArgument(p.getIndex()) as arg, arg.toString()

--- a/change_notes/2026-08-28-improve-exp37-c-performance.md
+++ b/change_notes/2026-08-28-improve-exp37-c-performance.md
@@ -1,0 +1,2 @@
+- `EXP37-C` - `DoNotCallFunctionsWithIncompatibleArguments.ql`:
+  - Improved query evaluation performance. Query results are unchanged.

--- a/cpp/common/src/codingstandards/cpp/MistypedFunctionArguments.qll
+++ b/cpp/common/src/codingstandards/cpp/MistypedFunctionArguments.qll
@@ -91,21 +91,22 @@ private predicate isTypeInComplexDomain(FloatingPointType type) {
   type.getUnderlyingType().(FloatingPointType).getDomain() instanceof ComplexDomain
 }
 
-predicate mistypedFunctionArguments(FunctionCall fc, Function f, Parameter p) {
-  f = fc.getTarget() and
-  p = f.getAParameter() and
-  hasZeroParamDecl(f) and
-  isCompiledAsC(f.getFile()) and
-  not f.isVarargs() and
-  not f instanceof BuiltInFunction and
-  p.getIndex() < fc.getNumberOfArguments() and
-  // Parameter p and its corresponding call argument must have mismatched types
-  not argMayBeUsed(fc.getArgument(p.getIndex()), p)
+predicate mistypedFunctionArguments(FunctionCall fc, Parameter p) {
+  exists(Function f |
+    f = fc.getTarget() and
+    p = f.getAParameter() and
+    hasZeroParamDecl(f) and
+    isCompiledAsC(f.getFile()) and
+    not f.isVarargs() and
+    not f instanceof BuiltInFunction and
+    p.getIndex() < fc.getNumberOfArguments() and
+    // Parameter p and its corresponding call argument must have mismatched types
+    not argMayBeUsed(fc.getArgument(p.getIndex()), p)
+  )
 }
 
-predicate complexArgumentPassedToRealParameter(FunctionCall fc, Function f, Parameter p) {
-  f = fc.getTarget() and
-  p = f.getAParameter() and
+predicate complexArgumentPassedToRealParameter(FunctionCall fc, Parameter p) {
+  p = fc.getTarget().getAParameter() and
   // Some implementations implicitly convert complex floating point values by
   // extracting the real part of the complex number (in-place or via a creal() call).
   // This predicate holds in those cases unless the value is explicitly converted.


### PR DESCRIPTION
This pull request refactors the logic for detecting function calls with incompatible arguments by simplifying predicate signatures and improving how parameters are matched with function calls. 
The changes focus on solving performance issues with newer CodeQL versions.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [ ] Internal documentation
 - [ ] External documentation
 - [x] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [ ] No rules added
 - [ ] Queries have been added for the following rules:
     - _rule number here_
 - [x] Queries have been modified for the following rules:
     - EXP37-C

## Release change checklist

A change note ([development_handbook.md#change-notes](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#change-notes)) is required for any pull request which modifies:

 - The structure or layout of the release artifacts.
 - The evaluation performance (memory, execution time) of an existing query.
 - The results of an existing query in any circumstance.

If you are only adding new rule queries, a change note is not required.

_**Author:**_ Is a change note required? 
  - [x] Yes
  - [ ] No

🚨🚨🚨
_**Reviewer:**_ Confirm that format of *shared* queries (not the .qll file, the
.ql file that imports it) is valid by running them within VS Code. 
  - [ ] Confirmed


_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

For PRs that add new queries or modify existing queries, the following checklist should be completed by both the author and reviewer:

### Author

 - [x] Have all the relevant rule package description files been checked in?
 - [x] Have you verified that the metadata properties of each new query is set appropriately?
 - [x] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [x] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [x] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [x] Does the query have an appropriate level of in-query comments/documentation?
 - [x] Have you considered/identified possible edge cases?
 - [x] Does the query not reinvent features in the standard library?
 - [x] Can the query be simplified further (not golfed!)

### Reviewer 

 - [ ] Have all the relevant rule package description files been checked in?
 - [ ] Have you verified that the metadata properties of each new query is set appropriately?
 - [ ] Do all the unit tests contain both "COMPLIANT" and "NON_COMPLIANT" cases?
 - [ ] Are the alert messages properly formatted and consistent with the [style guide](https://github.com/github/codeql-coding-standards/blob/main/docs/development_handbook.md#query-style-guide)?
 - [ ] Have you run the queries on OpenPilot and verified that the performance and results are acceptable?<br />_As a rule of thumb, predicates specific to the query should take no more than 1 minute, and for simple queries be under 10 seconds. If this is not the case, this should be highlighted and agreed in the code review process._
 - [ ] Does the query have an appropriate level of in-query comments/documentation?
 - [ ] Have you considered/identified possible edge cases?
 - [ ] Does the query not reinvent features in the standard library?
 - [ ] Can the query be simplified further (not golfed!)