### PR TITLE
Clarify Autofix deviation approval metadata

### DIFF
--- a/docs/autofix-instructions.md
+++ b/docs/autofix-instructions.md
@@ -174,7 +174,9 @@ When an alert is judged to be a false positive, the autofix PR must:
      (what the query missed, why the code is in fact compliant or safe);
    - `scope`, `background`, and `requirements` when they help a reviewer
      audit the decision;
-   - a `raised-by` entry (and leave `approved-by` for a human reviewer).
+   - omit both `raised-by` and `approved-by` from the initial fix because the
+     deviation format requires them to be specified together. A human reviewer
+     may add both entries when approving the deviation.
 4. **Place the deviation entry** of types 2. and 3. in an existing
    `coding-standards.yml` if one exists in an appropriate directory; 
    otherwise create one at the most specific directory whose subtree is


### PR DESCRIPTION
## Description

Clarify that Agentic Autofix must omit both `raised-by` and `approved-by` from an initial false-positive deviation record. The deviation format requires these fields to be specified together, so a human reviewer may add both when approving the deviation.

This prevents Autofix from generating an invalid record while preserving human approval of deviations.

## Change request type

 - [ ] Release or process automation (GitHub workflows, internal scripts)
 - [x] Internal documentation
 - [ ] External documentation
 - [ ] Query files (`.ql`, `.qll`, `.qls` or unit tests)
 - [ ] External scripts (analysis report or other code shipped as part of a release)

## Rules with added or modified queries

 - [x] No rules added
 - [ ] Queries have been added for the following rules:
 - [ ] Queries have been modified for the following rules:

## Release change checklist

A change note is required for changes to release artifact structure, query performance, or query results. This documentation-only change affects none of those.

_**Author:**_ Is a change note required?
  - [ ] Yes
  - [x] No

_**Reviewer:**_ Confirm that format of *shared* queries is valid by running them within VS Code.
  - [ ] Confirmed (not applicable; no query files changed)

_**Reviewer:**_ Confirm that either a change note is not required or the change note is required and has been added.
  - [ ] Confirmed

## Query development review checklist

Not applicable; this pull request does not add or modify queries.